### PR TITLE
Scc 3972/add redirect to vercel json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
-  "redirects":[
+  "redirects": [
     {
-      "source":"/",
-      "destination":"/research/research-catalog"
+      "source": "/",
+      "destination": "/research/research-catalog"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "redirects":[
+    {
+      "source":"/",
+      "destination":"/research/research-catalog"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a simple redirect to vercel.json that automatically redirects to the base url /research/research-catalog.

It seems to be working in the preview link of this PR, so I'm hoping this is sufficient to get all vercel works to redirect correctly.