### PR TITLE
SCC-4160: Second pass of accessibility fixes for My Account

### DIFF
--- a/src/components/EDSLink.tsx
+++ b/src/components/EDSLink.tsx
@@ -3,7 +3,7 @@ import ExternalLink from "./Links/ExternalLink/ExternalLink"
 import React from "react"
 
 /**
- * Renders a simple link to log out the user out from the Catalog.
+ * Renders an EDS link.
  */
 const EDSLink = () => {
   return (

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -1,4 +1,8 @@
-import { List, useNYPLBreakpoints } from "@nypl/design-system-react-components"
+import {
+  Box,
+  List,
+  useNYPLBreakpoints,
+} from "@nypl/design-system-react-components"
 import Barcode from "react-barcode"
 
 import styles from "../../../styles/components/MyAccount.module.scss"
@@ -22,13 +26,15 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
         icon: "",
         term: "",
         description: (
-          <Barcode
-            margin={0}
-            value={patron.barcode}
-            format="codabar"
-            displayValue={false}
-            width={isLargerThanMobile ? 2 : 1.5}
-          />
+          <Box role="img" aria-label="barcode">
+            <Barcode
+              margin={0}
+              value={patron.barcode}
+              format="codabar"
+              displayValue={false}
+              width={isLargerThanMobile ? 2 : 1.5}
+            />
+          </Box>
         ),
       },
       {

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -1,4 +1,4 @@
-import { List } from "@nypl/design-system-react-components"
+import { List, useNYPLBreakpoints } from "@nypl/design-system-react-components"
 import Barcode from "react-barcode"
 
 import styles from "../../../styles/components/MyAccount.module.scss"
@@ -8,6 +8,8 @@ import type { IconListElementPropType } from "./IconListElement"
 import { buildListElementsWithIcons } from "./IconListElement"
 
 const ProfileHeader = ({ patron }: { patron: Patron }) => {
+  const { isLargerThanMobile } = useNYPLBreakpoints()
+
   const profileData = (
     [
       { icon: "actionIdentityFilled", term: "Name", description: patron.name },
@@ -25,6 +27,7 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
             value={patron.barcode}
             format="codabar"
             displayValue={false}
+            width={isLargerThanMobile ? 2 : 1.5}
           />
         ),
       },

--- a/src/components/MyAccount/ProfileTabs.tsx
+++ b/src/components/MyAccount/ProfileTabs.tsx
@@ -124,7 +124,6 @@ const ProfileTabs = ({
       sx={{
         "div[role=tabpanel]": { padding: 0 },
         marginBottom: "xxl",
-        width: { base: "80%", md: "100%" },
       }}
     />
   )

--- a/src/components/MyAccount/RequestsTab/RequestsTab.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.tsx
@@ -54,7 +54,7 @@ const RequestsTab = ({
           updateHoldLocation={updateHoldLocation}
           pickupLocationOptions={pickupLocations}
           patronId={patron.id}
-          holdId={hold.id}
+          hold={hold}
           pickupLocation={hold.pickupLocation}
           key={i}
         />

--- a/src/components/MyAccount/RequestsTab/UpdateLocation.test.tsx
+++ b/src/components/MyAccount/RequestsTab/UpdateLocation.test.tsx
@@ -1,7 +1,10 @@
 import UpdateLocation from "./UpdateLocation"
 import { render, screen } from "../../../utils/testUtils"
 import userEvent from "@testing-library/user-event"
-import { filteredPickupLocations as pickupLocations } from "../../../../__test__/fixtures/processedMyAccountData"
+import {
+  filteredPickupLocations as pickupLocations,
+  processedHolds,
+} from "../../../../__test__/fixtures/processedMyAccountData"
 import { BASE_URL } from "../../../config/constants"
 
 global.fetch = jest
@@ -33,7 +36,7 @@ describe("UpdateLocation modal trigger", () => {
           updateHoldLocation={mockUpdateHoldLocation}
           pickupLocationOptions={pickupLocations}
           data-testId="click me"
-          holdId="987654"
+          hold={processedHolds[0]}
           patronId={1234567}
           pickupLocation={{ name: "SNFL", code: "sn" }}
           key={1}
@@ -57,7 +60,7 @@ describe("UpdateLocation modal trigger", () => {
       const submitButton = screen.getByText("Confirm location")
       await userEvent.click(submitButton)
       expect(fetchSpy).toHaveBeenCalledWith(
-        `${BASE_URL}/api/account/holds/update/987654`,
+        `${BASE_URL}/api/account/holds/update/49438189`,
         {
           method: "PUT",
           body: JSON.stringify({

--- a/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
+++ b/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
@@ -12,13 +12,13 @@ import {
   type BaseModalProps,
   SkeletonLoader,
 } from "@nypl/design-system-react-components"
-import type { SierraCodeName } from "../../../types/myAccountTypes"
+import type { Hold, SierraCodeName } from "../../../types/myAccountTypes"
 import styles from "../../../../styles/components/MyAccount.module.scss"
 import { useState } from "react"
 import { BASE_URL } from "../../../config/constants"
 
 interface UpdateLocationPropsType {
-  holdId: string
+  hold: Hold
   pickupLocation: SierraCodeName
   pickupLocationOptions: SierraCodeName[]
   key: number
@@ -30,7 +30,7 @@ const UpdateLocation = ({
   updateHoldLocation,
   pickupLocationOptions,
   patronId,
-  holdId,
+  hold,
   pickupLocation,
   key,
 }: UpdateLocationPropsType) => {
@@ -86,7 +86,7 @@ const UpdateLocation = ({
         bodyContent: <SkeletonLoader showImage={false} />,
       } as ConfirmationModalProps)
       const response = await fetch(
-        `${BASE_URL}/api/account/holds/update/${holdId}`,
+        `${BASE_URL}/api/account/holds/update/${hold.id}`,
         {
           method: "PUT",
           body: JSON.stringify({
@@ -135,7 +135,7 @@ const UpdateLocation = ({
       </h5>
     ),
     onClose: () => {
-      updateHoldLocation(holdId, newLocation)
+      updateHoldLocation(hold.id, newLocation)
       setModalProps(
         confirmLocationChangeModalProps(newLocation) as ConfirmationModalProps
       )
@@ -173,9 +173,12 @@ const UpdateLocation = ({
       </h5>
     ),
   }
+  const buttonLabel = "Change location"
+
   return (
     <>
       <Button
+        aria-label={`${buttonLabel} for ${hold.title}`}
         size="small"
         pl={0}
         onClick={openModal}
@@ -184,7 +187,7 @@ const UpdateLocation = ({
       >
         <Icon name="editorMode" align="left" size="medium"></Icon>
         <Text fontSize={0} className={styles.changeLocation}>
-          Change location
+          {buttonLabel}
         </Text>
       </Button>
       <Modal {...modalProps} />

--- a/src/components/SubNav/SubNav.tsx
+++ b/src/components/SubNav/SubNav.tsx
@@ -51,7 +51,7 @@ const SubNav = ({ activePage, isAuthenticated }: SubNavProps) => {
         </li>
         {isAuthenticated && (
           <li>
-            <RCLink href={logoutLink} includeBaseUrl={false}>
+            <RCLink href={logoutLink} includeBaseUrl={false} hasWhiteFocusRing>
               Log Out
             </RCLink>
           </li>


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4160](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4160)

## This PR does the following:

- Adds the white focus outline on the "Log out" link.
- Makes the barcode's width smaller on mobile so that the parent element and layout is more responsive. This causes a minor flicker for the barcode when it renders but let me know if it's jarring @charmingduchess .
- Adds `aria-label` to the "Change location" button. This meant passing the entire `hold` rather than `holdId` to the `UpdateLocation` component.
- Still need to work on one issue that is waiting for Clare's clarification.

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Fixes a few issues found by Clare during her review.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
