### PR TITLE
[SEB-3102] fix env var for travis previous image tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-
 language: ruby
 
 services:
@@ -36,9 +35,9 @@ jobs:
         - docker tag "$LOCAL_TAG_NAME" "$ECR_URL:$LOCAL_TAG_NAME"
         # Re-tag last latest image just in case
         - |
-          MANIFEST=$(aws ecr batch-get-image --repository-name research-catalog --image-ids imageTag="$ENV-latest" --output json | jq --raw-output --join-output '.images[0].imageManifest')
-          aws ecr batch-delete-image --repository-name research-catalog --image-ids imageTag="$ENV-previous" || true
-          aws ecr put-image --repository-name research-catalog --image-tag "$ENV-previous" --image-manifest "$MANIFEST" || true
+          MANIFEST=$(aws ecr batch-get-image --repository-name research-catalog --image-ids imageTag="$NEXT_PUBLIC_APP_ENV-latest" --output json | jq --raw-output --join-output '.images[0].imageManifest')
+          aws ecr batch-delete-image --repository-name research-catalog --image-ids imageTag="$NEXT_PUBLIC_APP_ENV-previous" || true
+          aws ecr put-image --repository-name research-catalog --image-tag "$NEXT_PUBLIC_APP_ENV-previous" --image-manifest "$MANIFEST" || true
         - docker push "$ECR_URL:$LOCAL_TAG_NAME"
 
     - stage: deploy qa


### PR DESCRIPTION
travis builds werent correctly tagging the previous QA and prod images -- 
```
aws: error: argument --image-tag: expected one argument
The command "MANIFEST=$(aws ecr batch-get-image --repository-name research-catalog --image-ids imageTag="$ENV-latest" --output json | jq --raw-output --join-output '.images[0].imageManifest')
```

the `$ENV` var was removed in favor of `$NEXT_PUBLIC_APP_ENV`
tested here: https://app.travis-ci.com/github/NYPL/research-catalog/builds/269946130

CC @gkallenberg 
ticket on SEB board - https://jira.nypl.org/browse/SEB-3102