### PR TITLE
SCC-4130: My Account - checkouts table accessibility zoom fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,8 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add caching of pickup location. Update Patron type to have a SierraCodeName for homeLibrary instead of a string for homeLibraryCode (SCC-4060)
 
 ### Updated
+
 - Extracted getEmailParams from Feedback API route and added test (SCC-4032)
 - Replaced all modals with new 'confirmation'/'default' variant (SCC-4110)
+
+### Fixed
+
+- Fixed mobile tabs width on My Account page so text is readable when a user zooms in.
 
 ## Hotfixes 2024-05-22
 

--- a/src/components/MyAccount/ProfileTabs.tsx
+++ b/src/components/MyAccount/ProfileTabs.tsx
@@ -113,7 +113,11 @@ const ProfileTabs = ({
         updatePath(tabsData[index].urlPath)
       }}
       tabsData={tabsData}
-      sx={{ "div[role=tabpanel]": { padding: 0 }, marginBottom: "xxl" }}
+      sx={{
+        "div[role=tabpanel]": { padding: 0 },
+        marginBottom: "xxl",
+        width: { base: "80%", md: "100%" },
+      }}
     />
   )
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4130](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4130)

## This PR does the following:

- Constraints the width of the `Tabs` component on mobile only. I was looking at updating the `Table` component itself but because it will go through some updates in the next few weeks, and because the issue is more global, I worked on the `Tabs` instead.

Before
<img width="1219" alt="Screenshot 2024-06-07 at 3 15 16 PM" src="https://github.com/NYPL/research-catalog/assets/1280564/246427d7-f851-4086-9517-50868a90debb">

After
<img width="1266" alt="Screenshot 2024-06-07 at 3 25 34 PM" src="https://github.com/NYPL/research-catalog/assets/1280564/8e1c939c-df70-4708-9c4f-092729fb8fda">


## How has this been tested?

Locally. Zoom in at 400x and view the checkouts table. It's not a perfect solution though so it may need a few tweaks.
 
## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Needs another accessibility review.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
