### PR TITLE
SCC-3714 - Search Results Component

### DIFF
--- a/__test__/fixtures/searchResultElectronicResources.ts
+++ b/__test__/fixtures/searchResultElectronicResources.ts
@@ -1,0 +1,116 @@
+export const searchResultElectronicResources = {
+  "@type": ["nypl:Item", "nypl:Resource"],
+  "@id": "res:b22133121",
+  carrierType: [
+    {
+      "@id": "carriertypes:nc",
+      prefLabel: "volume",
+    },
+  ],
+  contributorLiteral: [
+    "Acosta, María",
+    "Gomez, Vanessa, 1984-",
+    "OverDrive, Inc.",
+  ],
+  createdString: ["2019"],
+  createdYear: 2019,
+  creatorLiteral: ["Persico, Nicky"],
+  dateStartYear: 2019,
+  dateString: ["2019"],
+  description: [
+    "Un abogado en prácticas inexperto y un poco torpe se ve involucrado en la defensa de dos mujeres muy diferentes entre ellas por edad y clase social, unidas por el hecho de ser ambas víctimas de la violencia. A partir de aquí se desenmaraña, aderezado por intrigantes mezclas culinarias, un denso entramado de historias y personas que, entre el suspense y la gravedad, se adentra en el fenómeno del acoso y de la manipulación por medio de una sucesión de eventos destinados a revelar una realidad insospechable. En una encantadora Puglia, descripta de manera cuanto menos original, Nicky Persico guía al lector a través de un mundo de individuos peligrosos (enemigos invisibles ante los ojos de todo el mundo, y sin embargo envidiosos de la vida y la vitalidad de las víctimas que persiguen) proponiendo la receta que su protagonista ha ideado para transformar elementos triviales en filosofía de vida: los Spaghetti Paradiso.",
+  ],
+  electronicResources: [
+    {
+      title: "Access eNYPL",
+      url: "http://link.overdrive.com/?websiteId=37&titleId=5312492",
+      prefLabel: "Access eNYPL",
+    },
+  ],
+  extent: [
+    "1 online resource (1 sound file (06 hr., 55 min., 34 sec.)) : digital",
+  ],
+  genreForm: ["Audiobooks.", "Fiction."],
+  idIsbn: ["9788835401155", "8835401151"],
+  idOclc: ["1144496190"],
+  identifier: [
+    {
+      "@type": "nypl:Bnumber",
+      "@value": "22133121",
+    },
+    {
+      "@type": "bf:Isbn",
+      "@value": "9788835401155",
+    },
+    {
+      "@type": "bf:Isbn",
+      "@value": "8835401151",
+    },
+    {
+      "@type": "nypl:Oclc",
+      "@value": "1144496190",
+    },
+    {
+      "@type": "nypl:Oclc",
+      "@value": "1144496190",
+    },
+    {
+      "@type": "bf:Identifier",
+      "@value": "(OCoLC)1144496190",
+    },
+  ],
+  issuance: [
+    {
+      "@id": "urn:biblevel:m",
+      prefLabel: "monograph/item",
+    },
+  ],
+  items: [],
+  language: [
+    {
+      "@id": "lang:spa",
+      prefLabel: "Spanish",
+    },
+  ],
+  lccClassification: ["PQ4916.E778 S63 2019"],
+  materialType: [
+    {
+      "@id": "resourcetypes:aud",
+      prefLabel: "Audio",
+    },
+  ],
+  mediaType: [
+    {
+      "@id": "mediatypes:n",
+      prefLabel: "unmediated",
+    },
+  ],
+  numAvailable: 0,
+  numCheckinCardItems: 0,
+  numElectronicResources: 1,
+  numItemDatesParsed: 0,
+  numItemVolumesParsed: 0,
+  numItems: 0,
+  numItemsMatched: 0,
+  numItemsTotal: 0,
+  nyplSource: ["sierra-nypl"],
+  placeOfPublication: ["[Solon, Ohio]"],
+  publicationStatement: ["[Solon, Ohio] : Tektime, 2019."],
+  publisherLiteral: ["Tektime"],
+  subjectLiteral: [
+    "Sexual harassment of women -- Fiction.",
+    "Sexual harassment of women.",
+    "Puglia (Italy) -- Fiction.",
+    "Italy -- Puglia.",
+  ],
+  title: ["Spaghetti paradiso"],
+  titleDisplay: [
+    "Spaghetti paradiso / Nicky Persico ; traducción por: María Acosta.",
+  ],
+  type: ["nypl:Item"],
+  updatedAt: 1681346906709,
+  uri: "b22133121",
+  suppressed: false,
+  hasItemVolumes: false,
+  hasItemDates: false,
+}

--- a/__test__/fixtures/searchResultPhysicalItems.ts
+++ b/__test__/fixtures/searchResultPhysicalItems.ts
@@ -1,0 +1,212 @@
+export const searchResultPhysicalItems = {
+  "@type": ["nypl:Item", "nypl:Resource"],
+  "@id": "res:b12810991",
+  carrierType: [
+    {
+      "@id": "carriertypes:nc",
+      prefLabel: "volume",
+    },
+  ],
+  createdString: ["1955"],
+  createdYear: 1955,
+  creatorLiteral: ["Prezzolini, Giuseppe, 1882-"],
+  dateStartYear: 1955,
+  dateString: ["1955"],
+  dimensions: ["22 cm."],
+  electronicResources: [],
+  extent: ["148 p. illus."],
+  idLccn: ["55006407 /L"],
+  idOclc: ["787361"],
+  identifier: [
+    {
+      "@type": "bf:ShelfMark",
+      "@value": "D-11 2906",
+    },
+    {
+      "@type": "nypl:Bnumber",
+      "@value": "12810991",
+    },
+    {
+      "@type": "nypl:Oclc",
+      "@value": "787361",
+    },
+    {
+      "@type": "bf:Lccn",
+      "@value": "55006407 /L",
+    },
+    {
+      "@type": "bf:Identifier",
+      "@value": "(WaOLN)nyp2791238",
+    },
+  ],
+  issuance: [
+    {
+      "@id": "urn:biblevel:m",
+      prefLabel: "monograph/item",
+    },
+  ],
+  items: [
+    {
+      "@id": "res:i10572545",
+      "@type": ["bf:Item"],
+      accessMessage: [
+        {
+          "@id": "accessMessage:1",
+          prefLabel: "Use in library",
+        },
+      ],
+      catalogItemType: [
+        {
+          "@id": "catalogItemType:55",
+          prefLabel: "book, limited circ, MaRLI",
+        },
+      ],
+      eddRequestable: true,
+      formatLiteral: ["Text"],
+      holdingLocation: [
+        {
+          "@id": "loc:mal82",
+          prefLabel: "Schwarzman Building - Main Reading Room 315",
+        },
+      ],
+      idBarcode: ["33433090622188"],
+      identifier: [
+        {
+          "@type": "bf:ShelfMark",
+          "@value": "D-11 2906",
+        },
+        {
+          "@type": "bf:Barcode",
+          "@value": "33433090622188",
+        },
+      ],
+      owner: [
+        {
+          "@id": "orgs:1101",
+          prefLabel: "General Research Division",
+        },
+      ],
+      physRequestable: true,
+      physicalLocation: ["D-11 2906"],
+      requestable: [true],
+      shelfMark: ["D-11 2906"],
+      specRequestable: false,
+      status: [
+        {
+          "@id": "status:a",
+          prefLabel: "Available",
+        },
+      ],
+      uri: "i10572545",
+      idNyplSourceId: {
+        "@type": "SierraNypl",
+        "@value": "10572545",
+      },
+    },
+    {
+      "@id": "res:i10572546",
+      "@type": ["bf:Item"],
+      accessMessage: [
+        {
+          "@id": "accessMessage:2",
+          prefLabel: "Request in advance",
+        },
+      ],
+      catalogItemType: [
+        {
+          "@id": "catalogItemType:55",
+          prefLabel: "book, limited circ, MaRLI",
+        },
+      ],
+      eddRequestable: true,
+      formatLiteral: ["Text"],
+      holdingLocation: [
+        {
+          "@id": "loc:rc2ma",
+          prefLabel: "Offsite",
+        },
+      ],
+      idBarcode: ["33433077546822"],
+      identifier: [
+        {
+          "@type": "bf:ShelfMark",
+          "@value":
+            "VTI (Prezzolini, G. History of spaghetti eating and cooking for: spaghetti dinner)",
+        },
+        {
+          "@type": "bf:Barcode",
+          "@value": "33433077546822",
+        },
+      ],
+      owner: [
+        {
+          "@id": "orgs:1000",
+          prefLabel: "Stephen A. Schwarzman Building",
+        },
+      ],
+      physRequestable: true,
+      physicalLocation: [
+        "VTI (Prezzolini, G. History of spaghetti eating and cooking for: spaghetti dinner)",
+      ],
+      recapCustomerCode: ["NA"],
+      requestable: [true],
+      shelfMark: [
+        "VTI (Prezzolini, G. History of spaghetti eating and cooking for: spaghetti dinner)",
+      ],
+      specRequestable: false,
+      status: [
+        {
+          "@id": "status:a",
+          prefLabel: "Available",
+        },
+      ],
+      uri: "i10572546",
+      idNyplSourceId: {
+        "@type": "SierraNypl",
+        "@value": "10572546",
+      },
+    },
+  ],
+  language: [
+    {
+      "@id": "lang:eng",
+      prefLabel: "English",
+    },
+  ],
+  lccClassification: ["TS2157 .P7"],
+  materialType: [
+    {
+      "@id": "resourcetypes:txt",
+      prefLabel: "Text",
+    },
+  ],
+  mediaType: [
+    {
+      "@id": "mediatypes:n",
+      prefLabel: "unmediated",
+    },
+  ],
+  numCheckinCardItems: 0,
+  numElectronicResources: 0,
+  numItemDatesParsed: 0,
+  numItemVolumesParsed: 0,
+  numItemsMatched: 2,
+  numItemsTotal: 2,
+  nyplSource: ["sierra-nypl"],
+  placeOfPublication: ["New York"],
+  publicationStatement: ["New York, Abelard-Schuman [1955]"],
+  publisherLiteral: ["Abelard-Schuman"],
+  shelfMark: ["D-11 2906"],
+  subjectLiteral: ["Pasta products.", "Cooking (Pasta)"],
+  title: ["A history of spaghetti eating and cooking for: spaghetti dinner."],
+  titleAlt: ["Spaghetti dinner."],
+  titleDisplay: [
+    "A history of spaghetti eating and cooking for: spaghetti dinner.",
+  ],
+  type: ["nypl:Item"],
+  updatedAt: 1696279034748,
+  uri: "b12810991",
+  suppressed: false,
+  hasItemVolumes: false,
+  hasItemDates: false,
+}

--- a/__test__/pages/search/searchResults.test.tsx
+++ b/__test__/pages/search/searchResults.test.tsx
@@ -16,11 +16,11 @@ describe("Search Results page", () => {
       mockRouter.push(`/search?q=${query}`)
       render(<SearchResults results={results} />)
 
-      const displayingText = screen.getByRole("heading", { level: 3 })
+      const displayingText = screen.getByRole("heading", { level: 2 })
       expect(displayingText).toHaveTextContent(
         `Displaying 1-50 of ${results.results.totalResults} results for keyword "${query}"`
       )
-      const cards = screen.getAllByRole("heading", { level: 4 })
+      const cards = screen.getAllByRole("heading", { level: 3 })
       expect(cards).toHaveLength(50)
     })
   })

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -56,12 +56,12 @@ export default function Search({ results }) {
       >
         {totalResults ? (
           <>
-            <Heading level="three">
+            <Heading level="three" mb="xl">
               {`Displaying 1-50 of ${totalResults.toLocaleString()} results for keyword "${
                 searchParams.q
               }"`}
             </Heading>
-            <SimpleGrid columns={1}>
+            <SimpleGrid columns={1} gap="grid.xl">
               {searchResultBibs.map((bib: SearchResultsBib) => {
                 return <SearchResult key={bib.id} bib={bib} />
               })}

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -56,7 +56,7 @@ export default function Search({ results }) {
       >
         {totalResults ? (
           <>
-            <Heading level="three" mb="xl">
+            <Heading level="two" mb="xl">
               {`Displaying 1-50 of ${totalResults.toLocaleString()} results for keyword "${
                 searchParams.q
               }"`}

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -11,6 +11,8 @@ import { parse } from "qs"
 import RCLink from "../../src/components/RCLink/RCLink"
 import Layout from "../../src/components/Layout/Layout"
 import DRBContainer from "../../src/components/DRB/DRBContainer"
+import SearchResult from "../../src/components/SearchResult/SearchResult"
+
 import { fetchResults } from "../api/search"
 import {
   mapQueryToSearchParams,
@@ -67,13 +69,7 @@ export default function Search({ results }) {
             </Heading>
             <SimpleGrid columns={1}>
               {searchResultBibs.map((bib: SearchResultsBib) => {
-                return (
-                  <Card key={bib.id}>
-                    <CardHeading level="four">
-                      <RCLink href={bib.url}>{bib.title}</RCLink>
-                    </CardHeading>
-                  </Card>
-                )
+                return <SearchResult key={bib.id} bib={bib} />
               })}
             </SimpleGrid>
           </>

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -56,7 +56,7 @@ export default function Search({ results }) {
       >
         {totalResults ? (
           <>
-            <Heading level="two" mb="xl">
+            <Heading level="two" mb="xl" size="heading4">
               {`Displaying 1-50 of ${totalResults.toLocaleString()} results for keyword "${
                 searchParams.q
               }"`}

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,14 +1,8 @@
 import Head from "next/head"
-import {
-  Card,
-  CardHeading,
-  Heading,
-  SimpleGrid,
-} from "@nypl/design-system-react-components"
+import { Heading, SimpleGrid } from "@nypl/design-system-react-components"
 import { useRouter } from "next/router"
 import { parse } from "qs"
 
-import RCLink from "../../src/components/RCLink/RCLink"
 import Layout from "../../src/components/Layout/Layout"
 import DRBContainer from "../../src/components/DRB/DRBContainer"
 import SearchResult from "../../src/components/SearchResult/SearchResult"

--- a/src/components/SearchResult/SearchResult.test.tsx
+++ b/src/components/SearchResult/SearchResult.test.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import SearchResult from "./SearchResult"
+import SearchResultsBib from "../../models/SearchResultsBib"
+
+describe("SearchResult with Physical Items", () => {
+  beforeEach(() => {
+    const bib = new SearchResultsBib({ numItemsTotal: 2 })
+    bib.title = "Bib Title"
+    bib.id = "b12345678"
+    bib.materialType = "Text"
+    bib.publicationStatement = "Publication Statement"
+    bib.yearPublished = "1999"
+    render(<SearchResult bib={bib} />)
+  })
+
+  it("renders a title link with the correct bib href", async () => {
+    const resultTitleLink = screen.getByRole("link", { name: "Bib Title" })
+    expect(resultTitleLink).toHaveAttribute("href", "/bib/b12345678")
+  })
+
+  it("renders the primary bib fields", async () => {
+    screen.getByText("Text")
+    screen.getByText("Publication Statement")
+    screen.getByText("1999")
+    screen.getByText("2 Items")
+  })
+})
+
+describe("SearchResult with Electronic Resources", () => {
+  it("renders the correct item message for bib with electronic resources", async () => {
+    const bib = new SearchResultsBib({ electronicResources: [{}] })
+    render(<SearchResult bib={bib} />)
+    screen.getByText("1 Resource")
+  })
+})

--- a/src/components/SearchResult/SearchResult.test.tsx
+++ b/src/components/SearchResult/SearchResult.test.tsx
@@ -2,34 +2,33 @@ import React from "react"
 import { render, screen } from "@testing-library/react"
 import SearchResult from "./SearchResult"
 import SearchResultsBib from "../../models/SearchResultsBib"
+import { searchResultPhysicalItems } from "../../../__test__/fixtures/searchResultPhysicalItems"
+import { searchResultElectronicResources } from "../../../__test__/fixtures/searchResultElectronicResources"
 
 describe("SearchResult with Physical Items", () => {
   beforeEach(() => {
-    const bib = new SearchResultsBib({ numItemsTotal: 2 })
-    bib.title = "Bib Title"
-    bib.id = "b12345678"
-    bib.materialType = "Text"
-    bib.publicationStatement = "Publication Statement"
-    bib.yearPublished = "1999"
+    const bib = new SearchResultsBib(searchResultPhysicalItems)
     render(<SearchResult bib={bib} />)
   })
 
   it("renders a title link with the correct bib href", async () => {
-    const resultTitleLink = screen.getByRole("link", { name: "Bib Title" })
-    expect(resultTitleLink).toHaveAttribute("href", "/bib/b12345678")
+    const resultTitleLink = screen.getByRole("link", {
+      name: "A history of spaghetti eating and cooking for: spaghetti dinner.",
+    })
+    expect(resultTitleLink).toHaveAttribute("href", "/bib/b12810991")
   })
 
   it("renders the primary bib fields", async () => {
     screen.getByText("Text")
-    screen.getByText("Publication Statement")
-    screen.getByText("1999")
+    screen.getByText("New York, Abelard-Schuman [1955]")
+    screen.getByText("1955")
     screen.getByText("2 Items")
   })
 })
 
 describe("SearchResult with Electronic Resources", () => {
   it("renders the correct item message for bib with electronic resources", async () => {
-    const bib = new SearchResultsBib({ electronicResources: [{}] })
+    const bib = new SearchResultsBib(searchResultElectronicResources)
     render(<SearchResult bib={bib} />)
     screen.getByText("1 Resource")
   })

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -25,7 +25,7 @@ const SearchResult = ({ bib }: SearchResultProps) => {
         paddingBottom: "var(--nypl-space-m)",
       }}
     >
-      <CardHeading level="four">
+      <CardHeading level="three">
         <DSLink href={`${PATHS.BIB}/${bib.id}`}>{bib.title}</DSLink>
       </CardHeading>
       <CardContent>

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -3,6 +3,8 @@ import {
   CardContent,
   Link as DSLink,
   CardHeading,
+  Box,
+  Text,
 } from "@nypl/design-system-react-components"
 
 import type SearchResultsBib from "../../models/SearchResultsBib"
@@ -22,7 +24,12 @@ const SearchResult = ({ bib }: SearchResultProps) => {
         <DSLink href={`${PATHS.BIB}/${bib.id}`}>{bib.title}</DSLink>
       </CardHeading>
       <CardContent>
-        <ul></ul>
+        <Box>
+          {bib.materialType && <Text>{bib.materialType}</Text>}
+          {bib.publicationStatement && <Text>{bib.publicationStatement}</Text>}
+          {bib.yearPublished && <Text>{bib.yearPublished}</Text>}
+          {bib.itemMessage.length && <Text>{bib.itemMessage}</Text>}
+        </Box>
       </CardContent>
     </Card>
   )

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -23,7 +23,6 @@ const SearchResult = ({ bib }: SearchResultProps) => {
       sx={{
         borderBottom: "1px solid var(--nypl-colors-ui-border-default)",
         paddingBottom: "var(--nypl-space-m)",
-        marginBottom: "var(--nypl-space-l)",
       }}
     >
       <CardHeading level="three">

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -1,10 +1,12 @@
 import {
   Card,
   CardContent,
-  Text,
   Link as DSLink,
+  CardHeading,
 } from "@nypl/design-system-react-components"
+
 import type SearchResultsBib from "../../models/SearchResultsBib"
+import { PATHS } from "../../config/constants"
 
 interface SearchResultProps {
   bib: SearchResultsBib
@@ -16,10 +18,11 @@ interface SearchResultProps {
 const SearchResult = ({ bib }: SearchResultProps) => {
   return (
     <Card>
+      <CardHeading level="three">
+        <DSLink href={`${PATHS.BIB}/${bib.id}`}>{bib.title}</DSLink>
+      </CardHeading>
       <CardContent>
-        <DSLink href="/">
-          <Text size="subtitle1">{bib.title}</Text>
-        </DSLink>
+        <ul></ul>
       </CardContent>
     </Card>
   )

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -1,0 +1,28 @@
+import {
+  Card,
+  CardContent,
+  Text,
+  Link as DSLink,
+} from "@nypl/design-system-react-components"
+import type SearchResultsBib from "../../models/SearchResultsBib"
+
+interface SearchResultProps {
+  bib: SearchResultsBib
+}
+
+/**
+ * The SearchResult component displays a single search result element.
+ */
+const SearchResult = ({ bib }: SearchResultProps) => {
+  return (
+    <Card>
+      <CardContent>
+        <DSLink href="/">
+          <Text size="subtitle1">{bib.title}</Text>
+        </DSLink>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default SearchResult

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -22,16 +22,14 @@ const SearchResult = ({ bib }: SearchResultProps) => {
     <Card
       sx={{
         borderBottom: "1px solid var(--nypl-colors-ui-border-default)",
-        paddingBottom: "var(--nypl-space-m)",
+        paddingBottom: "m",
       }}
     >
       <CardHeading level="three">
         <DSLink href={`${PATHS.BIB}/${bib.id}`}>{bib.title}</DSLink>
       </CardHeading>
       <CardContent>
-        <Box
-          sx={{ p: { display: "inline", marginRight: "var(--nypl-space-s)" } }}
-        >
+        <Box sx={{ p: { display: "inline", marginRight: "s" } }}>
           {bib.materialType && <Text>{bib.materialType}</Text>}
           {bib.publicationStatement && <Text>{bib.publicationStatement}</Text>}
           {bib.yearPublished && <Text>{bib.yearPublished}</Text>}

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -19,12 +19,20 @@ interface SearchResultProps {
  */
 const SearchResult = ({ bib }: SearchResultProps) => {
   return (
-    <Card>
+    <Card
+      sx={{
+        borderBottom: "1px solid var(--nypl-colors-ui-border-default)",
+        paddingBottom: "var(--nypl-space-m)",
+        marginBottom: "var(--nypl-space-l)",
+      }}
+    >
       <CardHeading level="three">
         <DSLink href={`${PATHS.BIB}/${bib.id}`}>{bib.title}</DSLink>
       </CardHeading>
       <CardContent>
-        <Box>
+        <Box
+          sx={{ p: { display: "inline", marginRight: "var(--nypl-space-s)" } }}
+        >
           {bib.materialType && <Text>{bib.materialType}</Text>}
           {bib.publicationStatement && <Text>{bib.publicationStatement}</Text>}
           {bib.yearPublished && <Text>{bib.yearPublished}</Text>}

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -28,7 +28,7 @@ const SearchResult = ({ bib }: SearchResultProps) => {
           {bib.materialType && <Text>{bib.materialType}</Text>}
           {bib.publicationStatement && <Text>{bib.publicationStatement}</Text>}
           {bib.yearPublished && <Text>{bib.yearPublished}</Text>}
-          {bib.itemMessage.length && <Text>{bib.itemMessage}</Text>}
+          <Text>{bib.itemMessage}</Text>
         </Box>
       </CardContent>
     </Card>

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -25,7 +25,7 @@ const SearchResult = ({ bib }: SearchResultProps) => {
         paddingBottom: "var(--nypl-space-m)",
       }}
     >
-      <CardHeading level="three">
+      <CardHeading level="four">
         <DSLink href={`${PATHS.BIB}/${bib.id}`}>{bib.title}</DSLink>
       </CardHeading>
       <CardContent>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,6 +10,7 @@ export const PATHS = {
   HOME: "/",
   SEARCH: "/search",
   ADVANCED_SEARCH: "/search/advanced",
+  BIB: "/bib",
   "404": "/404",
   "404_REDIRECT": "/404/redirect",
 }


### PR DESCRIPTION
This PR initializes the Search Result component as well as basic tests for rendering the primary Bib fields.

https://jira.nypl.org/browse/SCC-3714

It does not include fields or other functionality related to the item table.