### PR TITLE
SCC-4028 - Pass req.cookies into initializePatronTokenAuth

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed logout button not appearing on Advanced Search page (SCC-4028)
 
-
 ## [1.0.0] 2024-03-04
 
 ## Release Notes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] 2024-03-06
+
+### Fixes
+
+- Fixed logout button not appearing on Advanced Search page (SCC-4028)
+
+
 ## [1.0.0] 2024-03-04
 
 ## Release Notes

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -304,7 +304,7 @@ export default function AdvancedSearch({ isAuthenticated }) {
 }
 
 export async function getServerSideProps({ req }) {
-  const patronTokenResponse = await initializePatronTokenAuth(req)
+  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
   const isAuthenticated = patronTokenResponse.isTokenValid
   return {
     props: { isAuthenticated },


### PR DESCRIPTION
Small bug fix, passing req instead of req.cookies to initializePatronTokenAuth was preventing the authentication status from being set correctly on advanced search.