### PR TITLE
Bug: Closing renew checkout modal

### DIFF
--- a/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
+++ b/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
@@ -21,7 +21,7 @@ const RenewButton = ({
   patron: Patron
 }) => {
   const [isButtonDisabled, setButtonDisabled] = useState(false)
-  const { onOpen, Modal } = useModal()
+  const { onOpen, onClose, Modal } = useModal()
   const [modalProps, setModalProps] = useState(null)
 
   const successModalProps = {
@@ -35,15 +35,20 @@ const RenewButton = ({
     ),
     closeButtonLabel: "OK",
     headingText: (
-      <Box className={styles.modalHeading}>
-        <Icon
-          size="large"
-          name="actionCheckCircleFilled"
-          color="ui.success.primary"
-        />
-        <Text sx={{ marginBottom: 0 }}> Renewal successful </Text>
-      </Box>
+      <Heading className={styles.modalHeading}>
+        <>
+          <Icon
+            size="large"
+            name="actionCheckCircleFilled"
+            color="ui.success.primary"
+          />
+          <Text sx={{ marginBottom: 0 }}> Renewal successful </Text>
+        </>
+      </Heading>
     ),
+    onClose: () => {
+      onClose()
+    },
   }
   const failureModalProps = {
     type: "default",
@@ -67,6 +72,9 @@ const RenewButton = ({
         </>
       </Heading>
     ),
+    onClose: () => {
+      onClose()
+    },
   }
 
   useEffect(() => {
@@ -92,6 +100,7 @@ const RenewButton = ({
         body: JSON.stringify({ patronId: patron.id }),
       }
     )
+    console.log("trying to renew")
     const responseData = await response.json()
     if (responseData.message == "Renewed") {
       setButtonDisabled(true)

--- a/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
+++ b/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
@@ -100,7 +100,6 @@ const RenewButton = ({
         body: JSON.stringify({ patronId: patron.id }),
       }
     )
-    console.log("trying to renew")
     const responseData = await response.json()
     if (responseData.message == "Renewed") {
       setButtonDisabled(true)


### PR DESCRIPTION
## Ticket:

No ticket, this fix will be duplicated in #213

## This PR does the following:

- Adds onClose to renew checkout success/failure modals

## How has this been tested?

Locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
