### PR TITLE
SCC-383x/vqa

### DIFF
--- a/src/components/EDSLink.tsx
+++ b/src/components/EDSLink.tsx
@@ -6,8 +6,8 @@ import React from "react"
  */
 const EDSLink = () => {
   return (
-    <Box mt="s" mb="s">
-      <Text size="body2" className="eds-link">
+    <Box mt="0" mb="0">
+      <Text size="body1" className="eds-link">
         <span style={{ color: "var(--nypl-colors-ui-success-primary)" }}>
           New!
         </span>{" "}

--- a/src/components/EDSLink.tsx
+++ b/src/components/EDSLink.tsx
@@ -1,0 +1,25 @@
+import { Box, Text, Link as DSLink } from "@nypl/design-system-react-components"
+import React from "react"
+
+/**
+ * Renders a simple link to log out the user out from the Catalog.
+ */
+const EDSLink = () => {
+  return (
+    <Box mt="s" mb="s">
+      <Text size="body2" className="eds-link">
+        <span style={{ color: "var(--nypl-colors-ui-success-primary)" }}>
+          New!
+        </span>{" "}
+        Try our{" "}
+        <DSLink href="https://research.ebsco.com/c/2styhb" target="_blank">
+          <strong>Article Search</strong>
+        </DSLink>{" "}
+        to discover online journals, books, and more from home with your library
+        card.
+      </Text>
+    </Box>
+  )
+}
+
+export default EDSLink

--- a/src/components/EDSLink.tsx
+++ b/src/components/EDSLink.tsx
@@ -1,13 +1,15 @@
 import { Box, Text, Link as DSLink } from "@nypl/design-system-react-components"
 import React from "react"
 
+import styles from "../../styles/components/Search.module.scss"
+
 /**
  * Renders a simple link to log out the user out from the Catalog.
  */
 const EDSLink = () => {
   return (
-    <Box mt="0" mb="0">
-      <Text size="body1" className="eds-link">
+    <Box className={styles.edsLink} mt="0" mb="0">
+      <Text size="body2" className="eds-link">
         <span style={{ color: "var(--nypl-colors-ui-success-primary)" }}>
           New!
         </span>{" "}

--- a/src/components/RCLink/RCLink.tsx
+++ b/src/components/RCLink/RCLink.tsx
@@ -6,6 +6,7 @@ interface RCLinkProps {
   active?: boolean
   href: string
   children: ReactNode
+  className?: string
 }
 
 /**
@@ -13,10 +14,18 @@ interface RCLinkProps {
  * Next's Link component to allow for correct navigation in Next per the design system's
  * docs. It also includes an 'active' prop used for styling the SubNav component.
  */
-const RCLink = ({ href, children, active = false, ...rest }: RCLinkProps) => {
+const RCLink = ({
+  className,
+  href,
+  children,
+  active = false,
+  ...rest
+}: RCLinkProps) => {
   return (
     <Link href={href} passHref {...rest}>
-      <DSLink fontWeight={active && "bold"}>{children}</DSLink>
+      <DSLink className={className} fontWeight={active && "bold"}>
+        {children}
+      </DSLink>
     </Link>
   )
 }

--- a/src/components/SearchForm/SearchForm.test.tsx
+++ b/src/components/SearchForm/SearchForm.test.tsx
@@ -20,6 +20,8 @@ describe("SearchForm", () => {
     const input = screen.getByRole("textbox")
     await userEvent.clear(input)
   })
+  it.todo("searches on an empty keyword after clearing the form")
+  it.todo("searches for {TBD} on an empty query")
   it("submits a keyword query by default", async () => {
     render(<SearchForm />)
     const input = screen.getByRole("textbox")

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -78,10 +78,10 @@ const SearchForm = () => {
             }}
           />
         </div>
-        <div className={styles.advancedSearchContainer}>
+        <div className={styles.auxSearchContainer}>
+          <EDSLink />
           <RCLink href={"/search/advanced"}>Advanced Search</RCLink>
         </div>
-        <EDSLink />
       </div>
     </div>
   )

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -66,6 +66,7 @@ const SearchForm = () => {
             textInputProps={{
               isClearable: true,
               onChange: (e) => handleChange(e, setSearchTerm),
+              isClearableCallback: () => setSearchTerm(""),
               value: searchTerm,
               labelText:
                 "Search by keyword, title, journal title, or author/contributor",

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -63,6 +63,7 @@ const SearchForm = () => {
               ],
             }}
             textInputProps={{
+              isClearable: true,
               onChange: (e) => handleChange(e, setSearchTerm),
               value: searchTerm,
               labelText:

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -81,7 +81,9 @@ const SearchForm = () => {
         </div>
         <div className={styles.auxSearchContainer}>
           <EDSLink />
-          <RCLink href={"/search/advanced"}>Advanced Search</RCLink>
+          <RCLink className={styles.advancedSearch} href={"/search/advanced"}>
+            Advanced Search
+          </RCLink>
         </div>
       </div>
     </div>

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -7,6 +7,7 @@ import styles from "../../../styles/components/Search.module.scss"
 import RCLink from "../RCLink/RCLink"
 import { getQueryString } from "../../utils/searchUtils"
 import { BASE_URL, PATHS } from "../../config/constants"
+import EDSLink from "../EDSLink"
 
 /**
  * The SearchForm component renders and controls the Search form and
@@ -80,6 +81,7 @@ const SearchForm = () => {
         <div className={styles.advancedSearchContainer}>
           <RCLink href={"/search/advanced"}>Advanced Search</RCLink>
         </div>
+        <EDSLink />
       </div>
     </div>
   )

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,7 @@
 import { appConfig } from "./config"
 
 export const BASE_URL = "/research/research-catalog"
-export const SITE_NAME = "NYPL Research Catalog"
+export const SITE_NAME = "Research Catalog | NYPL"
 export const RESULTS_PER_PAGE = 50
 export const DRB_RESULTS_PER_PAGE = 3
 

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -13,13 +13,19 @@
 .auxSearchContainer {
   display: flex;
   justify-content: space-between;
+  margin: var(--nypl-space-xs) 0;
   @media (max-width: 400px) {
     flex-direction: column-reverse;
     bottom-padding: var(--nypl-space-s);
     align-items: flex-end;
   }
-  a {
-    margin-top: var(--nypl-space-xs);
-    margin-bottom: var(--nypl-space-s);
-  }
+}
+
+.advancedSearch {
+  min-width: 127px;
+  margin-bottom: var(--nypl-space-s);
+}
+
+.edsLink {
+  padding-right: var(--nypl-space-xl);
 }

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -10,11 +10,12 @@
   @include maxWidth;
 }
 
-.advancedSearchContainer {
+.auxSearchContainer {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 
   a {
-    margin-top: var(--nypl-space-s);
+    margin-top: var(--nypl-space-xs);
+    margin-bottom: var(--nypl-space-s);
   }
 }

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -15,6 +15,6 @@
   justify-content: flex-end;
 
   a {
-    margin-top: var(--nypl-space-xxs);
+    margin-top: var(--nypl-space-s);
   }
 }

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -13,7 +13,11 @@
 .auxSearchContainer {
   display: flex;
   justify-content: space-between;
-
+  @media (max-width: 400px) {
+    flex-direction: column-reverse;
+    bottom-padding: var(--nypl-space-s);
+    align-items: flex-end;
+  }
   a {
     margin-top: var(--nypl-space-xs);
     margin-bottom: var(--nypl-space-s);

--- a/styles/components/SubNav.module.scss
+++ b/styles/components/SubNav.module.scss
@@ -18,6 +18,10 @@
         }
       }
     }
+    @media screen and (max-width: 400px) {
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   a {


### PR DESCRIPTION
This combines work called out in 3 VQA tickets (SCC-3830, 3831, and 3832), including:

-  Page title change to “Research Catalog | NYPL”.  
-  Add Article Search link
- SubNav wrapping keeping link text together
   - Note this one i did not follow the spec 100%, but instead implemented a simpler fix... TBD if it is acceptable.
- Placeholder text in the text input field italicized.
- An ‘X’ clear button should appear in the text input field once the patron starts typing - I believe this functionality exists in the DS search bar, but let me know if that isn’t the case. 
  - this and previous was fixed with my search form update to include the DS search bar
- 16px margin for Advanced Search button
  