### PR TITLE
SCC-3987 - Add base URL to links and update tests

### DIFF
--- a/__test__/pages/404/404.test.tsx
+++ b/__test__/pages/404/404.test.tsx
@@ -17,7 +17,7 @@ describe("404", () => {
     render(<Custom404 />)
 
     const homeLink = screen.getByText("Research Catalog")
-    expect(homeLink).toHaveAttribute("href", "/")
+    expect(homeLink).toHaveAttribute("href", "/research/research-catalog")
     const legacyLink = screen.getByText("Legacy Catalog")
     expect(legacyLink).toHaveAttribute(
       "href",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11331,6 +11331,126 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -4,6 +4,7 @@ import { Heading } from "@nypl/design-system-react-components"
 import { appConfig } from "../../src/config/config"
 import Layout from "../../src/components/Layout/Layout"
 import RCLink from "../../src/components/RCLink/RCLink"
+import { BASE_URL } from "../../src/config/constants"
 
 export default function Custom404() {
   return (
@@ -16,7 +17,7 @@ export default function Custom404() {
         <p>We&apos;re sorry...</p>
         <p>The page you were looking for doesn&apos;t exist.</p>
         <p>
-          Search the <RCLink href="/">Research Catalog</RCLink> or our{" "}
+          Search the <RCLink href={BASE_URL}>Research Catalog</RCLink> or our{" "}
           <RCLink href={appConfig.externalUrls.legacyCatalog}>
             Legacy Catalog
           </RCLink>{" "}

--- a/pages/404/redirect.tsx
+++ b/pages/404/redirect.tsx
@@ -2,6 +2,7 @@ import Head from "next/head"
 import { Heading } from "@nypl/design-system-react-components"
 
 import { appConfig } from "../../src/config/config"
+import { BASE_URL } from "../../src/config/constants"
 import Layout from "../../src/components/Layout/Layout"
 import RCLink from "../../src/components/RCLink/RCLink"
 
@@ -16,7 +17,7 @@ export default function Redirect404() {
         <p>You&apos;ve followed an out-of-date link to our research catalog.</p>
         <p>
           You may be able to find what you&apos;re looking for in the{" "}
-          <RCLink href="/">Research Catalog</RCLink> or the{" "}
+          <RCLink href={BASE_URL}>Research Catalog</RCLink> or the{" "}
           <RCLink href={appConfig.externalUrls.circulatingCatalog}>
             Circulating Catalog
           </RCLink>

--- a/src/components/SearchResult/ElectronicResourcesLink.test.tsx
+++ b/src/components/SearchResult/ElectronicResourcesLink.test.tsx
@@ -67,6 +67,9 @@ describe("Electronic Resources Link with multiple resources", () => {
     const link = screen.getByRole("link", {
       name: "See All Available Online Resources",
     })
-    expect(link).toHaveAttribute("href", "/bib/b22133121#electronic-resources")
+    expect(link).toHaveAttribute(
+      "href",
+      "/research/research-catalog/bib/b22133121#electronic-resources"
+    )
   })
 })

--- a/src/components/SearchResult/ElectronicResourcesLink.tsx
+++ b/src/components/SearchResult/ElectronicResourcesLink.tsx
@@ -5,6 +5,7 @@ import {
 } from "@nypl/design-system-react-components"
 
 import RCLink from "../RCLink/RCLink"
+import { BASE_URL } from "../../config/constants"
 import type { ElectronicResource } from "../../types/bibTypes"
 
 interface ElectronicResourcesLinkProps {
@@ -33,7 +34,10 @@ const ElectronicResourcesLink = ({
           {electronicResources[0].prefLabel || electronicResources[0].url}
         </DSLink>
       ) : (
-        <RCLink href={`${bibUrl}#electronic-resources`} type="standalone">
+        <RCLink
+          href={`${BASE_URL}${bibUrl}#electronic-resources`}
+          type="standalone"
+        >
           See All Available Online Resources
         </RCLink>
       )}

--- a/src/components/SearchResult/SearchResult.test.tsx
+++ b/src/components/SearchResult/SearchResult.test.tsx
@@ -43,7 +43,7 @@ describe("SearchResult with Many Physical Items", () => {
     })
     expect(resultTitleLink).toHaveAttribute(
       "href",
-      "/bib/b14753192#items-table"
+      "/research/research-catalog/bib/b14753192#items-table"
     )
   })
 })

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -73,7 +73,10 @@ const SearchResult = ({ bib }: SearchResultProps) => {
             ))}
             {bib.showViewAllItemsLink && (
               <CardActions>
-                <RCLink href={`${bib.url}#items-table`} type="standalone">
+                <RCLink
+                  href={`${BASE_URL}${bib.url}#items-table`}
+                  type="standalone"
+                >
                   {`View All ${bib.itemMessage} `}
                 </RCLink>
               </CardActions>

--- a/src/components/SubNav/SubNav.tsx
+++ b/src/components/SubNav/SubNav.tsx
@@ -31,7 +31,7 @@ const SubNav = ({ activePage }: SubNavProps) => {
         </li>
         <li>
           <RCLink
-            href="/subject_headings"
+            href={`${BASE_URL}/subject_headings`}
             active={activePage === "shep"}
             aria-current={activePage === "shep" ? "page" : undefined}
             hasWhiteFocusRing
@@ -41,7 +41,7 @@ const SubNav = ({ activePage }: SubNavProps) => {
         </li>
         <li>
           <RCLink
-            href="/account"
+            href={`${BASE_URL}/account`}
             active={activePage === "account"}
             aria-current={activePage === "account" ? "page" : undefined}
             hasWhiteFocusRing


### PR DESCRIPTION
Several links on the refactored app were broken after the change to the DS Link component that renders a basic link rather than a next link, which automatically prepended the base url.

This PR simply adds the base URL to the links that were missing it and fixes the failing tests.