### PR TITLE
SCC-4112: passing proper argument to auth function and adding id to results list

### DIFF
--- a/pages/bib/[id].tsx
+++ b/pages/bib/[id].tsx
@@ -68,7 +68,7 @@ export async function getServerSideProps({ params, resolvedUrl, req }) {
     id,
     bibParams
   )
-  const patronTokenResponse = await initializePatronTokenAuth(req)
+  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
   const isAuthenticated = patronTokenResponse.isTokenValid
 
   switch (status) {

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -192,7 +192,7 @@ export default function Search({
               }}
             />
             {!isLoading ? (
-              <SimpleGrid columns={1} gap="grid.l">
+              <SimpleGrid columns={1} id="search-results-list" gap="grid.l">
                 {searchResultBibs.map((bib: SearchResultsBib) => {
                   return <SearchResult key={bib.id} bib={bib} />
                 })}
@@ -241,7 +241,7 @@ export async function getServerSideProps({ resolvedUrl, req }) {
   // Remove everything before the query string delineator '?', necessary for correctly parsing the 'q' param.
   const queryString = resolvedUrl.slice(resolvedUrl.indexOf("?") + 1)
   const results = await fetchResults(mapQueryToSearchParams(parse(queryString)))
-  const patronTokenResponse = await initializePatronTokenAuth(req)
+  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
   const isAuthenticated = patronTokenResponse.isTokenValid
   const isFreshSortByQuery = getFreshSortByQuery(
     req.headers.referer,


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4112](https://jira.nypl.org/browse/SCC-4112)

## This PR does the following:

- The Search Results page was missing the logout link in the banner section. The `initializePatronTokenAuth` needed `req.cookies` instead of `req`.
- Also added an id `search-results-list` to the parent of the search results list as a convenience for QA testing.

## How has this been tested?

Locally, when signed in the "Log Out" link appears on the Search Results page.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
