### PR TITLE
SCC-4137 - Fix title search bug on main search form

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
-- Replaced all modals with new 'confirmation'/'default' variant (SCC-4110)
-
 ### Updated
+
+### Hotfixes 2024-05-22
+
+- Fix bug caused by advanced search query parameters not clearing when search scope is set to anything other than "all"
+- Replaced all modals with new 'confirmation'/'default' variant (SCC-4110)
 
 ## [1.1.2] 2024-05-20
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+- Replaced all modals with new 'confirmation'/'default' variant (SCC-4110)
+
 ### Updated
 
-### Hotfixes 2024-05-22
+### Fixed
 
 - Fix bug caused by advanced search query parameters not clearing when search scope is set to anything other than "all"
-- Replaced all modals with new 'confirmation'/'default' variant (SCC-4110)
 
 ## [1.1.2] 2024-05-20
 

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -203,6 +203,7 @@ export function getSearchQuery({
 
   const filterQuery = getFilterQuery(filters)
   const fieldQuery = getFieldQuery(field)
+
   const identifierQuery = getIdentifierQuery(identifiers)
   const pageQuery = page !== 1 ? `&page=${page}` : ""
 
@@ -210,7 +211,14 @@ export function getSearchQuery({
   const contributorQuery = contributor ? `&contributor=${contributor}` : ""
   const titleQuery = title ? `&title=${title}` : ""
   const subjectQuery = subject ? `&subject=${subject}` : ""
-  const advancedQuery = `${contributorQuery}${titleQuery}${subjectQuery}`
+
+  // if a search_scope is "all", we want to clear the advanced search query params
+  // and default to the q param
+  const isAdvancedSearchOrAllFields = field.length && field === "all"
+
+  const advancedQuery = isAdvancedSearchOrAllFields
+    ? `${contributorQuery}${titleQuery}${subjectQuery}`
+    : ""
 
   const completeQuery = `${searchKeywordsQuery}${advancedQuery}${filterQuery}${sortQuery}${fieldQuery}${pageQuery}${identifierQuery}`
 

--- a/src/utils/utilsTests/searchUtils.test.ts
+++ b/src/utils/utilsTests/searchUtils.test.ts
@@ -51,6 +51,53 @@ describe("searchUtils", () => {
         })
       ).toBe(true)
     })
+    it("includes advanced search query params when field is set to 'all'", () => {
+      const testQuery =
+        "?q=shel%20silverstein&contributor=shel silverstein&title=the giving tree&subject=books"
+      expect(
+        checkQueryParamsEquality(testQuery, {
+          q: "shel silverstein",
+          title: "the giving tree",
+          contributor: "shel silverstein",
+          subject: "books",
+          field: "all",
+        })
+      ).toBe(true)
+    })
+    it("clears advanced search query params when field param is anything other than 'all'", () => {
+      const titleQuery = "?q=shel%20silverstein&search_scope=title"
+      expect(
+        checkQueryParamsEquality(titleQuery, {
+          q: "shel silverstein",
+          title: "the giving tree",
+          contributor: "shel silverstein",
+          subject: "books",
+          field: "title",
+        })
+      ).toBe(true)
+
+      const subjectQuery = "?q=shel%20silverstein&search_scope=subject"
+      expect(
+        checkQueryParamsEquality(subjectQuery, {
+          q: "shel silverstein",
+          title: "the giving tree",
+          contributor: "shel silverstein",
+          subject: "books",
+          field: "subject",
+        })
+      ).toBe(true)
+
+      const contributorQuery = "?q=shel%20silverstein&search_scope=contributor"
+      expect(
+        checkQueryParamsEquality(contributorQuery, {
+          q: "shel silverstein",
+          title: "the giving tree",
+          contributor: "shel silverstein",
+          subject: "books",
+          field: "contributor",
+        })
+      ).toBe(true)
+    })
   })
   describe("mapQueryToSearchParams", () => {
     it("should consolidate identifiers, change some keys, and initializes the page number to 1", () => {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4137](https://jira.nypl.org/browse/SCC-4137)

## This PR does the following:

- Adds the logic derrived from DFE that removes advanced search query parameters when the search_scope is "all" (main search with "All" selected or Advanced Search.

## How has this been tested?

I've tested it locally and it has been tested by Sean, Nicole and Edwin on Vercel