### PR TITLE
Only linting on commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run prettier
-npm run lint
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "start": "next start",
     "local-prod": "next build && next start -p 8080",
     "check-types": "tsc --noemit",
-    "lint": "eslint . --fix && npm run check-types",
-    "prettier": "prettier --write .",
     "prepare": "husky install",
     "test": "jest",
     "test-watch": "jest --watch --verbose --silent=false",

--- a/src/components/EDSLink.tsx
+++ b/src/components/EDSLink.tsx
@@ -12,7 +12,8 @@ const EDSLink = () => {
       <Text size="body2" className="eds-link">
         <span style={{ color: "var(--nypl-colors-ui-success-primary)" }}>
           New!
-        </span>{" "}
+        </span>
+        {" spaghetti"}
         Try our{" "}
         <DSLink href="https://research.ebsco.com/c/2styhb" target="_blank">
           <strong>Article Search</strong>


### PR DESCRIPTION
This PR removes the check-types script from the pre-commit hook, but not from package.json. 
Husky will instead run lint-staged, which includes eslint and prettier autoformatting.