### PR TITLE
SCC-4081: Failed cancel/freeze holds error handling

### DIFF
--- a/src/components/MyAccount/RequestsTab/CancelButton.tsx
+++ b/src/components/MyAccount/RequestsTab/CancelButton.tsx
@@ -52,6 +52,32 @@ const CancelButton = ({
     }
   }
 
+  function failureModalProps(hold) {
+    return {
+      bodyContent: (
+        <Box className={styles.modalBody}>
+          <Text sx={{ marginLeft: "l", marginRight: "m" }}>
+            Your request for{" "}
+            <span style={{ fontWeight: "var(--nypl-fontWeights-medium)" }}>
+              {hold.title}
+            </span>{" "}
+            has not been canceled. Please try again.
+          </Text>
+        </Box>
+      ),
+      closeButtonLabel: "OK",
+      headingText: (
+        <Heading className={styles.modalHeading}>
+          <>
+            <Icon size="large" name="errorFilled" color="ui.error.primary" />
+            <Text sx={{ marginBottom: 0 }}>Failed to cancel request </Text>
+          </>
+        </Heading>
+      ),
+      onClose: closeModal(),
+    }
+  }
+
   function checkModalProps(hold) {
     return {
       bodyContent: (
@@ -93,6 +119,8 @@ const CancelButton = ({
           if (response.status == 200) {
             // Open next modal to confirm request has been canceled.
             setModalProps(confirmModalProps(hold))
+          } else {
+            setModalProps(failureModalProps)
           }
         } else {
           closeModal()

--- a/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "../../../utils/testUtils"
+import { render, screen } from "../../../utils/testUtils"
 import {
   mockCheckouts,
   mockFines,
@@ -96,10 +96,46 @@ describe("RequestsTab", () => {
         body: JSON.stringify({ patronId: mockPatron.id }),
       }
     )
+    expect
     await userEvent.click(component.getAllByText("OK")[0])
 
     const rows = component.getAllByRole("row")
     expect(rows.length).toBe(2)
+  })
+
+  it("does not remove hold from list when cancel fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => "Nooo",
+      status: 400,
+    } as Response)
+    const component = render(
+      <ProfileTabs
+        patron={mockPatron}
+        checkouts={mockCheckouts}
+        holds={mockHolds}
+        fines={mockFines}
+        activePath="requests"
+      />
+    )
+
+    await userEvent.click(component.getAllByText("Cancel")[0])
+    await userEvent.click(component.getAllByText("Yes, cancel")[0])
+
+    expect(fetch).toHaveBeenCalledWith(
+      `/research/research-catalog/api/account/holds/cancel/${mockHolds[0].id}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ patronId: mockPatron.id }),
+      }
+    )
+
+    await userEvent.click(screen.getAllByText("OK", { exact: false })[0])
+
+    const rows = component.getAllByRole("row")
+    expect(rows.length).toBe(3)
   })
 
   it("displays freeze buttons only for holds that can be frozen", async () => {
@@ -115,6 +151,10 @@ describe("RequestsTab", () => {
   })
 
   it("freezes and unfreezes, with button reflecting current state", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => "Updated",
+      status: 200,
+    } as Response)
     const component = render(
       <RequestsTab
         patron={mockPatron}
@@ -139,6 +179,7 @@ describe("RequestsTab", () => {
       }
     )
 
+    await userEvent.click(screen.getAllByText("OK", { exact: false })[0])
     expect(component.queryByText("Freeze")).not.toBeInTheDocument()
     const unfreezeButton = component.getAllByText("Unfreeze")[0]
     await userEvent.click(unfreezeButton)
@@ -159,6 +200,28 @@ describe("RequestsTab", () => {
     )
 
     expect(component.queryByText("Unfreeze")).not.toBeInTheDocument()
+    const freezeButtons = component.getAllByText("Freeze")
+    expect(freezeButtons.length).toBe(1)
+  })
+
+  it("shows failure modal when freeze doesn't work", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => "Nooo",
+      status: 400,
+    } as Response)
+    const component = render(
+      <RequestsTab
+        patron={mockPatron}
+        holds={mockHolds}
+        removeHold={mockRemoveHold}
+      />
+    )
+    const freezeButton = component.getAllByText("Freeze")[0]
+    await userEvent.click(freezeButton)
+    expect(
+      component.getByText("Freezing this hold failed", { exact: false })
+    ).toBeInTheDocument()
+    await userEvent.click(screen.getAllByText("OK", { exact: false })[0])
     const freezeButtons = component.getAllByText("Freeze")
     expect(freezeButtons.length).toBe(1)
   })


### PR DESCRIPTION
Resolves [SCC-4081](https://jira.nypl.org/browse/SCC-4081). Adds failure modal to Freeze button and Cancel button on the Requests tab.