### PR TITLE
SCC-4175 - Fix patron name parsing issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add caching of pickup location. Update Patron type to have a SierraCodeName for homeLibrary instead of a string for homeLibraryCode (SCC-4060)
 
 ### Updated
+
 - Refactored bibUtils and removed BibParams type (SCC-4136)
 - Created npm run test-watch-quiet to run tests for changed files without printing the HTML from RTL errors.
 - Update Account Settings notification preference selector to be a controlled component in order to validate based on the selected preference. This includes changing the Patron type that is returned from the My Account model
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue caused by formatPatronName when a non-comma separated value is passed in (SCC-4175)
 - Fixed mobile tabs width on My Account page so text is readable when a user zooms in.
 
 ## Hotfixes 2024-05-22

--- a/src/components/MyAccount/Settings/AccountSettingsUtils.test.ts
+++ b/src/components/MyAccount/Settings/AccountSettingsUtils.test.ts
@@ -16,7 +16,7 @@ describe("Account settings utils", () => {
     })
   })
   describe("formatPatronName", () => {
-    it("correctly formats the patron name when in call caps and comma separated", () => {
+    it("correctly formats the patron name when in all caps and comma-separated", () => {
       expect(formatPatronName("LAST,FIRST")).toEqual("First Last")
     })
     it("falls back to the input name when not comma-separated", () => {

--- a/src/components/MyAccount/Settings/AccountSettingsUtils.test.ts
+++ b/src/components/MyAccount/Settings/AccountSettingsUtils.test.ts
@@ -5,7 +5,7 @@ import {
   formatPhoneNumber,
 } from "./AccountSettingsUtils"
 import { processedPatron } from "../../../../__test__/fixtures/processedMyAccountData"
-import { formatDate } from "../../../utils/myAccountUtils"
+import { formatDate, formatPatronName } from "../../../utils/myAccountUtils"
 import type { FixedField, Patron } from "../../../types/myAccountTypes"
 
 describe("Account settings utils", () => {
@@ -13,6 +13,14 @@ describe("Account settings utils", () => {
     it("can parse a date", () => {
       const date = "2025-03-28"
       expect(formatDate(date)).toEqual("March 28, 2025")
+    })
+  })
+  describe("formatPatronName", () => {
+    it("correctly formats the patron name when in call caps and comma separated", () => {
+      expect(formatPatronName("LAST,FIRST")).toEqual("First Last")
+    })
+    it("falls back to the input name when not comma-separated", () => {
+      expect(formatPatronName("QA Tester ILS")).toEqual("QA Tester ILS")
     })
   })
   describe("formatPhoneNumber", () => {

--- a/src/utils/myAccountUtils.ts
+++ b/src/utils/myAccountUtils.ts
@@ -15,16 +15,18 @@ export const notificationPreferenceTuples = Object.keys(
 /**
  * Formats the patron's name per NYPL guidelines.
  */
-function formatPatronName(name = "") {
+export function formatPatronName(name = "") {
   if (!name) return ""
-
-  const [lastName = "", firstName = ""] = name.split(",")
+  if (!name.includes(",")) return name
+  const [lastName, firstName] = name.split(",")
   // The name from Sierra is in all caps, so we need to lowercase
   // all but the first letter.
   function capitalize(name: string) {
     return `${name.charAt(0)}${name.slice(1).toLowerCase()}`
   }
-  return `${capitalize(firstName.trim())} ${capitalize(lastName.trim())}`
+  return `${firstName && capitalize(firstName.trim())} ${capitalize(
+    lastName.trim()
+  )}`
 }
 
 /**

--- a/src/utils/myAccountUtils.ts
+++ b/src/utils/myAccountUtils.ts
@@ -18,7 +18,7 @@ export const notificationPreferenceTuples = Object.keys(
 function formatPatronName(name = "") {
   if (!name) return ""
 
-  const [lastName, firstName] = name.split(",")
+  const [lastName = "", firstName = ""] = name.split(",")
   // The name from Sierra is in all caps, so we need to lowercase
   // all but the first letter.
   function capitalize(name: string) {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4175](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4175)

## This PR does the following:

- Fixes a bug parsing the patron name when a non-comma separated value is passed, as was seen on Chris' test account.

## How has this been tested?

- Added unit tests for formatPatronName

## Concerns

- We should look into why the account name wasn't received in the Sierra format and whether this will impact non-test accounts.

[SCC-4175]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ