### PR TITLE
SCC-3838 - Fix empty search query

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -25,7 +25,6 @@ export async function fetchResults(
   searchParams: SearchParams
 ): Promise<SearchResultsResponse | Error> {
   const { q, field, filters } = searchParams
-
   // If user is making a search for bib number (i.e. field set to "standard_number"),
   // standardize the bib ID and pass it as the search keywords
   const keywordsOrBibId = field === "standard_number" ? standardizeBibId(q) : q

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -25,6 +25,7 @@ export async function fetchResults(
   searchParams: SearchParams
 ): Promise<SearchResultsResponse | Error> {
   const { q, field, filters } = searchParams
+
   // If user is making a search for bib number (i.e. field set to "standard_number"),
   // standardize the bib ID and pass it as the search keywords
   const keywordsOrBibId = field === "standard_number" ? standardizeBibId(q) : q

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -21,6 +21,11 @@ import {
 import { standardizeBibId } from "../../src/utils/bibUtils"
 import { getDRBQueryStringFromSearchParams } from "../../src/utils/drbUtils"
 
+// Config required by Vercel to allow the search fetcher function to run for a maximum of 60 seconds
+export const config = {
+  maxDuration: 60,
+}
+
 export async function fetchResults(
   searchParams: SearchParams
 ): Promise<SearchResultsResponse | Error> {
@@ -50,7 +55,9 @@ export async function fetchResults(
   const queryString = getSearchQuery(modifiedSearchParams)
 
   const aggregationQuery = `/aggregations${queryString}`
-  const resultsQuery = `${queryString}&per_page=${RESULTS_PER_PAGE.toString()}`
+  const resultsQuery = `${
+    !queryString.length && "?"
+  }${queryString}&per_page=${RESULTS_PER_PAGE.toString()}`
   const drbQuery = getDRBQueryStringFromSearchParams(modifiedSearchParams)
 
   // Get the following in parallel:

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -21,11 +21,6 @@ import {
 import { standardizeBibId } from "../../src/utils/bibUtils"
 import { getDRBQueryStringFromSearchParams } from "../../src/utils/drbUtils"
 
-// Config required by Vercel to allow the search fetcher function to run for a maximum of 60 seconds
-export const config = {
-  maxDuration: 60,
-}
-
 export async function fetchResults(
   searchParams: SearchParams
 ): Promise<SearchResultsResponse | Error> {

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -55,7 +55,6 @@ export async function fetchResults(
   }
   const aggregationQuery = `/aggregations${queryString}`
   const resultsQuery = `${queryString}&per_page=${RESULTS_PER_PAGE.toString()}`
-  console.log("resultsQuery", resultsQuery)
   const drbQuery = getDRBQueryStringFromSearchParams(modifiedSearchParams)
 
   // Get the following in parallel:

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -52,12 +52,15 @@ export async function fetchResults(
     q: keywordsOrBibId,
   }
 
-  const queryString = getSearchQuery(modifiedSearchParams)
+  let queryString = getSearchQuery(modifiedSearchParams)
 
+  // Fall back to a single "?" in the case of an empty query
+  if (!queryString.length) {
+    queryString = "?"
+  }
   const aggregationQuery = `/aggregations${queryString}`
-  const resultsQuery = `${
-    !queryString.length && "?"
-  }${queryString}&per_page=${RESULTS_PER_PAGE.toString()}`
+  const resultsQuery = `${queryString}&per_page=${RESULTS_PER_PAGE.toString()}`
+  console.log("resultsQuery", resultsQuery)
   const drbQuery = getDRBQueryStringFromSearchParams(modifiedSearchParams)
 
   // Get the following in parallel:

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -86,7 +86,7 @@ export default function AdvancedSearch() {
     e.preventDefault()
     const queryString = getSearchQuery(searchFormState as SearchParams)
 
-    if (queryString === "?") {
+    if (!queryString.length) {
       setErrorMessage(defaultEmptySearchErrorMessage)
       setAlert(true)
       // Very basic validation for the date range.

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -86,7 +86,7 @@ export default function AdvancedSearch() {
     e.preventDefault()
     const queryString = getSearchQuery(searchFormState as SearchParams)
 
-    if (!queryString.length) {
+    if (queryString === "?") {
       setErrorMessage(defaultEmptySearchErrorMessage)
       setAlert(true)
       // Very basic validation for the date range.

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -112,11 +112,11 @@ export default function Search({ results }) {
           </>
         }
       >
-        {totalResults ? (
+        {isLoading ? (
+          <SkeletonLoader showImage={false} />
+        ) : (
           <>
-            {isLoading ? (
-              <SkeletonLoader showImage={false} />
-            ) : (
+            {totalResults ? (
               <>
                 <Heading level="h2" mb="xl" size="heading4">
                   {getSearchResultsHeading(
@@ -131,22 +131,14 @@ export default function Search({ results }) {
                   })}
                 </SimpleGrid>
               </>
+            ) : (
+              /**
+               * TODO: The logic and copy for different scenarios will need to be added when
+               * filters are implemented
+               */
+              <Heading level="h3">No results. Try a different search.</Heading>
             )}
-            <Pagination
-              id="results-pagination"
-              mt="xl"
-              initialPage={searchParams.page}
-              currentPage={searchParams.page}
-              pageCount={Math.ceil(totalResults / RESULTS_PER_PAGE)}
-              onPageChange={handlePageChange}
-            />
           </>
-        ) : (
-          /**
-           * TODO: The logic and copy for different scenarios will need to be added when
-           * filters are implemented
-           */
-          <Heading level="h3">No results. Try a different search.</Heading>
         )}
       </Layout>
     </>

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -43,7 +43,8 @@ export default function Search({ results }) {
 
   // TODO: Move this to global context
   const searchParams = mapQueryToSearchParams(query)
-
+  console.log(totalResults)
+  console.log(searchResultsElements)
   // Map Search Results Elements from response to SearchResultBib objects
   const searchResultBibs = mapElementsToSearchResultsBibs(searchResultsElements)
   // Map DRB Works from response to DRBResult objects
@@ -165,7 +166,6 @@ export async function getServerSideProps({ resolvedUrl }) {
   // Remove everything before the query string delineator '?', necessary for correctly parsing the 'q' param.
   const queryString = resolvedUrl.slice(resolvedUrl.indexOf("?") + 1)
   const results = await fetchResults(mapQueryToSearchParams(parse(queryString)))
-
   return {
     props: {
       results,

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -112,11 +112,11 @@ export default function Search({ results }) {
           </>
         }
       >
-        {isLoading ? (
-          <SkeletonLoader showImage={false} />
-        ) : (
+        {totalResults ? (
           <>
-            {totalResults ? (
+            {isLoading ? (
+              <SkeletonLoader showImage={false} />
+            ) : (
               <>
                 <Heading level="h2" mb="xl" size="heading4">
                   {getSearchResultsHeading(
@@ -131,14 +131,22 @@ export default function Search({ results }) {
                   })}
                 </SimpleGrid>
               </>
-            ) : (
-              /**
-               * TODO: The logic and copy for different scenarios will need to be added when
-               * filters are implemented
-               */
-              <Heading level="h3">No results. Try a different search.</Heading>
             )}
+            <Pagination
+              id="results-pagination"
+              mt="xl"
+              initialPage={searchParams.page}
+              currentPage={searchParams.page}
+              pageCount={Math.ceil(totalResults / RESULTS_PER_PAGE)}
+              onPageChange={handlePageChange}
+            />
           </>
+        ) : (
+          /**
+           * TODO: The logic and copy for different scenarios will need to be added when
+           * filters are implemented
+           */
+          <Heading level="h3">No results. Try a different search.</Heading>
         )}
       </Layout>
     </>

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -165,7 +165,6 @@ export async function getServerSideProps({ resolvedUrl }) {
   // Remove everything before the query string delineator '?', necessary for correctly parsing the 'q' param.
   const queryString = resolvedUrl.slice(resolvedUrl.indexOf("?") + 1)
   const results = await fetchResults(mapQueryToSearchParams(parse(queryString)))
-
   return {
     props: {
       results,

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -43,8 +43,7 @@ export default function Search({ results }) {
 
   // TODO: Move this to global context
   const searchParams = mapQueryToSearchParams(query)
-  console.log(totalResults)
-  console.log(searchResultsElements)
+
   // Map Search Results Elements from response to SearchResultBib objects
   const searchResultBibs = mapElementsToSearchResultsBibs(searchResultsElements)
   // Map DRB Works from response to DRBResult objects
@@ -166,6 +165,7 @@ export async function getServerSideProps({ resolvedUrl }) {
   // Remove everything before the query string delineator '?', necessary for correctly parsing the 'q' param.
   const queryString = resolvedUrl.slice(resolvedUrl.indexOf("?") + 1)
   const results = await fetchResults(mapQueryToSearchParams(parse(queryString)))
+
   return {
     props: {
       results,

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -149,7 +149,7 @@ export function getSearchQuery({
 
   const completeQuery = `${searchKeywordsQuery}${advancedQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}${identifierQuery}`
 
-  return completeQuery?.length ? `?q=${completeQuery}` : ""
+  return completeQuery?.length ? `?q=${completeQuery}` : "?"
 }
 
 /**
@@ -192,13 +192,15 @@ export function mapRequestBodyToSearchParams(
 export function mapElementsToSearchResultsBibs(
   elements: SearchResultsElement[]
 ): SearchResultsBib[] | null {
-  return elements
-    .filter((result) => {
-      return !(isEmpty(result) || (result.result && isEmpty(result.result)))
-    })
-    .map((result) => {
-      return new SearchResultsBib(result.result)
-    })
+  return (
+    elements
+      ?.filter((result) => {
+        return !(isEmpty(result) || (result.result && isEmpty(result.result)))
+      })
+      .map((result) => {
+        return new SearchResultsBib(result.result)
+      }) || null
+  )
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -221,7 +223,7 @@ export const sortOptions: Record<string, string> = {
  * It also parses the results page number from a string, defaulting to 1 if absent
  */
 export function mapQueryToSearchParams({
-  q,
+  q = "",
   search_scope,
   sort_direction,
   page,

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -149,7 +149,7 @@ export function getSearchQuery({
 
   const completeQuery = `${searchKeywordsQuery}${advancedQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}${identifierQuery}`
 
-  return completeQuery?.length ? `?q=${completeQuery}` : "?"
+  return completeQuery?.length ? `?q=${completeQuery}` : ""
 }
 
 /**

--- a/src/utils/utilsTests/searchUtils.test.ts
+++ b/src/utils/utilsTests/searchUtils.test.ts
@@ -40,6 +40,7 @@ describe("searchUtils", () => {
           isbn: "456",
         },
         page: 1,
+        q: "",
         field: "contributor",
         order: "asc",
         sortBy: "relevance",
@@ -52,6 +53,7 @@ describe("searchUtils", () => {
         })
       ).toEqual({
         page: 2,
+        q: "",
       })
     })
   })

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,9 @@
     }
   ],
   "functions": {
+    "pages/search/index.tsx": {
+      "maxDuration": 60
+    },
     "pages/api/*.js": {
       "maxDuration": 60
     }

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,10 @@
       "source": "/",
       "destination": "/research/research-catalog"
     }
-  ]
+  ],
+  "functions": {
+    "pages/api/*.js": {
+      "maxDuration": 60
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes an issue where an empty search would yield no results.

This was caused by the query string falling back to "" instead of "?" when search params are absent. I also set a default q value of "" when it is undefined so that it displays as the search term instead of "undefined".