### PR TITLE
Header URL env var update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ jobs:
         - if [[ $TRAVIS_BRANCH == "qa" ]];
           then
           export ENV="qa";
-          export HEADER_URL="https://qa-ds-header.nypl.org";
+          export NYPL_HEADER_URL="https://qa-ds-header.nypl.org";
           fi
         - if [[ "$TRAVIS_BRANCH" == "production" ]];
           then
           export ENV="production";
-          export HEADER_URL="https://ds-header.nypl.org";
+          export NYPL_HEADER_URL="https://ds-header.nypl.org";
           fi
       env:
         - ECR_URL=946183545209.dkr.ecr.us-east-1.amazonaws.com/research-catalog
@@ -32,7 +32,7 @@ jobs:
         - export LOCAL_TAG_NAME="${ENV}-latest"
       script:
         - eval $(aws ecr get-login --no-include-email --region us-east-1)
-        - docker build -t "$LOCAL_TAG_NAME" --build-arg HEADER_URL="${HEADER_URL} .
+        - docker build -t "$LOCAL_TAG_NAME" --build-arg NYPL_HEADER_URL="${NYPL_HEADER_URL} .
         - docker tag "$LOCAL_TAG_NAME" "$ECR_URL:$LOCAL_TAG_NAME"
         # Re-tag last latest image just in case
         - |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM node:16-alpine AS production
 #RUN apt-get upgrade -y
 
 ARG HEADER_URL
-ENV HEADER_URL=${HEADER_URL}
 
 WORKDIR /app
 
@@ -22,6 +21,7 @@ RUN npm install
 # Add application code.
 COPY . .
 
+ENV NEXT_PUBLIC_HEADER_URL=${HEADER_URL}
 RUN npm run build
 
 # Explicitly set port 3000 as open to requests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:16-alpine AS production
 #RUN apt-get update
 #RUN apt-get upgrade -y
 
-ARG HEADER_URL
+ARG NYPL_HEADER_URL
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN npm install
 # Add application code.
 COPY . .
 
-ENV NEXT_PUBLIC_HEADER_URL=${HEADER_URL}
+ENV NYPL_HEADER_URL=${NYPL_HEADER_URL}
 RUN npm run build
 
 # Explicitly set port 3000 as open to requests.

--- a/ENVIRONMENTVARS.md
+++ b/ENVIRONMENTVARS.md
@@ -21,8 +21,8 @@ If an environment variable is updated, make sure to restart the server for the a
 These environment variables control how certain elements on the page render and where to fetch data.
 
 | Variable          | Type   | Value Example                | Description                                                              |
-| ----------------- | ------ | ---------------------------- | ------------------------------------------------------------------------ | --- |
-| `NYPL_HEADER_URL` | string | "https://ds-header.nypl.org" | The base URL of the NYPL environment-specific header and footer scripts. |     |
+| ----------------- | ------ | ---------------------------- | ------------------------------------------------------------------------ |
+| `NYPL_HEADER_URL` | string | "https://ds-header.nypl.org" | The base URL of the NYPL environment-specific header and footer scripts. |
 
 ## AWS ECS Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "next dev -p 8080",
     "build": "next build",
     "start": "next start",
+    "local-prod": "next build && next start -p 8080",
     "lint": "eslint . --fix",
     "prettier": "prettier --write .",
     "prepare": "husky install"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -23,7 +23,7 @@ export default function Document() {
         <div id="Header-Placeholder">
           <div id="nypl-header"></div>
           <script
-            src={`${process.env.NEXT_PUBLIC_NYPL_HEADER_URL}/header.min.js?containerId=nypl-header`}
+            src={`${process.env.NYPL_HEADER_URL}/header.min.js?containerId=nypl-header`}
             async
           />
         </div>
@@ -31,7 +31,7 @@ export default function Document() {
         <NextScript />
         {/* NYPL Footer script and container */}
         <script
-          src={`${process.env.NEXT_PUBLIC_NYPL_HEADER_URL}/footer.min.js?containerId=nypl-footer`}
+          src={`${process.env.NYPL_HEADER_URL}/footer.min.js?containerId=nypl-footer`}
           async
         />
         <div id="nypl-footer"></div>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -23,7 +23,7 @@ export default function Document() {
         <div id="Header-Placeholder">
           <div id="nypl-header"></div>
           <script
-            src={`${process.env.NYPL_HEADER_URL}/header.min.js?containerId=nypl-header`}
+            src={`${process.env.NEXT_PUBLIC_NYPL_HEADER_URL}/header.min.js?containerId=nypl-header`}
             async
           />
         </div>
@@ -31,7 +31,7 @@ export default function Document() {
         <NextScript />
         {/* NYPL Footer script and container */}
         <script
-          src={`${process.env.NYPL_HEADER_URL}/footer.min.js?containerId=nypl-footer`}
+          src={`${process.env.NEXT_PUBLIC_NYPL_HEADER_URL}/footer.min.js?containerId=nypl-footer`}
           async
         />
         <div id="nypl-footer"></div>


### PR DESCRIPTION
It seems the travis var name was not consistent with what docker and the app expected the env var to be so the Header and Footer never loaded in the AWS QA instance. This should fix that.