### PR TITLE
Homepage relative urls

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   CardHeading,
   CardContent,
+  Link,
 } from "@nypl/design-system-react-components"
 
 import RCLink from "../src/components/RCLink/RCLink"
@@ -26,9 +27,9 @@ export default function Home() {
           Culture, and The New York Public Library for the Performing Arts.
           Plus, access materials from library collections at Columbia
           University, Harvard University, and Princeton University.{" "}
-          <RCLink href="/research/collections/about/shared-collection-catalog">
+          <Link href="/research/collections/about/shared-collection-catalog">
             Learn more.
-          </RCLink>
+          </Link>
         </p>
         <p>
           Please note that the Research Catalog does not include circulating
@@ -60,9 +61,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="/research/collections">
-              Collections
-            </RCLink>
+            <Link href="/research/collections">Collections</Link>
           </CardHeading>
           <CardContent>
             <p>
@@ -81,9 +80,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="/locations/map?libraries=research">
-              Locations
-            </RCLink>
+            <Link href="/locations/map?libraries=research">Locations</Link>
           </CardHeading>
           <CardContent>
             <p>
@@ -102,7 +99,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="https://nypl.org/about/divisions">Divisions</RCLink>
+            <Link href="/about/divisions">Divisions</Link>
           </CardHeading>
           <CardContent>
             <p>
@@ -121,7 +118,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="/research/support">Support</RCLink>
+            <Link href="/research/support">Support</Link>
           </CardHeading>
           <CardContent>
             <p>
@@ -140,7 +137,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="/research/services">Services</RCLink>
+            <Link href="/research/services">Services</Link>
           </CardHeading>
           <CardContent>
             <p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,7 @@ export default function Home() {
           Culture, and The New York Public Library for the Performing Arts.
           Plus, access materials from library collections at Columbia
           University, Harvard University, and Princeton University.{" "}
-          <RCLink href="https://www.nypl.org/research/collections/about/shared-collection-catalog">
+          <RCLink href="/research/collections/about/shared-collection-catalog">
             Learn more.
           </RCLink>
         </p>
@@ -34,7 +34,7 @@ export default function Home() {
           Please note that the Research Catalog does not include circulating
           materials. For books and more that you can check out to take home
           please visit our{" "}
-          <RCLink href="https://browse.nypl.org">
+          <RCLink href="https://nypl.na2.iiivega.com/">
             circulating branch catalog.
           </RCLink>{" "}
           The{" "}
@@ -60,7 +60,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="https://nypl.org/research/collections">
+            <RCLink href="/research/collections">
               Collections
             </RCLink>
           </CardHeading>
@@ -81,7 +81,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="https://nypl.org/locations/map?libraries=research">
+            <RCLink href="/locations/map?libraries=research">
               Locations
             </RCLink>
           </CardHeading>
@@ -121,7 +121,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="https://nypl.org/research/support">Support</RCLink>
+            <RCLink href="/research/support">Support</RCLink>
           </CardHeading>
           <CardContent>
             <p>
@@ -140,7 +140,7 @@ export default function Home() {
           layout="row"
         >
           <CardHeading level="four">
-            <RCLink href="https://nypl.org/research/services">Services</RCLink>
+            <RCLink href="/research/services">Services</RCLink>
           </CardHeading>
           <CardContent>
             <p>


### PR DESCRIPTION
Small update to get relative urls for NYPL.org links. This is to get the appropriate QA or production link for testing.

I could not use the `RCLink` component since next.js thinks a relative link is part of the app and injects the root URL. So instead just the DS `Link` is used so that the URL is relative to the domain and not the root path (/research/research-catalog).

This won't work locally or on Vercel but _should_ work on the QA site _after_ we do the reverse proxy. For example, 
`https://qa-research-catalog.nypl.org/about/divisions` won't work but when the app is reverse proxied onto qa-www.nypl.org, it'll work as intended.