### PR TITLE
SCC-3614 - Show error to user when there is an error on in the feedback api response

### DIFF
--- a/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.tsx
@@ -44,7 +44,8 @@ const FeedbackForm = () => {
       })
       const responseJson = await response.json()
       if (responseJson.error) {
-        console.error(responseJson.error)
+        console.error("Error in feedback api response", responseJson.error)
+        setFeedbackFormScreen("error")
         return
       }
       setFeedbackFormScreen("confirmation")

--- a/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.tsx
@@ -46,9 +46,9 @@ const FeedbackForm = () => {
       if (responseJson.error) {
         console.error("Error in feedback api response", responseJson.error)
         setFeedbackFormScreen("error")
-        return
+      } else {
+        setFeedbackFormScreen("confirmation")
       }
-      setFeedbackFormScreen("confirmation")
     } catch (error) {
       console.error("Error posting feedback", error)
       setFeedbackFormScreen("error")


### PR DESCRIPTION
Small fix that shows the user an error when there's an issue in the feedback API endpoint response, most likely an error returned from the SES service.