### PR TITLE
Make search form controlled component

### DIFF
--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -61,7 +61,9 @@ export default function Search({ results }) {
         {totalResults ? (
           <>
             <Heading level="three">
-              {`Displaying 1-50 of ${totalResults.toLocaleString()} results for keyword "${
+              {`Displaying ${
+                totalResults > 50 ? "1-50" : totalResults.toLocaleString()
+              } of ${totalResults.toLocaleString()} results for keyword "${
                 searchParams.q
               }"`}
             </Heading>

--- a/src/components/SearchForm/SearchForm.test.tsx
+++ b/src/components/SearchForm/SearchForm.test.tsx
@@ -13,6 +13,9 @@ describe("SearchForm", () => {
       screen.getByRole("button", { name: "Search" }),
       new MouseEvent("click")
     )
+  beforeEach(() => {
+    mockRouter.query.q = ""
+  })
   afterEach(async () => {
     const input = screen.getByRole("textbox")
     await userEvent.clear(input)
@@ -35,7 +38,7 @@ describe("SearchForm", () => {
       await userEvent.selectOptions(searchScopeSelect, "journal_title")
       submit()
       expect(mockRouter.asPath).toBe(
-        "/search?q=spaghettispaghetti&search_scope=journal_title"
+        "/search?q=spaghetti&search_scope=journal_title"
       )
     })
   })

--- a/src/components/SearchForm/SearchForm.test.tsx
+++ b/src/components/SearchForm/SearchForm.test.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { render, screen, fireEvent, act } from "@testing-library/react"
+import mockRouter from "next-router-mock"
+
+import SearchForm from "./SearchForm"
+import userEvent from "@testing-library/user-event"
+
+jest.mock("next/router", () => jest.requireActual("next-router-mock"))
+
+describe("SubNav", () => {
+  const submit = () =>
+    fireEvent(
+      screen.getByRole("button", { name: "Search" }),
+      new MouseEvent("click")
+    )
+  it("submits a keyword query", async () => {
+    render(<SearchForm />)
+    const input = screen.getByRole("textbox")
+    await act(async () => {
+      await userEvent.type(input, "spaghetti")
+      submit()
+      expect(mockRouter.asPath).toBe("/search?q=spaghetti")
+    })
+  })
+})

--- a/src/components/SearchForm/SearchForm.test.tsx
+++ b/src/components/SearchForm/SearchForm.test.tsx
@@ -7,13 +7,17 @@ import userEvent from "@testing-library/user-event"
 
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 
-describe("SubNav", () => {
+describe("SearchForm", () => {
   const submit = () =>
     fireEvent(
       screen.getByRole("button", { name: "Search" }),
       new MouseEvent("click")
     )
-  it("submits a keyword query", async () => {
+  afterEach(async () => {
+    const input = screen.getByRole("textbox")
+    await userEvent.clear(input)
+  })
+  it("submits a keyword query by default", async () => {
     render(<SearchForm />)
     const input = screen.getByRole("textbox")
     await act(async () => {
@@ -21,5 +25,24 @@ describe("SubNav", () => {
       submit()
       expect(mockRouter.asPath).toBe("/search?q=spaghetti")
     })
+  })
+  it("submits a journal_title query", async () => {
+    render(<SearchForm />)
+    const input = screen.getByRole("textbox")
+    const searchScopeSelect = screen.getByRole("combobox")
+    await act(async () => {
+      await userEvent.type(input, "spaghetti")
+      await userEvent.selectOptions(searchScopeSelect, "journal_title")
+      submit()
+      expect(mockRouter.asPath).toBe(
+        "/search?q=spaghettispaghetti&search_scope=journal_title"
+      )
+    })
+  })
+  it("gets keyword from url", () => {
+    mockRouter.query.q = "spaghetti"
+    render(<SearchForm />)
+    const input = screen.getByDisplayValue("spaghetti")
+    expect(input).toBeTruthy()
   })
 })

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -14,7 +14,9 @@ import { BASE_URL, PATHS } from "../../config/constants"
  */
 const SearchForm = () => {
   const router = useRouter()
-  const [searchTerm, setSearchTerm] = useState((router.query.q as string) || "")
+  const [searchTerm, setSearchTerm] = useState(
+    (router?.query?.q as string) || ""
+  )
   const [searchScope, setSearchScope] = useState("all")
 
   const handleSubmit = async (e: SyntheticEvent) => {

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -1,11 +1,11 @@
 import { SearchBar } from "@nypl/design-system-react-components"
 import { useRouter } from "next/router"
-import type { SyntheticEvent } from "react"
+import type { SyntheticEvent, Dispatch, SetStateAction } from "react"
+import { useState } from "react"
 
 import styles from "../../../styles/components/Search.module.scss"
 import RCLink from "../RCLink/RCLink"
 import { getQueryString } from "../../utils/searchUtils"
-import type { SearchFormEvent } from "../../types/searchTypes"
 import { BASE_URL, PATHS } from "../../config/constants"
 
 /**
@@ -14,17 +14,26 @@ import { BASE_URL, PATHS } from "../../config/constants"
  */
 const SearchForm = () => {
   const router = useRouter()
+  const [searchTerm, setSearchTerm] = useState((router.query.q as string) || "")
+  const [searchScope, setSearchScope] = useState("all")
 
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
-    const target = e.target as typeof e.target & SearchFormEvent
     const searchParams = {
-      q: target.q.value,
-      field: target.search_scope.value,
+      q: searchTerm,
+      field: searchScope,
     }
     const queryString = getQueryString(searchParams)
 
     await router.push(`${PATHS.SEARCH}${queryString}`)
+  }
+
+  const handleInputChange = (
+    e: SyntheticEvent,
+    setValue: Dispatch<SetStateAction<string>>
+  ) => {
+    const target = e.target as HTMLInputElement
+    setValue(target.value)
   }
 
   return (
@@ -38,6 +47,8 @@ const SearchForm = () => {
             onSubmit={handleSubmit}
             labelText="Search Bar Label"
             selectProps={{
+              value: searchScope,
+              onChange: (e) => handleInputChange(e, setSearchScope),
               labelText: "Select a category",
               name: "search_scope",
               optionsData: [
@@ -50,6 +61,8 @@ const SearchForm = () => {
               ],
             }}
             textInputProps={{
+              onChange: (e) => handleInputChange(e, setSearchTerm),
+              value: searchTerm,
               labelText:
                 "Search by keyword, title, journal title, or author/contributor",
               name: "q",

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -28,7 +28,7 @@ const SearchForm = () => {
     await router.push(`${PATHS.SEARCH}${queryString}`)
   }
 
-  const handleInputChange = (
+  const handleChange = (
     e: SyntheticEvent,
     setValue: Dispatch<SetStateAction<string>>
   ) => {
@@ -48,7 +48,7 @@ const SearchForm = () => {
             labelText="Search Bar Label"
             selectProps={{
               value: searchScope,
-              onChange: (e) => handleInputChange(e, setSearchScope),
+              onChange: (e) => handleChange(e, setSearchScope),
               labelText: "Select a category",
               name: "search_scope",
               optionsData: [
@@ -61,7 +61,7 @@ const SearchForm = () => {
               ],
             }}
             textInputProps={{
-              onChange: (e) => handleInputChange(e, setSearchTerm),
+              onChange: (e) => handleChange(e, setSearchTerm),
               value: searchTerm,
               labelText:
                 "Search by keyword, title, journal title, or author/contributor",


### PR DESCRIPTION
- Search form prepopulates search bar with the value of q from the url (not global state). 
- Select and text input are now controlled components sharing a handler function
- tests!

- also updated search results string to be dynamic to less than 50 results