### PR TITLE
Adding base URL to hold request links

### DIFF
--- a/src/components/ItemTable/RequestButtons.test.tsx
+++ b/src/components/ItemTable/RequestButtons.test.tsx
@@ -34,7 +34,7 @@ describe("RequestButtons", () => {
       })
     ).toHaveAttribute(
       "href",
-      "/hold/request/b12810991-i14119377?searchKeywords=TODO"
+      "/research/research-catalog/hold/request/b12810991-i14119377"
     )
   })
   it("renders an an request scan link if item is EDD requestable", async () => {
@@ -46,7 +46,7 @@ describe("RequestButtons", () => {
       })
     ).toHaveAttribute(
       "href",
-      "/hold/request/b12810991-i15550040/edd?searchKeywords=TODO"
+      "/research/research-catalog/hold/request/b12810991-i15550040/edd"
     )
   })
 })

--- a/src/components/ItemTable/RequestButtons.tsx
+++ b/src/components/ItemTable/RequestButtons.tsx
@@ -2,6 +2,7 @@ import { Box } from "@nypl/design-system-react-components"
 import RCLink from "../RCLink/RCLink"
 
 import type Item from "../../models/Item"
+import { BASE_URL } from "../../config/constants"
 
 interface RequestButtonsProps {
   item: Item
@@ -9,7 +10,7 @@ interface RequestButtonsProps {
 
 /**
  * The StatusLinks component appears in the Item Table
- * TODO: Pass search keywords to links
+ * TODO: Pass search keywords to links as ?searchKeywords=${"TODO"}
  */
 const RequestButtons = ({ item }: RequestButtonsProps) => {
   if (item.allLocationsClosed) return null
@@ -28,9 +29,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
         <>
           {item.isPhysicallyRequestable && (
             <RCLink
-              href={`/hold/request/${item.bibId}-${
-                item.id
-              }?searchKeywords=${"TODO"}`}
+              href={`${BASE_URL}/hold/request/${item.bibId}-${item.id}`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
               aria-label={`Request for On-site Use, ${item.bibTitle}`}
               disabled={!item.isAvailable}
@@ -40,9 +39,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
           )}
           {item.isEDDRequestable && (
             <RCLink
-              href={`/hold/request/${item.bibId}-${
-                item.id
-              }/edd?searchKeywords=${"TODO"}`}
+              href={`${BASE_URL}/hold/request/${item.bibId}-${item.id}/edd`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
               aria-label={`Request Scan, ${item.bibTitle}`}
               disabled={!item.isAvailable}

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -27,7 +27,7 @@ interface SearchResultProps {
  * The SearchResult component displays a single search result element.
  */
 const SearchResult = ({ bib }: SearchResultProps) => {
-  const { isLargerThanMobile: isDesktop } = useNYPLBreakpoints()
+  const { isLargerThanLarge: isDesktop } = useNYPLBreakpoints()
 
   // On Search Results, a separate ItemTable is constructed for each item up to
   // the limit set in ITEMS_PER_SEARCH_RESULT.

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -27,9 +27,10 @@ interface SearchResultProps {
  * The SearchResult component displays a single search result element.
  */
 const SearchResult = ({ bib }: SearchResultProps) => {
-  const { isLargerThanLarge: isDesktop } = useNYPLBreakpoints()
+  const { isLargerThanMobile: isDesktop } = useNYPLBreakpoints()
 
-  // On Search Results, a separate ItemTable is constructed for each item up to the limit set in ITEMS_PER_SEARCH_RESULT.
+  // On Search Results, a separate ItemTable is constructed for each item up to
+  // the limit set in ITEMS_PER_SEARCH_RESULT.
   // TODO: Move this preprocessing to SearchResultsBib model
   const searchResultItems: ItemTableData[] =
     bib.hasItems &&

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -29,8 +29,7 @@ interface SearchResultProps {
 const SearchResult = ({ bib }: SearchResultProps) => {
   const { isLargerThanLarge: isDesktop } = useNYPLBreakpoints()
 
-  // On Search Results, a separate ItemTable is constructed for each item up to
-  // the limit set in ITEMS_PER_SEARCH_RESULT.
+  // On Search Results, a separate ItemTable is constructed for each item up to the limit set in ITEMS_PER_SEARCH_RESULT.
   // TODO: Move this preprocessing to SearchResultsBib model
   const searchResultItems: ItemTableData[] =
     bib.hasItems &&


### PR DESCRIPTION
Adds `BASE_URL` to the hold request links.
- The Hold pages don't exist in this app yet, so the route will return a 404.
- In the context of the QA site that has reverse proxy, this update will navigate from Research Catalog search results to Discovery Front-End Hold pages.