### PR TITLE
SCC-3770 - Search Results Pagination

### DIFF
--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -37,10 +37,10 @@ export default function Search({ results }) {
   // TODO: Move this to global context
   const searchParams = mapQueryToSearchParams(query)
   const [resultsStart, resultsEnd] = getPaginationOffsetStrings(
-    searchParams.page || 1,
-    RESULTS_PER_PAGE,
+    searchParams.page,
     totalResults
   )
+  console.log(searchParams)
 
   // Map Search Results Elements from response to SearchResultBib objects
   const searchResultBibs = mapElementsToSearchResultsBibs(searchResultsElements)

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -40,7 +40,6 @@ export default function Search({ results }) {
     searchParams.page,
     totalResults
   )
-  console.log(searchParams)
 
   // Map Search Results Elements from response to SearchResultBib objects
   const searchResultBibs = mapElementsToSearchResultsBibs(searchResultsElements)
@@ -88,6 +87,7 @@ export default function Search({ results }) {
             </SimpleGrid>
             <Pagination
               mt="xl"
+              initialPage={searchParams.page}
               currentPage={searchParams.page}
               pageCount={Math.ceil(totalResults / RESULTS_PER_PAGE)}
               onPageChange={handlePageChange}

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -16,6 +16,7 @@ import {
   mapQueryToSearchParams,
   mapElementsToSearchResultsBibs,
   getQueryString,
+  getPaginationOffsetStrings,
 } from "../../src/utils/searchUtils"
 import { mapWorksToDRBResults } from "../../src/utils/drbUtils"
 import { SITE_NAME, RESULTS_PER_PAGE } from "../../src/config/constants"
@@ -35,6 +36,11 @@ export default function Search({ results }) {
 
   // TODO: Move this to global context
   const searchParams = mapQueryToSearchParams(query)
+  const [resultsStart, resultsEnd] = getPaginationOffsetStrings(
+    searchParams.page || 1,
+    RESULTS_PER_PAGE,
+    totalResults
+  )
 
   // Map Search Results Elements from response to SearchResultBib objects
   const searchResultBibs = mapElementsToSearchResultsBibs(searchResultsElements)
@@ -69,7 +75,7 @@ export default function Search({ results }) {
             <Heading level="two" mb="xl" size="heading4">
               {`Displaying ${
                 totalResults > RESULTS_PER_PAGE
-                  ? "1-50"
+                  ? `${resultsStart}-${resultsEnd}`
                   : totalResults.toLocaleString()
               } of ${totalResults.toLocaleString()} results for keyword "${
                 searchParams.q
@@ -83,7 +89,7 @@ export default function Search({ results }) {
             <Pagination
               mt="xl"
               currentPage={searchParams.page}
-              pageCount={Math.floor(totalResults / RESULTS_PER_PAGE)}
+              pageCount={Math.ceil(totalResults / RESULTS_PER_PAGE)}
               onPageChange={handlePageChange}
             />
           </>

--- a/src/types/searchTypes.ts
+++ b/src/types/searchTypes.ts
@@ -89,8 +89,8 @@ export interface SearchQueryParams extends Identifiers {
   sort_direction?: string
   sort_scope?: string
   search_scope?: string
-  page?: number
-  per_page?: number
+  page?: string
+  per_page?: string
 }
 
 export interface SearchFormEvent {

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -204,7 +204,7 @@ export function mapQueryToSearchParams({
   return {
     q,
     field: search_scope,
-    page,
+    page: parseInt(page),
     contributor,
     title,
     subject,

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -140,7 +140,7 @@ export function mapRequestBodyToSearchParams(
 ): SearchParams {
   const {
     q,
-    page,
+    page = 1,
     contributor,
     title,
     subject,

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -204,7 +204,7 @@ export function mapQueryToSearchParams({
   return {
     q,
     field: search_scope,
-    page: parseInt(page),
+    page: page ? parseInt(page) : 1,
     contributor,
     title,
     subject,

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -8,6 +8,20 @@ import type {
   SearchResultsElement,
 } from "../types/searchTypes"
 import SearchResultsBib from "../models/SearchResultsBib"
+import { RESULTS_PER_PAGE } from "../config/constants"
+
+export function getPaginationOffsetStrings(
+  page: number,
+  limit: number,
+  total: number
+) {
+  const offset = RESULTS_PER_PAGE * page - RESULTS_PER_PAGE
+  const start = offset + 1
+  let end = offset + limit
+  end = end <= total ? end : total
+
+  return [start.toLocaleString(), end.toLocaleString()]
+}
 
 /**
  * getSortQuery

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -18,7 +18,7 @@ export function getPaginationOffsetStrings(
   page: number,
   limit: number,
   total: number
-) {
+): [string, string] {
   const offset = RESULTS_PER_PAGE * page - RESULTS_PER_PAGE
   const start = offset + 1
   let end = offset + limit

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -10,6 +10,10 @@ import type {
 import SearchResultsBib from "../models/SearchResultsBib"
 import { RESULTS_PER_PAGE } from "../config/constants"
 
+/**
+ * getPaginationOffsetStrings
+ * Used to generate search results start and end counts on Search Results page
+ */
 export function getPaginationOffsetStrings(
   page: number,
   limit: number,

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -15,13 +15,12 @@ import { RESULTS_PER_PAGE } from "../config/constants"
  * Used to generate search results start and end counts on Search Results page
  */
 export function getPaginationOffsetStrings(
-  page: number,
-  limit: number,
+  page = 1,
   total: number
 ): [string, string] {
   const offset = RESULTS_PER_PAGE * page - RESULTS_PER_PAGE
   const start = offset + 1
-  let end = offset + limit
+  let end = offset + RESULTS_PER_PAGE
   end = end >= total ? total : end
 
   return [start.toLocaleString(), end.toLocaleString()]

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -22,7 +22,7 @@ export function getPaginationOffsetStrings(
   const offset = RESULTS_PER_PAGE * page - RESULTS_PER_PAGE
   const start = offset + 1
   let end = offset + limit
-  end = end <= total ? end : total
+  end = end >= total ? total : end
 
   return [start.toLocaleString(), end.toLocaleString()]
 }


### PR DESCRIPTION
This PR adds the following:

1. Pagination component from the DS, including a click handler that updates the router with the appropriate page in the query string.
2. A utility function that programmatically generates page offset value strings based on the current page and the page limit (e.g. Showing results 501-550)
3. Parsing of the page number in the query string into a number. This was necessary this since the QS library parses numbers in the query string as strings, and overriding this functionality globally is too cumbersome for our use case.