### PR TITLE
Removing nextjs config for page routing

### DIFF
--- a/__test__/pages/404/404.test.tsx
+++ b/__test__/pages/404/404.test.tsx
@@ -1,9 +1,9 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 
-import Custom404 from "."
-import Redirect404 from "./redirect"
-import { LEGACY_CATALOG_URL } from "../../src/config/constants"
+import Custom404 from "../../../pages/404/index"
+import Redirect404 from "../../../pages/404/redirect"
+import { LEGACY_CATALOG_URL } from "../../../src/config/constants"
 
 describe("404", () => {
   it("should display 404 text", () => {

--- a/__test__/pages/Home.test.tsx
+++ b/__test__/pages/Home.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 
-import Home from "./index"
+import Home from "../../pages/index"
 
 describe("Home", () => {
   it("should render an H2", () => {

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, act } from "@testing-library/react"
 import mockRouter from "next-router-mock"
 import userEvent from "@testing-library/user-event"
 
-import AdvancedSearch from "./advanced"
+import AdvancedSearch from "../../../pages/search/advanced"
 
 // Mock next router
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))

--- a/__test__/pages/search/searchResults.test.tsx
+++ b/__test__/pages/search/searchResults.test.tsx
@@ -3,9 +3,9 @@ import { render, screen } from "@testing-library/react"
 
 import mockRouter from "next-router-mock"
 
-import { results } from "../../__test__/fixtures/searchResultsManyBibs"
-import { noBibs } from "../../__test__/fixtures/searchResultsNoBibs"
-import SearchResults from "./index"
+import { results } from "../../fixtures/searchResultsManyBibs"
+import { noBibs } from "../../fixtures/searchResultsNoBibs"
+import SearchResults from "../../../pages/search/index"
 
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   basePath: "/research/research-catalog",
+  // pageExtensions: ["page.tsx", "page.ts", "page.jsx", "page.js"],
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   basePath: "/research/research-catalog",
-  pageExtensions: ["page.tsx", "page.ts", "page.jsx", "page.js"],
+  // pageExtensions: ["page.tsx", "page.ts", "page.jsx", "page.js"],
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,6 @@
 const nextConfig = {
   reactStrictMode: true,
   basePath: "/research/research-catalog",
-  // pageExtensions: ["page.tsx", "page.ts", "page.jsx", "page.js"],
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Removing `pageExtension` from nextjs' config. It did not allow the render locally or on Vercel.