### PR TITLE
SCC-3618 - 404 page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       install:
         - pip install --user awscli
       script:
-      - aws ecs update-service --cluster $CLUSTER_NAME --service $CLUSTER_NAME --force-new-deployment
+        - aws ecs update-service --cluster $CLUSTER_NAME --service $CLUSTER_NAME --force-new-deployment
 
     - stage: deploy production
       if: branch IN (production) AND type != pull_request

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Running the app locally via Docker is optional for now, and provided as an alter
 1. [Download](https://docs.docker.com/get-docker/) and install Docker.
 2. `cd` into research-catalog repo
 3. Run `docker-compose up --build --force-recreate`
-4. Check that app is being served at http://localhost:3000/
+4. Check that app is being served at http://localhost:8080/research/research-catalog

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "research-catalog",
   "version": "0.1.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 8080",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --fix",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,25 @@
+import Head from "next/head"
+import { Heading } from "@nypl/design-system-react-components"
+
+import RCLink from "../src/components/RCLink/RCLink"
+import { LEGACY_CATALOG_URL } from "../src/config/constants"
+
+export default function Custom404() {
+  return (
+    <div style={{ paddingBottom: "var(--nypl-space-l)" }}>
+      <Head>
+        <title>404 Not Found</title>
+      </Head>
+      <Heading level="one">404 Not Found</Heading>
+      <div>
+        <p>We&apos;re sorry...</p>
+        <p>The page you were looking for doesn&apos;t exist.</p>
+        <p>
+          Search the <RCLink href="/">Research Catalog</RCLink> or our{" "}
+          <RCLink href={LEGACY_CATALOG_URL}>Legacy Catalog</RCLink> for research
+          materials.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -1,8 +1,8 @@
 import Head from "next/head"
 import { Heading } from "@nypl/design-system-react-components"
 
-import RCLink from "../src/components/RCLink/RCLink"
-import { LEGACY_CATALOG_URL } from "../src/config/constants"
+import RCLink from "../../src/components/RCLink/RCLink"
+import { LEGACY_CATALOG_URL } from "../../src/config/constants"
 
 export default function Custom404() {
   return (

--- a/pages/404/redirect.tsx
+++ b/pages/404/redirect.tsx
@@ -1,0 +1,32 @@
+import Head from "next/head"
+import { Heading } from "@nypl/design-system-react-components"
+
+import RCLink from "../../src/components/RCLink/RCLink"
+import {
+  CIRCULATING_CATALOG_URL,
+  LEGACY_CATALOG_URL,
+} from "../../src/config/constants"
+
+export default function Redirect404() {
+  return (
+    <div style={{ paddingBottom: "var(--nypl-space-l)" }}>
+      <Head>
+        <title>404 Not Found</title>
+      </Head>
+      <Heading level="one">We&apos;re sorry...</Heading>
+      <div>
+        <p>You&apos;ve followed an out-of-date link to our research catalog.</p>
+        <p>
+          You may be able to find what you&apos;re looking for in the{" "}
+          <RCLink href="/">Research Catalog</RCLink> or the{" "}
+          <RCLink href={CIRCULATING_CATALOG_URL}>Circulating Catalog</RCLink>.
+          for research materials.
+        </p>
+        <p>
+          You can also try the{" "}
+          <RCLink href={LEGACY_CATALOG_URL}>Legacy Catalog</RCLink>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -23,29 +23,32 @@ interface LayoutProps {
  */
 const Layout = ({ children, activePage }: LayoutProps) => {
   const showSearch = activePage === "search"
+  const showHeader = activePage !== "404"
 
   return (
     <DSProvider>
       <TemplateAppContainer
         breakout={
-          <>
-            <Breadcrumbs
-              breadcrumbsType="research"
-              breadcrumbsData={[
-                { url: "https://nypl.org", text: "Home" },
-                { url: "https://www.nypl.org/research", text: "Research" },
-                {
-                  url: `https://www.nypl.org${BASE_URL}`,
-                  text: "Research Catalog",
-                },
-              ]}
-            />
-            <div className={styles.researchHeadingContainer}>
-              <Heading id="heading-h1" level="one" text="Research Catalog" />
-              <SubNav activePage={activePage} />
-              {showSearch && <SearchForm />}
-            </div>
-          </>
+          showHeader && (
+            <>
+              <Breadcrumbs
+                breadcrumbsType="research"
+                breadcrumbsData={[
+                  { url: "https://nypl.org", text: "Home" },
+                  { url: "https://www.nypl.org/research", text: "Research" },
+                  {
+                    url: `https://www.nypl.org${BASE_URL}`,
+                    text: "Research Catalog",
+                  },
+                ]}
+              />
+              <div className={styles.researchHeadingContainer}>
+                <Heading id="heading-h1" level="one" text="Research Catalog" />
+                <SubNav activePage={activePage} />
+                {showSearch && <SearchForm />}
+              </div>
+            </>
+          )
         }
         contentPrimary={children}
       />

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,5 +1,8 @@
 export const BASE_URL = "/research/research-catalog"
 export const RESULTS_PER_PAGE = 50
 
+// URLs
+export const LEGACY_CATALOG_URL = "https://legacycatalog.nypl.org/"
+
 // API Routes
 export const DISCOVERY_API_SEARCH_ROUTE = "/discovery/resources"

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,6 +2,7 @@ export const BASE_URL = "/research/research-catalog"
 export const RESULTS_PER_PAGE = 50
 
 // URLs
+export const CIRCULATING_CATALOG_URL = "https://nypl.na2.iiivega.com/"
 export const LEGACY_CATALOG_URL = "https://legacycatalog.nypl.org/"
 
 // API Routes

--- a/src/types/pageTypes.ts
+++ b/src/types/pageTypes.ts
@@ -1,1 +1,1 @@
-export type RCPage = "search" | "shep" | "account" | ""
+export type RCPage = "search" | "shep" | "account" | "404" | ""

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -7,7 +7,6 @@ import type { RCPage } from "../types/pageTypes"
  * conditionally rendering the Search.
  */
 export const getActivePage = (pathname: string): RCPage => {
-  console.log(pathname)
   if (pathname === "/" || pathname.includes("search")) {
     return "search"
   } else if (pathname.includes("subject_headings")) {

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -7,12 +7,15 @@ import type { RCPage } from "../types/pageTypes"
  * conditionally rendering the Search.
  */
 export const getActivePage = (pathname: string): RCPage => {
+  console.log(pathname)
   if (pathname === "/" || pathname.includes("search")) {
     return "search"
   } else if (pathname.includes("subject_headings")) {
     return "shep"
   } else if (pathname.includes("account")) {
     return "account"
+  } else if (pathname.includes("404")) {
+    return "404"
   } else {
     return ""
   }


### PR DESCRIPTION
This PR adds the 404 page template and logic to hide the Research Catalog header on 404 pages.

Unrelated to the ticket, but I also changed the localhost port to 8080 temporarily to avoid conflicts with port 3000 on DFE for convenience.

https://jira.nypl.org/browse/SCC-3618