### PR TITLE
SCC-4150 - Convert bib detail ids to kebab case

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
+- Pass bibDetail test ids as kebabCase (SCC-4150)
 - Refactored bibUtils and removed BibParams type (SCC-4136)
 - Created npm run test-watch-quiet to run tests for changed files without printing the HTML from RTL errors.
 - Update Account Settings notification preference selector to be a controlled component in order to validate based on the selected preference. This includes changing the Patron type that is returned from the My Account model

--- a/__test__/pages/bib/bibPage.test.tsx
+++ b/__test__/pages/bib/bibPage.test.tsx
@@ -31,10 +31,10 @@ describe("Bib Page with items", () => {
   })
 
   it("renders the top bib details", () => {
-    expect(screen.getAllByTestId("Title")[0]).toHaveTextContent(
+    expect(screen.getAllByTestId("title")[0]).toHaveTextContent(
       "Urban spaghetti."
     )
-    expect(screen.getByTestId("Published By")).toHaveTextContent(
+    expect(screen.getByTestId("published-by")).toHaveTextContent(
       "Mansfield, Ohio : Urban Spaghetti, [1999?-"
     )
   })
@@ -44,40 +44,40 @@ describe("Bib Page with items", () => {
   })
 
   it("renders the bottom bib details", () => {
-    expect(screen.getByTestId("Publication Date")).toHaveTextContent(
+    expect(screen.getByTestId("publication-date")).toHaveTextContent(
       "Vol. 1, issue 1-"
     )
-    expect(screen.getByTestId("Description")).toHaveTextContent(
+    expect(screen.getByTestId("description")).toHaveTextContent(
       "v. : ill.; 22 cm."
     )
-    expect(screen.getByTestId("Donor/Sponsor")).toHaveTextContent(
+    expect(screen.getByTestId("donor-sponsor")).toHaveTextContent(
       "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest"
     )
-    expect(screen.getByTestId("Alternative Title")).toHaveTextContent(
+    expect(screen.getByTestId("alternative-title")).toHaveTextContent(
       "Urban spaghetti literary arts journal"
     )
-    expect(screen.getByTestId("Subject")).toHaveTextContent("Arts, Modern")
-    expect(screen.getAllByTestId("Call Number")[0]).toHaveTextContent(
+    expect(screen.getByTestId("subject")).toHaveTextContent("Arts, Modern")
+    expect(screen.getAllByTestId("call-number")[0]).toHaveTextContent(
       "JFK 01-374"
     )
-    expect(screen.getAllByTestId("Title")[1]).toHaveTextContent(
+    expect(screen.getAllByTestId("title")[1]).toHaveTextContent(
       "Urban spaghetti."
     )
-    expect(screen.getByTestId("Imprint")).toHaveTextContent(
+    expect(screen.getByTestId("imprint")).toHaveTextContent(
       "Mansfield, Ohio : Urban Spaghetti, [1999?-"
     )
-    expect(screen.getByTestId("Current Frequency")).toHaveTextContent(
+    expect(screen.getByTestId("current-frequency")).toHaveTextContent(
       "Semiannual"
     )
-    expect(screen.getByTestId("Abbreviated Title")).toHaveTextContent(
+    expect(screen.getByTestId("abbreviated-title")).toHaveTextContent(
       "Urban spaghetti"
     )
-    expect(screen.getByTestId("Cover Title")).toHaveTextContent(
+    expect(screen.getByTestId("cover-title")).toHaveTextContent(
       "Urban spaghetti literary arts journal"
     )
-    expect(screen.getByTestId("LCCN")).toHaveTextContent("sn 98001765")
-    expect(screen.getByTestId("ISSN")).toHaveTextContent("1521-1371")
-    expect(screen.getByTestId("Research Call Number")).toHaveTextContent(
+    expect(screen.getByTestId("lccn")).toHaveTextContent("sn 98001765")
+    expect(screen.getByTestId("issn")).toHaveTextContent("1521-1371")
+    expect(screen.getByTestId("research-call-number")).toHaveTextContent(
       "JFK 01-374"
     )
   })

--- a/src/components/BibPage/BibDetail.test.tsx
+++ b/src/components/BibPage/BibDetail.test.tsx
@@ -41,7 +41,7 @@ describe("BibDetail component", () => {
     })
     it("renders multiple values, primaries and orphaned parallels", () => {
       render(<BibDetails details={parallelsBibModel.topDetails} />)
-      const publisherDetails = screen.getByTestId("Published By")
+      const publisherDetails = screen.getByTestId("published-by")
       expect(publisherDetails.children).toHaveLength(3)
     })
   })
@@ -79,7 +79,7 @@ describe("BibDetail component", () => {
       render(<BibDetails details={noParallelsBibModel.bottomDetails} />, {
         wrapper: MemoryRouterProvider,
       })
-      subjectHeadings = screen.getAllByTestId("subjectLinksPer")
+      subjectHeadings = screen.getAllByTestId("subject-links-per")
     })
     it("renders subject link groups per subject literal", () => {
       expect(subjectHeadings).toHaveLength(

--- a/src/components/BibPage/BibDetail.tsx
+++ b/src/components/BibPage/BibDetail.tsx
@@ -1,4 +1,7 @@
 import { Heading, List } from "@nypl/design-system-react-components"
+import { kebabCase } from "lodash"
+import { type ReactElement } from "react"
+
 import styles from "../../../styles/components/BibDetails.module.scss"
 import RCLink from "../Links/RCLink/RCLink"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
@@ -51,7 +54,7 @@ const DetailElement = (label: string, listChildren: ReactNode[]) => {
     <>
       <dt>{label}</dt>
       <dd>
-        <List noStyling data-testId={label} type="ol">
+        <List noStyling data-testid={kebabCase(label)} type="ol">
           {listChildren}
         </List>
       </dd>
@@ -63,7 +66,7 @@ const PlainTextElement = (field: BibDetail) => {
   const values = field?.value?.map((val: string, i: number) => {
     const stringDirection = rtlOrLtr(val)
     return (
-      <li dir={stringDirection} key={`${field}-${i}`}>
+      <li dir={stringDirection} key={`${kebabCase(field.label)}-${i}`}>
         {val}
       </li>
     )
@@ -78,7 +81,7 @@ const CompoundSubjectHeadingElement = (field: SubjectHeadingDetail) => {
     }
   )
   const values = subjectHeadingLinksPerSubject.map((subject, i) => (
-    <li key={`subject-heading-${i}`} data-testid="subjectLinksPer">
+    <li key={`subject-heading-${i}`} data-testid="subject-link-per">
       {subject}
     </li>
   ))
@@ -86,7 +89,7 @@ const CompoundSubjectHeadingElement = (field: SubjectHeadingDetail) => {
 }
 
 const SingleSubjectHeadingElement = (subjectHeadingUrls: Url[]) => {
-  const urls = subjectHeadingUrls.reduce((linksPerSubject, url: Url, index) => {
+  return subjectHeadingUrls.reduce((linksPerSubject, url: Url, index) => {
     const divider = (
       // this span will render as > in between the divided subject heading links
       <span data-testid="divider" key={`divider-${index}`}>
@@ -100,22 +103,23 @@ const SingleSubjectHeadingElement = (subjectHeadingUrls: Url[]) => {
       linksPerSubject.push(divider)
     }
     return linksPerSubject
-  }, [] as React.JSX.Element[])
-  return urls
+  }, [] as ReactElement[])
 }
 
 const LinkedDetailElement = (field: LinkedBibDetail) => {
   const internalOrExternal = field.link
   const values = field.value.map((urlInfo: Url, i) => {
     return (
-      <li key={`${field}-${i}`}>{LinkElement(urlInfo, internalOrExternal)}</li>
+      <li key={`${kebabCase(field.label)}-${i}`}>
+        {LinkElement(urlInfo, internalOrExternal)}
+      </li>
     )
   })
   return DetailElement(field.label, values)
 }
 
 const LinkElement = (url: Url, linkType: string) => {
-  let Link
+  let Link: typeof RCLink | typeof ExternalLink
   if (linkType === "internal") Link = RCLink
   else if (linkType === "external") Link = ExternalLink
   const stringDirection = rtlOrLtr(url.urlLabel)

--- a/src/components/BibPage/BibDetail.tsx
+++ b/src/components/BibPage/BibDetail.tsx
@@ -81,7 +81,7 @@ const CompoundSubjectHeadingElement = (field: SubjectHeadingDetail) => {
     }
   )
   const values = subjectHeadingLinksPerSubject.map((subject, i) => (
-    <li key={`subject-heading-${i}`} data-testid="subject-link-per">
+    <li key={`subject-heading-${i}`} data-testid="subject-links-per">
       {subject}
     </li>
   ))


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4150](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4150)

## This PR does the following:

- Uses lodash's kebabCase method to convert the test ids used in bibDetails to conform to the format used elsewhere in the app.

## How has this been tested?

- I've updated the unit tests

## Accessibility concerns or updates

NA

### Checklist:

- [X] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [X] All new and existing tests passed.


[SCC-4150]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ