### PR TITLE
Hotfix: catching Platform API errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Hotfixes 2024-05-17
+
+- Hardcode notification banner content.
+- Temporarily remove log in/out links for My Account.
+- Catching Platform API errors when it's down.
+
 ### Updated
 
 ## [1.1.1] 2024-05-15

--- a/src/server/api/search.ts
+++ b/src/server/api/search.ts
@@ -58,9 +58,9 @@ export async function fetchResults(
 
   const [resultsResponse, aggregationsResponse, drbResultsResponse] =
     await Promise.allSettled([
-      await client.get(`${DISCOVERY_API_SEARCH_ROUTE}${resultsQuery}`),
-      await client.get(`${DISCOVERY_API_SEARCH_ROUTE}${aggregationQuery}`),
-      await drbClient.get(drbQuery),
+      client.get(`${DISCOVERY_API_SEARCH_ROUTE}${resultsQuery}`),
+      client.get(`${DISCOVERY_API_SEARCH_ROUTE}${aggregationQuery}`),
+      drbClient.get(drbQuery),
     ])
 
   // Assign results values for each response when status is fulfilled


### PR DESCRIPTION
Error: search page returned a 500 error
<img width="1231" alt="Screenshot 2024-05-17 at 12 33 48 PM" src="https://github.com/NYPL/research-catalog/assets/1280564/568e189c-df2b-4c33-9730-86c0bf6567f2">

This fix catches the API call error and display a "No results. Try a different Search" message but still renders the page.

--- 

Platform API calls were invoked in the `promise.allSettled` too soon. This handles the issue where Platform API is down and calls to the `NyplApiClient` cannot be made.

Specifically, `nypl-data-api-client` threw an error failing to get a token:

<img width="1048" alt="Screenshot 2024-05-17 at 12 16 26 PM" src="https://github.com/NYPL/research-catalog/assets/1280564/e1f482c2-10b5-431f-b671-5839f320a093">
