### PR TITLE
SCC-4093 update: Making subject searches going to SHEP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,18 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Updated
+
+- Extracted SearchResultsSort into its own component to render it in a different location on mobile.
+- No longer hiding the Item Location in the ItemTable on mobile.
+- Updated to DS v3.1.1 (as part of SCC-4090)
+
 ### Fixed
 
 - Fixed VQA issues for the searchbar, results heading, sort dropdown, and individual search result card in the Search Results page (SCC-4065)
 - Fixed second half of Accessibility QA issues for Search Results (SCC-4064)
 - Fixed second half of the VQA issues, as well as the "Second Pass" requests mostly related to mobile styles (SCC-4066)
 - Fixed color contrast issue on item availability text (SCC-4090)
-
-### Updated
-
-- Extracted SearchResultsSort into its own component to render it in a different location on mobile.
-- No longer hiding the Item Location in the ItemTable on mobile.
-- Updated to DS v3.1.1 (as part of SCC-4090)
+- Fixed "subject" searches going to SHEP.
 
 ## [1.0.3] 2024-04-03
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed second half of the VQA issues, as well as the "Second Pass" requests mostly related to mobile styles (SCC-4066)
 - Fixed color contrast issue on item availability text (SCC-4090)
 - Fixed "subject" searches going to SHEP.
+- Fixed the special case for the author/contributor display string for the "Author" select dropdown value.
 
 ## [1.0.3] 2024-04-03
 

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -37,6 +37,16 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
       q: searchTerm,
       field: searchScope,
     }
+
+    // Keeping the feature where if the search scope from the select
+    // dropdown is "subject", it will redirect to SHEP.
+    if (searchScope === "subject") {
+      window.location.href = `${BASE_URL}/subject_headings?filter=${
+        searchTerm.charAt(0).toUpperCase() + searchTerm.slice(1)
+      }`
+      return
+    }
+
     const queryString = getSearchQuery(searchParams)
 
     await router.push(`${PATHS.SEARCH}${queryString}`)

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -81,9 +81,13 @@ function buildQueryDisplayString(searchParams: SearchParams): string {
   Object.keys(searchParams).forEach((param) => {
     const displayParam = searchFields.find((field) => field.name === param)
     if (displayParam && searchParams[param]) {
-      const label = displayParam.label.toLowerCase()
+      let label = displayParam.label.toLowerCase()
       const value = searchParams[param]
       const plural = label === "keyword" && value.indexOf(" ") > -1 ? "s" : ""
+      // Special case for the author display string.
+      if (label === "author") {
+        label = "author/contributor"
+      }
 
       paramsStringCollection[param] = `${label}${plural} "${value}"`
     }

--- a/src/utils/utilsTests/searchUtils.test.ts
+++ b/src/utils/utilsTests/searchUtils.test.ts
@@ -153,6 +153,12 @@ describe("searchUtils", () => {
         'Displaying 1-50 of 100 results for keyword "spaghetti"'
       )
     })
+    it("handles the special case for the author field", () => {
+      const heading = getSearchResultsHeading({ contributor: "spaghetti" }, 100)
+      expect(heading).toEqual(
+        'Displaying 1-50 of 100 results for author/contributor "spaghetti"'
+      )
+    })
     it("displays all of the values from advanced search and nothing else", () => {
       const heading = getSearchResultsHeading(
         {
@@ -166,7 +172,7 @@ describe("searchUtils", () => {
         100
       )
       expect(heading).toEqual(
-        'Displaying 1-50 of 100 results for keyword "spaghetti" and title "ricotta" and author "pasta mama" and subject "italian"'
+        'Displaying 1-50 of 100 results for keyword "spaghetti" and title "ricotta" and author/contributor "pasta mama" and subject "italian"'
       )
     })
     it("displays the appropriate string for certain values", () => {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4093](https://jira.nypl.org/browse/SCC-4093)

## This PR does the following:

- "subject" searches should go to SHEP.
- Bug that Chris found in an existing ticket so this is subsequent work.

## How has this been tested?

Locally, this will not work because SHEP does not exist. This will work, however, in the reverse proxy state.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
