### PR TITLE
fix date off by one

### DIFF
--- a/src/utils/myAccountUtils.ts
+++ b/src/utils/myAccountUtils.ts
@@ -42,10 +42,10 @@ export function formatDate(date: string | number | Date) {
   // pickup location returns an iso string, but expiration date is YYYY-MM-DD.
   // we need to specify timezone to avoid off by one error.
   // perhaps this method needs to be two methods for the specific cases.
-  if (typeof date === "string" && !date.includes("Z")) date += " GMT-0400"
   const d = new Date(date)
+  console.log(d)
   const year = d.getFullYear()
-  const day = d.getDate()
+  const day = d.getUTCDate()
   const month = d.toLocaleString("default", { month: "long" })
   return `${month} ${day}, ${year}`
 }


### PR DESCRIPTION
## Ticket:
NA

## This PR does the following:

unlike what the name of the branch says, this pr fixes the date off by one error in the patron's expiration date and due date for checkouts.

## How has this been tested?

Locally

## Accessibility concerns or updates

NA


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
