### PR TITLE
Fixing nextjs/DS Link unit test failures

### DIFF
--- a/src/components/BibPage/BibDetail.test.tsx
+++ b/src/components/BibPage/BibDetail.test.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event"
+// import userEvent from "@testing-library/user-event"
 import {
   bibWithSupplementaryContent,
   noParallels,
@@ -40,11 +40,15 @@ describe("BibDetail component", () => {
         wrapper: MemoryRouterProvider,
       })
       const creatorLiteralLink = screen.getByText("Cortanze, Gérard de.")
-      await userEvent.click(creatorLiteralLink)
-
-      expect(mockRouter.asPath).toBe(
-        "/search?filters%5BcreatorLiteral%5D%5B0%5D=Cortanze%2C+G%C3%A9rard+de."
+      expect(creatorLiteralLink).toHaveAttribute(
+        "href",
+        "/search?filters[creatorLiteral][0]=Cortanze,%20G%C3%A9rard%20de."
       )
+      // @TODO: This will work once the Nextjs `Link` component is used again
+      // await userEvent.click(creatorLiteralLink)
+      // expect(mockRouter.asPath).toBe(
+      //   "/search?filters%5BcreatorLiteral%5D%5B0%5D=Cortanze%2C+G%C3%A9rard+de."
+      // )
     })
     it("external link", async () => {
       render(<BibDetails details={suppBib.topDetails} />, {
@@ -81,17 +85,19 @@ describe("BibDetail component", () => {
       const authors20BioSubject = screen.getByText("Biography")
       expect(authorsSubject).toHaveAttribute(
         "href",
-        expect.stringContaining(encodeURI("Authors, French"))
+        `/search?filters[subjectLiteral]=${encodeURI("Authors, French")}`
       )
       expect(authors20Subject).toHaveAttribute(
         "href",
-        expect.stringContaining(encodeURI("Authors, French -- 20th century"))
+        `/search?filters[subjectLiteral]=${encodeURI(
+          "Authors, French -- 20th century"
+        )}`
       )
       expect(authors20BioSubject).toHaveAttribute(
         "href",
-        expect.stringContaining(
-          encodeURI("Authors, French -- 20th century -- Biography")
-        )
+        `/search?filters[subjectLiteral]=${encodeURI(
+          "Authors, French -- 20th century -- Biography"
+        )}`
       )
     })
   })

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -41,7 +41,9 @@ export default class BibDetailsModel {
       link: "internal",
       label: fieldMapping.label,
       value: value.map((v: string) => {
-        const internalUrl = `/search?filters[${fieldMapping.field}][0]=${v}`
+        const internalUrl = `/search?filters[${
+          fieldMapping.field
+        }][0]=${encodeURI(v)}`
         return { url: internalUrl, urlLabel: v }
       }),
     }
@@ -140,7 +142,9 @@ export default class BibDetailsModel {
         // splitSubjectHeadings: ["a", "b", "c"]
         const splitSubjectHeadings = subject.split(" -- ")
         return splitSubjectHeadings.map((heading, index) => {
-          const urlWithFilterQuery = `${filterQueryForSubjectHeading}${stackedSubjectHeadings[index]}`
+          const urlWithFilterQuery = `${filterQueryForSubjectHeading}${encodeURI(
+            stackedSubjectHeadings[index]
+          )}`
           const subjectHeadingUrl = {
             url: urlWithFilterQuery,
             urlLabel: heading,

--- a/src/models/modelTests/BibDetails.test.ts
+++ b/src/models/modelTests/BibDetails.test.ts
@@ -20,37 +20,43 @@ describe("Bib model", () => {
         value: [
           [
             {
-              url: filterQueryForSubjectHeading + "Authors, French",
+              url: `${filterQueryForSubjectHeading}${encodeURI(
+                "Authors, French"
+              )}`,
               urlLabel: "Authors, French",
             },
             {
-              url:
-                filterQueryForSubjectHeading +
-                "Authors, French -- 20th century",
+              url: `${filterQueryForSubjectHeading}${encodeURI(
+                "Authors, French -- 20th century"
+              )}`,
               urlLabel: "20th century",
             },
             {
-              url:
-                filterQueryForSubjectHeading +
-                "Authors, French -- 20th century -- Biography",
+              url: `${filterQueryForSubjectHeading}${encodeURI(
+                "Authors, French -- 20th century -- Biography"
+              )}`,
               urlLabel: "Biography",
             },
           ],
           [
             {
-              url: filterQueryForSubjectHeading + "Autobiographical Narrative",
+              url: `${filterQueryForSubjectHeading}${encodeURI(
+                "Autobiographical Narrative"
+              )}`,
               urlLabel: "Autobiographical Narrative",
             },
           ],
           [
             {
-              url: filterQueryForSubjectHeading + "Cortanze, Gérard de",
+              url: `${filterQueryForSubjectHeading}${encodeURI(
+                "Cortanze, Gérard de"
+              )}`,
               urlLabel: "Cortanze, Gérard de",
             },
             {
-              url:
-                filterQueryForSubjectHeading +
-                "Cortanze, Gérard de -- Childhood and youth",
+              url: `${filterQueryForSubjectHeading}${encodeURI(
+                "Cortanze, Gérard de -- Childhood and youth"
+              )}`,
               urlLabel: "Childhood and youth",
             },
           ],
@@ -166,7 +172,7 @@ describe("Bib model", () => {
         value: [
           {
             urlLabel: "Watson, Tom, 1965-",
-            url: "/search?filters[creatorLiteral][0]=Watson, Tom, 1965-",
+            url: "/search?filters[creatorLiteral][0]=Watson,%20Tom,%201965-",
           },
         ],
       })


### PR DESCRIPTION
Unit tests were failing on `main` because of Nextjs vs DS `Link` component usage. The Nextjs `Link` component was removed (but will be added later) and that broke some tests which (somehow) did not fail before.

This also encodes the query param values same as they are in prod.