### PR TITLE
Noref location filter bugfix

### DIFF
--- a/src/utils/refineSearchUtils.ts
+++ b/src/utils/refineSearchUtils.ts
@@ -60,7 +60,7 @@ export const addLabelPropAndParseFilters = (
     // There are some filters which don't return aggregations and are not used
     // for applied filter fields (yet). This is mainly the unsupported holding
     // location filter (eg filters[holdingLocation][0]=loc:scff2), which is
-    // used by devs to assist QA.
+    // used by devs to assist QA. See line 69 for explanation of date exclusion.
     if (!matchingFieldAggregation && !appliedFilterField.includes("date"))
       continue
     appliedFilterValuesWithLabels[appliedFilterField] = appliedFilterValues[

--- a/src/utils/utilsTests/refineSearchUtils.test.ts
+++ b/src/utils/utilsTests/refineSearchUtils.test.ts
@@ -7,6 +7,48 @@ import { aggregationsResults } from "../../../__test__/fixtures/searchResultsMan
 
 describe("refineSearchUtils", () => {
   describe("addLabelPropAndParseFilters", () => {
+    it("does not return filter value for invalid filter", () => {
+      const aggregations = [
+        {
+          "@type": "nypl:Aggregation",
+          "@id": "res:owner",
+          id: "owner",
+          field: "owner",
+          values: [
+            {
+              value: "orgs:1121",
+              count: 1,
+              label: "Jerome Robbins Dance Division",
+            },
+          ],
+        },
+        {
+          "@type": "nypl:Aggregation",
+          "@id": "res:contributorLiteral",
+          id: "contributorLiteral",
+          field: "contributorLiteral",
+          values: [
+            {
+              value: "Schomburg Children's Collection.",
+              count: 54,
+              label: "Schomburg Children's Collection.",
+            },
+            {
+              value: "Schomburg Children's Collection. ",
+              count: 11,
+              label: "Schomburg Children's Collection. ",
+            },
+          ],
+        },
+      ]
+      const appliedFilterValues = {
+        holdingLocation: ["loc:scff2"],
+      }
+      expect(
+        addLabelPropAndParseFilters(aggregations, appliedFilterValues)
+      ).toStrictEqual({})
+    })
+
     it("takes applied filter values and adds the appropriate label", () => {
       const appliedFilterValues = {
         materialType: ["resourcetypes:txt"],


### PR DESCRIPTION
this endpoint:
`https://qa-www.nypl.org/research/research-catalog/search?q=dance&filters[holdingLocation][0]=loc:scff2`
Though it is technically not supported by the front end, I use it for QA and finding bibs with specific holding locations. It was causing a server error. I added some extra checks to make sure that filters not present in aggregations do not break the site.