### PR TITLE
rm status:o from available criteria

### DIFF
--- a/src/utils/itemUtils.ts
+++ b/src/utils/itemUtils.ts
@@ -4,7 +4,7 @@ import type {
   ItemLocationEndpoint,
 } from "../types/itemTypes"
 
-export const itemAvailableIds = ["status:a", "status:o"]
+export const itemAvailableIds = ["status:a"]
 
 // Default delivery location for an item.
 export const defaultNYPLLocation: ItemLocation = {


### PR DESCRIPTION
items with status:o/use in library are not requestable in Sierra due to loan rules. They should not be considered available on the front end, either.