### PR TITLE
Scc 4027/adv search display

### DIFF
--- a/__test__/pages/search/searchResults.test.tsx
+++ b/__test__/pages/search/searchResults.test.tsx
@@ -17,10 +17,11 @@ describe("Search Results page", () => {
       mockRouter.push(`/search?q=${query}`)
       render(<SearchResults isAuthenticated={true} results={{ results }} />)
 
-      const displayingText = screen.getByRole("heading", { level: 2 })
-      expect(displayingText).toHaveTextContent(
-        `Displaying 1-50 of ${results.totalResults} results for keyword "${query}"`
+      const displayingText = screen.getByText(
+        `Displaying 1-50 of ${results.totalResults} results for Keyword: "${query}"`
       )
+      expect(displayingText).toBeInTheDocument()
+
       const cards = screen.getAllByRole("heading", { level: 3 })
       expect(cards).toHaveLength(50)
     })

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -35,8 +35,6 @@ import { SearchResultsAggregationsProvider } from "../../src/context/SearchResul
 import useLoading from "../../src/hooks/useLoading"
 import initializePatronTokenAuth from "../../src/server/auth"
 import AppliedFilters from "../../src/components/SearchFilters/AppliedFilters"
-import { collapseMultiValueQueryParams } from "../../src/utils/refineSearchUtils"
-import { Aggregation } from "../../src/types/filterTypes"
 
 interface SearchProps {
   bannerNotification?: string
@@ -152,11 +150,7 @@ export default function Search({
               <>
                 {displayAppliedFilters && <AppliedFilters />}
                 <Heading level="h2" mb="xl" size="heading4">
-                  {getSearchResultsHeading(
-                    searchParams.page,
-                    totalResults,
-                    searchParams.q
-                  )}
+                  {getSearchResultsHeading(searchParams, totalResults)}
                 </Heading>
                 <SimpleGrid columns={1} gap="grid.xl">
                   {searchResultBibs.map((bib: SearchResultsBib) => {

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -11,7 +11,7 @@ import { useState, useCallback } from "react"
 import { useRouter } from "next/router"
 
 import styles from "../../../styles/components/Search.module.scss"
-import FieldsetDate, { type DateFormName }from "../SearchFilters/FieldsetDate"
+import FieldsetDate, { type DateFormName } from "../SearchFilters/FieldsetDate"
 import SearchResultsFilters from "../../models/SearchResultsFilters"
 import RefineSearchCheckBoxField from "./RefineSearchCheckboxField"
 import {
@@ -44,7 +44,6 @@ const RefineSearch = ({
     { value: "dateBefore", label: "End Year" },
     { value: "subjectLiteral", label: "Subject" },
   ]
-
   const dateFieldset = (
     <FieldsetDate
       onDateChange={(dateField: DateFormName, data: string) => {

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -51,17 +51,19 @@ export function getSearchResultsHeading(
 
 function buildQueryDisplayString(searchParams: SearchParams): string {
   const params = Object.keys(searchParams)
-  return params.reduce((displayString, param, i) => {
-    const displayParam = textInputFields.find((field) => field.name === param)
-    // if it's a param we want to display and it is a populated value
-    if (displayParam && searchParams[param]) {
-      const label = displayParam.label
-      const value = searchParams[param]
-      displayString += displayString.length ? "and " : "for "
-      displayString += `${label}: "${value}"`
-    }
-    return displayString
-  }, "")
+  return params
+    .reduce((displayString, param, i) => {
+      const displayParam = textInputFields.find((field) => field.name === param)
+      // if it's a param we want to display and it is a populated value
+      if (displayParam && searchParams[param]) {
+        const label = displayParam.label
+        const value = searchParams[param]
+        displayString += displayString.length ? "and " : "for "
+        displayString += `${label}: "${value}" `
+      }
+      return displayString
+    }, "")
+    .trim()
 }
 
 /**

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -1,5 +1,6 @@
 import { isArray, isEmpty, mapObject, forEach } from "underscore"
 
+import { textInputFields } from "./advancedSearchUtils"
 import type {
   SearchParams,
   SearchQueryParams,
@@ -32,19 +33,35 @@ export function getPaginationOffsetStrings(
  * TODO: Make search query type (i.e. "Keyword") dynamic
  */
 export function getSearchResultsHeading(
-  page: number,
-  totalResults: number,
-  query: string
+  searchParams: SearchParams,
+  totalResults: number
 ): string {
   const [resultsStart, resultsEnd] = getPaginationOffsetStrings(
-    page,
+    searchParams.page,
     totalResults
   )
+  const queryDisplayString = buildQueryDisplayString(searchParams)
+
   return `Displaying ${
     totalResults > RESULTS_PER_PAGE
       ? `${resultsStart}-${resultsEnd}`
       : totalResults.toLocaleString()
-  } of ${totalResults.toLocaleString()} results for keyword "${query}"`
+  } of ${totalResults.toLocaleString()} results ${queryDisplayString}`
+}
+
+function buildQueryDisplayString(searchParams: SearchParams): string {
+  const params = Object.keys(searchParams)
+  return params.reduce((displayString, param, i) => {
+    const displayParam = textInputFields.find((field) => field.name === param)
+    // if it's a param we want to display and it is a populated value
+    if (displayParam && searchParams[param]) {
+      const label = displayParam.label
+      const value = searchParams[param]
+      displayString += displayString.length ? "and " : "for "
+      displayString += `${label}: "${value}"`
+    }
+    return displayString
+  }, "")
 }
 
 /**

--- a/src/utils/utilsTests/searchUtils.test.ts
+++ b/src/utils/utilsTests/searchUtils.test.ts
@@ -1,3 +1,4 @@
+import { textInputFields } from "../advancedSearchUtils"
 import {
   getPaginationOffsetStrings,
   getSearchQuery,
@@ -103,7 +104,22 @@ describe("searchUtils", () => {
       )
       expect(heading.includes('keyword ""')).toBe(false)
     })
-    it.todo("doesn't display filter params")
+    it("displays all of the values from advanced search and nothing else", () => {
+      const heading = getSearchResultsHeading(
+        {
+          page: 1,
+          q: "spaghetti",
+          title: "ricotta",
+          contributor: "pasta mama",
+          subject: "italian",
+          filters: { language: "italian" },
+        },
+        100
+      )
+      expect(heading).toEqual(
+        'Displaying 1-50 of 100 results for Keyword: "spaghetti" and Title: "ricotta" and Author: "pasta mama" and Subject: "italian"'
+      )
+    })
     it("returns the correct heading string for first page", () => {
       const heading = getSearchResultsHeading({ page: 1, q: "cats" }, 1200)
       expect(heading).toEqual(

--- a/src/utils/utilsTests/searchUtils.test.ts
+++ b/src/utils/utilsTests/searchUtils.test.ts
@@ -96,16 +96,24 @@ describe("searchUtils", () => {
     })
   })
   describe("getSearchResultsHeading", () => {
+    it("doesn't display empty keyword if other params are present", () => {
+      const heading = getSearchResultsHeading(
+        { page: 1, q: "", title: "Strega Nonna" },
+        1200
+      )
+      expect(heading.includes('keyword ""')).toBe(false)
+    })
+    it.todo("doesn't display filter params")
     it("returns the correct heading string for first page", () => {
-      const heading = getSearchResultsHeading(1, 1200, "cats")
+      const heading = getSearchResultsHeading({ page: 1, q: "cats" }, 1200)
       expect(heading).toEqual(
-        'Displaying 1-50 of 1,200 results for keyword "cats"'
+        'Displaying 1-50 of 1,200 results for Keyword: "cats"'
       )
     })
     it("returns the correct heading string for other pages", () => {
-      const heading = getSearchResultsHeading(5, 1200, "cats")
+      const heading = getSearchResultsHeading({ page: 5, q: "cats" }, 1200)
       expect(heading).toEqual(
-        'Displaying 201-250 of 1,200 results for keyword "cats"'
+        'Displaying 201-250 of 1,200 results for Keyword: "cats"'
       )
     })
   })

--- a/src/utils/utilsTests/searchUtils.test.ts
+++ b/src/utils/utilsTests/searchUtils.test.ts
@@ -102,7 +102,7 @@ describe("searchUtils", () => {
         { page: 1, q: "", title: "Strega Nonna" },
         1200
       )
-      expect(heading.includes('keyword ""')).toBe(false)
+      expect(heading.toLocaleLowerCase().includes("keyword")).toBe(false)
     })
     it("displays all of the values from advanced search and nothing else", () => {
       const heading = getSearchResultsHeading(


### PR DESCRIPTION
Includes advanced search params to "Displaying 1-50 results..." string so users know what advanced search params have been applied to their search. Advanced search options that are filters are not included in this, but they do show up in the applied filters tagset.