### PR TITLE
update husky script and install tsc-files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run prettier
-npm run lint
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@nypl/design-system-react-components": "2.1.6",
         "@nypl/nypl-data-api-client": "1.0.5",
         "@nypl/sierra-wrapper": "1.1.0",
-        "@types/node": "20.3.1",
         "@types/react": "18.2.13",
         "@types/react-dom": "18.2.6",
         "aws-sdk": "2.99.0",
@@ -34,6 +33,7 @@
         "@testing-library/user-event": "^14.5.1",
         "@types/jest": "^29.5.5",
         "@types/jest-axe": "^3.5.6",
+        "@types/node": "^20.11.25",
         "@types/qs": "^6.9.8",
         "@types/underscore": "^1.11.6",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -54,6 +54,7 @@
         "prettier": "^2.8.8",
         "react-element-to-jsx-string": "^15.0.0",
         "sass": "^1.63.6",
+        "tsc-files": "^1.1.4",
         "typescript": "5.0.4",
         "user-event": "^4.0.0"
       }
@@ -3151,9 +3152,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -10936,6 +10940,18 @@
         }
       }
     },
+    "node_modules/tsc-files": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/tsc-files/-/tsc-files-1.1.4.tgz",
+      "integrity": "sha512-RePsRsOLru3BPpnf237y1Xe1oCGta8rmSYzM76kYo5tLGsv5R2r3s64yapYorGTPuuLyfS9NVbh9ydzmvNie2w==",
+      "dev": true,
+      "bin": {
+        "tsc-files": "cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=3"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -11127,6 +11143,11 @@
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "build": "next build",
     "start": "next start",
     "local-prod": "next build && next start -p 8080",
-    "check-types": "tsc --noemit",
     "lint": "eslint . --fix && npm run check-types",
     "prettier": "prettier --write .",
     "prepare": "husky install",
@@ -18,7 +17,6 @@
     "@nypl/design-system-react-components": "2.1.6",
     "@nypl/nypl-data-api-client": "1.0.5",
     "@nypl/sierra-wrapper": "1.1.0",
-    "@types/node": "20.3.1",
     "@types/react": "18.2.13",
     "@types/react-dom": "18.2.6",
     "aws-sdk": "2.99.0",
@@ -41,6 +39,7 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.5",
     "@types/jest-axe": "^3.5.6",
+    "@types/node": "^20.11.25",
     "@types/qs": "^6.9.8",
     "@types/underscore": "^1.11.6",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -61,6 +60,7 @@
     "prettier": "^2.8.8",
     "react-element-to-jsx-string": "^15.0.0",
     "sass": "^1.63.6",
+    "tsc-files": "^1.1.4",
     "typescript": "5.0.4",
     "user-event": "^4.0.0"
   },
@@ -69,6 +69,6 @@
       "eslint . --fix",
       "prettier --write ."
     ],
-    "**/*.ts": "tsc-files --noEmit"
+    "**/*.{ts,tsx}": "tsc-files --noEmit"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["jest", "@testing-library/jest-dom"]
+    "types": ["jest", "@testing-library/jest-dom", "node"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR includes the installation tsc-files and replacing our npm run scripts with lint-staged. This work allows us to lint [run type checks only on staged files](https://github.com/microsoft/TypeScript/issues/27379). This really shortens the time needed to commit something and also will help me avoid a nervous breakdown. 
I've run this on another branch and it successfully commits when code has no type errors, and blocks commits when there are type errors.