### PR TITLE
SCC-4062 - Replace hardcoded vega links with config var

### DIFF
--- a/__test__/fixtures/myAccountFixtures.js
+++ b/__test__/fixtures/myAccountFixtures.js
@@ -2212,7 +2212,7 @@ export const mockCheckouts = [
     isResearch: false,
     bibId: "21678146",
     isNyplOwned: true,
-    catalogHref: "https://nypl.na2.iiivega.com/search/card?recordId=21678146",
+    catalogHref: "https://borrow.nypl.org/search/card?recordId=21678146",
   },
   {
     id: "65060570",
@@ -2224,7 +2224,7 @@ export const mockCheckouts = [
     isResearch: false,
     bibId: "17699134",
     isNyplOwned: true,
-    catalogHref: "https://nypl.na2.iiivega.com/search/card?recordId=17699134",
+    catalogHref: "https://borrow.nypl.org/search/card?recordId=17699134",
   },
 ]
 
@@ -2242,7 +2242,7 @@ export const mockHolds = [
     isResearch: false,
     bibId: "22002760",
     isNyplOwned: true,
-    catalogHref: "https://nypl.na2.iiivega.com/search/card?recordId=22002760",
+    catalogHref: "https://borrow.nypl.org/search/card?recordId=22002760",
   },
   {
     patron: "2772226",
@@ -2257,7 +2257,7 @@ export const mockHolds = [
     isResearch: false,
     bibId: "22002761",
     isNyplOwned: true,
-    catalogHref: "https://nypl.na2.iiivega.com/search/card?recordId=22002760",
+    catalogHref: "https://borrow.nypl.org/search/card?recordId=22002760",
   },
 ]
 export const mockFines = {

--- a/src/components/MyAccount/FeesBanner.tsx
+++ b/src/components/MyAccount/FeesBanner.tsx
@@ -5,6 +5,7 @@ import {
   Text,
 } from "@nypl/design-system-react-components"
 import styles from "../../../styles/components/MyAccount.module.scss"
+import { appConfig } from "../../config/config"
 
 const FeesBanner = () => {
   return (
@@ -20,7 +21,9 @@ const FeesBanner = () => {
             for cardholders with replacement fees totaling $100 or more. <br />{" "}
             Fees can be paid at any New York Public Library branch in cash, U.S.
             Postal money order, personal check, or{" "}
-            <Link href="https://nypl.na2.iiivega.com//?openAccount=fines-and-fees">
+            <Link
+              href={`${appConfig.urls.circulatingCatalog}?openAccount=fines-and-fees`}
+            >
               {" "}
               online through the Library website
             </Link>

--- a/src/components/MyAccount/ItemsTab.tsx
+++ b/src/components/MyAccount/ItemsTab.tsx
@@ -1,5 +1,6 @@
 import { Box, Icon, Link, Table } from "@nypl/design-system-react-components"
 import styles from "../../../styles/components/MyAccount.module.scss"
+import { appConfig } from "../../config/config"
 
 const ItemsTab = ({
   headers,
@@ -20,8 +21,8 @@ const ItemsTab = ({
       <Box className={styles.notificationWithIcon}>
         <Icon size="medium" name="errorOutline" iconRotation="rotate180" />{" "}
         <span>
-          See <Link href="https://nypl.na2.iiivega.com/">this page</Link> for
-          eBooks and eAudiobooks {userAction} by you
+          See <Link href={appConfig.urls.circulatingCatalog}>this page</Link>{" "}
+          for eBooks and eAudiobooks {userAction} by you
         </span>
       </Box>
       {data?.length > 0 && (

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -65,7 +65,7 @@ export const appConfig: AppConfig = {
   urls: {
     drbAbout:
       "https://digital-research-books-beta.nypl.org/about?source=catalog",
-    circulatingCatalog: "https://nypl.na2.iiivega.com",
+    circulatingCatalog: "https://borrow.nypl.org",
     legacyCatalog: "https://legacycatalog.nypl.org/",
     login: "https://login.nypl.org/auth/login",
     locations: "https://www.nypl.org/locations/",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -65,7 +65,7 @@ export const appConfig: AppConfig = {
   urls: {
     drbAbout:
       "https://digital-research-books-beta.nypl.org/about?source=catalog",
-    circulatingCatalog: "https://nypl.na2.iiivega.com/",
+    circulatingCatalog: "https://nypl.na2.iiivega.com",
     legacyCatalog: "https://legacycatalog.nypl.org/",
     login: "https://login.nypl.org/auth/login",
     locations: "https://www.nypl.org/locations/",

--- a/src/models/MyAccount.ts
+++ b/src/models/MyAccount.ts
@@ -14,6 +14,7 @@ import type {
   SierraBibEntry,
   BibDataMapType,
 } from "../types/myAccountTypes"
+import { appConfig } from "../config/config"
 
 let client
 
@@ -155,7 +156,7 @@ export default class MyAccount {
         catalogHref: bibForHold.isNyplOwned
           ? bibForHold.isResearch
             ? `https://nypl.org/research/research-catalog/bib/b${bibId}`
-            : `https://nypl.na2.iiivega.com/search/card?recordId=${bibId}`
+            : `${appConfig.urls.circulatingCatalog}/search/card?recordId=${bibId}`
           : null,
       }
     })
@@ -182,7 +183,7 @@ export default class MyAccount {
         catalogHref: bibDataMap[checkout.item.bibIds[0]].isNyplOwned
           ? bibDataMap[checkout.item.bibIds[0]].isResearch
             ? `https://nypl.org/research/research-catalog/bib/b${checkout.item.bibIds[0]}`
-            : `https://nypl.na2.iiivega.com/search/card?recordId=${checkout.item.bibIds[0]}`
+            : `${appConfig.urls.circulatingCatalog}/search/card?recordId=${checkout.item.bibIds[0]}`
           : null,
       }
     })

--- a/src/models/modelTests/MyAccount.test.ts
+++ b/src/models/modelTests/MyAccount.test.ts
@@ -101,8 +101,7 @@ describe("MyAccountModel", () => {
           isResearch: false,
           bibId: "22002760",
           isNyplOwned: true,
-          catalogHref:
-            "https://nypl.na2.iiivega.com/search/card?recordId=22002760",
+          catalogHref: "https://borrow.nypl.org/search/card?recordId=22002760",
         },
         {
           patron: "2772226",
@@ -116,8 +115,7 @@ describe("MyAccountModel", () => {
           isResearch: false,
           bibId: "21317166",
           isNyplOwned: true,
-          catalogHref:
-            "https://nypl.na2.iiivega.com/search/card?recordId=21317166",
+          catalogHref: "https://borrow.nypl.org/search/card?recordId=21317166",
         },
       ])
       expect(account.checkouts).toStrictEqual([
@@ -131,8 +129,7 @@ describe("MyAccountModel", () => {
           isResearch: false,
           bibId: "21678146",
           isNyplOwned: true,
-          catalogHref:
-            "https://nypl.na2.iiivega.com/search/card?recordId=21678146",
+          catalogHref: "https://borrow.nypl.org/search/card?recordId=21678146",
         },
         {
           id: "65060570",
@@ -144,8 +141,7 @@ describe("MyAccountModel", () => {
           isResearch: false,
           bibId: "17699134",
           isNyplOwned: true,
-          catalogHref:
-            "https://nypl.na2.iiivega.com/search/card?recordId=17699134",
+          catalogHref: "https://borrow.nypl.org/search/card?recordId=17699134",
         },
       ])
       expect(account.fines).toStrictEqual({

--- a/src/server/api/bib.ts
+++ b/src/server/api/bib.ts
@@ -61,7 +61,9 @@ export async function fetchBib(
       if (sierraBibResponse.statusCode === 200) {
         return {
           status: 307,
-          redirectUrl: `${appConfig.urls.circulatingCatalog}/iii/encore/record/C__R${id}`,
+          redirectUrl: `${
+            appConfig.urls.circulatingCatalog
+          }/search/card?recordId=${id.replace(/^b/, "")}`,
         }
       } else {
         console.error("There was a problem fetching the bib from Sierra")

--- a/src/server/api/tests/bib.test.ts
+++ b/src/server/api/tests/bib.test.ts
@@ -102,7 +102,7 @@ describe("fetchBib", () => {
 
     expect(bibResponse.status).toEqual(307)
     expect(bibResponse.redirectUrl).toEqual(
-      "https://nypl.na2.iiivega.com/iii/encore/record/C__Rb17418167"
+      "https://borrow.nypl.org/iii/encore/record/C__Rb17418167"
     )
   })
 

--- a/src/server/api/tests/bib.test.ts
+++ b/src/server/api/tests/bib.test.ts
@@ -102,7 +102,7 @@ describe("fetchBib", () => {
 
     expect(bibResponse.status).toEqual(307)
     expect(bibResponse.redirectUrl).toEqual(
-      "https://borrow.nypl.org/iii/encore/record/C__Rb17418167"
+      "https://borrow.nypl.org/search/card?recordId=17418167"
     )
   })
 

--- a/src/server/api/tests/bib.test.ts
+++ b/src/server/api/tests/bib.test.ts
@@ -102,7 +102,7 @@ describe("fetchBib", () => {
 
     expect(bibResponse.status).toEqual(307)
     expect(bibResponse.redirectUrl).toEqual(
-      "https://nypl.na2.iiivega.com//iii/encore/record/C__Rb17418167"
+      "https://nypl.na2.iiivega.com/iii/encore/record/C__Rb17418167"
     )
   })
 


### PR DESCRIPTION
Ticket:
https://jira.nypl.org/browse/SCC-4062

In anticipation of the changing of the vega url from https://nypl.na2.iiivega.com to borrow.nypl.org, I'm opening a small PR that replaces any hardcoded instance of the old url with the value stored in appConfig to easily switch it over.

All instances of the url in DFE are currently coming from an Env var so it should just be a matter of changing it and redeploying there when it's time to switch.