### PR TITLE
Item Availability Bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Added status:o (Use in Library) to availability ID's list
+- Added status:o (Use in Library) to availability IDs list
 
 ## [1.1.0] 2024-05-09
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added status:o (Use in Library) to availability ID's list
+
 ## [1.1.0] 2024-05-09
 
 - This version represents the first public release of the Search Results page, including various fixes for visual and accessibility issues found in VQA.

--- a/__test__/fixtures/itemFixtures.ts
+++ b/__test__/fixtures/itemFixtures.ts
@@ -339,13 +339,13 @@ export const itemAvailableOnsite = {
   },
 }
 
-export const itemNoShelfMark = {
-  "@id": "res:i10572546",
+export const itemUseInLibrary = {
+  "@id": "res:i14119377",
   "@type": ["bf:Item"],
   accessMessage: [
     {
-      "@id": "accessMessage:2",
-      prefLabel: "Request in advance",
+      "@id": "accessMessage:1",
+      prefLabel: "Use in library",
     },
   ],
   catalogItemType: [
@@ -358,82 +358,37 @@ export const itemNoShelfMark = {
   formatLiteral: ["Text"],
   holdingLocation: [
     {
-      "@id": "loc:rc2ma",
-      prefLabel: "Offsite",
+      "@id": "loc:mal92",
+      prefLabel: "Schwarzman Building M2 - General Research Room 315",
+      endpoint: "schwarzman" as ItemLocationEndpoint,
     },
   ],
-  idBarcode: ["33433077546822"],
-  owner: [
+  idBarcode: ["33433048828085"],
+  identifier: [
     {
-      "@id": "orgs:1000",
-      prefLabel: "Stephen A. Schwarzman Building",
+      "@type": "bf:ShelfMark",
+      "@value": "JFE 93-253",
+    },
+    {
+      "@type": "bf:Barcode",
+      "@value": "33433048828085",
     },
   ],
+  m2CustomerCode: ["XF"],
   physRequestable: true,
-  physicalLocation: [
-    "VTI (Prezzolini, G. History of spaghetti eating and cooking for: spaghetti dinner)",
-  ],
-  recapCustomerCode: ["NA"],
+  physicalLocation: ["JFE 93-253"],
   requestable: [true],
+  shelfMark: ["JFE 93-253"],
   specRequestable: false,
   status: [
     {
-      "@id": "status:a",
-      prefLabel: "Available",
+      "@id": "status:o",
+      prefLabel: "Use in Library",
     },
   ],
-  uri: "i10572546",
+  uri: "i14119377",
   idNyplSourceId: {
     "@type": "SierraNypl",
-    "@value": "10572546",
-  },
-}
-
-export const itemNoShelfMarkNoURI = {
-  "@id": "res:i10572546",
-  "@type": ["bf:Item"],
-  accessMessage: [
-    {
-      "@id": "accessMessage:2",
-      prefLabel: "Request in advance",
-    },
-  ],
-  catalogItemType: [
-    {
-      "@id": "catalogItemType:55",
-      prefLabel: "book, limited circ, MaRLI",
-    },
-  ],
-  eddRequestable: true,
-  formatLiteral: ["Text"],
-  holdingLocation: [
-    {
-      "@id": "loc:rc2ma",
-      prefLabel: "Offsite",
-    },
-  ],
-  idBarcode: ["33433077546822"],
-  owner: [
-    {
-      "@id": "orgs:1000",
-      prefLabel: "Stephen A. Schwarzman Building",
-    },
-  ],
-  physRequestable: true,
-  physicalLocation: [
-    "VTI (Prezzolini, G. History of spaghetti eating and cooking for: spaghetti dinner)",
-  ],
-  recapCustomerCode: ["NA"],
-  requestable: [true],
-  specRequestable: false,
-  status: [
-    {
-      "@id": "status:a",
-      prefLabel: "Available",
-    },
-  ],
-  idNyplSourceId: {
-    "@type": "SierraNypl",
-    "@value": "10572546",
+    "@value": "14119377",
   },
 }

--- a/src/models/modelTests/Item.test.ts
+++ b/src/models/modelTests/Item.test.ts
@@ -6,8 +6,7 @@ import {
   itemUnavailable,
   itemPartnerReCAP,
   itemNYPLReCAP,
-  itemNoShelfMark,
-  itemNoShelfMarkNoURI,
+  itemUseInLibrary,
 } from "../../../__test__/fixtures/itemFixtures"
 import { searchResultPhysicalItems } from "../../../__test__/fixtures/searchResultPhysicalItems"
 
@@ -88,6 +87,9 @@ describe("Item model", () => {
   describe("isAvailable", () => {
     it("determines if an item is available based on the status label", () => {
       expect(item.isAvailable).toBe(true)
+
+      const useInLibraryItem = new Item(itemUseInLibrary, parentBib)
+      expect(useInLibraryItem.isAvailable).toBe(true)
 
       const unavailableItem = new Item(itemUnavailable, parentBib)
       expect(unavailableItem.isAvailable).toBe(false)

--- a/src/utils/itemUtils.ts
+++ b/src/utils/itemUtils.ts
@@ -4,7 +4,7 @@ import type {
   ItemLocationEndpoint,
 } from "../types/itemTypes"
 
-export const itemAvailableIds = ["status:a"]
+export const itemAvailableIds = ["status:a", "status:o"]
 
 // Default delivery location for an item.
 export const defaultNYPLLocation: ItemLocation = {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4123](https://jira.nypl.org/browse/SCC-4123)

## This PR does the following:

- Adds "status:o" (Use in Library) to the Availability Ids list used to generated Availability text.
- Removes a couple of unused item fixtures (itemNoShelfMark and itemNoShelfMarkNoURI) but I can add them back if they'll be useful later.
