### PR TITLE
Scc 4196/update location modal bug

### DIFF
--- a/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
@@ -266,4 +266,55 @@ describe("RequestsTab", () => {
     await userEvent.click(component.getAllByText("OK")[0])
     expect(component.getByTestId("items-tab")).toHaveFocus()
   })
+  describe("update location focus", () => {
+    const openModal = async () => {
+      const modalTrigger = screen.getAllByText("Change location")[0]
+      await userEvent.click(modalTrigger)
+    }
+    it("focuses on update location button after updating and closing", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () =>
+          JSON.stringify({
+            patron: { id: 123 },
+            holds: processedHolds,
+            pickupLocations,
+          }),
+        status: 200,
+      } as Response)
+      renderWithPatronDataContext()
+      await openModal()
+
+      const select = screen.getByLabelText("Pickup location")
+      await userEvent.selectOptions(select, "mp   ")
+      const submitButton = screen.getByText("Confirm location")
+      await userEvent.click(submitButton)
+      await userEvent.click(screen.getByText("OK"))
+      const updateLocation = screen.getByTestId("change-location-button")
+      expect(updateLocation).toHaveFocus()
+    })
+    it("focuses on update location button after closing modal without updating", async () => {
+      renderWithPatronDataContext()
+      await openModal()
+
+      await userEvent.click(screen.getByLabelText("Close"))
+      const updateLocation = screen.getByTestId("change-location-button")
+      expect(updateLocation).toHaveFocus()
+    })
+    it("focuses on update location button after failed update and closing modal", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => JSON.stringify({ id: "spaghetti" }),
+        status: 500,
+      } as Response)
+      renderWithPatronDataContext()
+      await openModal()
+
+      const select = screen.getByLabelText("Pickup location")
+      await userEvent.selectOptions(select, "mp   ")
+      const submitButton = screen.getByText("Confirm location")
+      await userEvent.click(submitButton)
+      await userEvent.click(screen.getByText("OK"))
+      const updateLocation = screen.getByTestId("change-location-button")
+      expect(updateLocation).toHaveFocus()
+    })
+  })
 })

--- a/src/components/MyAccount/RequestsTab/RequestsTab.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.tsx
@@ -19,7 +19,6 @@ const RequestsTab = () => {
   const tabRef = useRef(null)
   const [focusOnRequestTab, setFocusOnRequestTab] = useState(false)
   const {
-    patronDataLoading,
     updatedAccountData: { holds, patron, pickupLocations },
   } = useContext(PatronDataContext)
   function formatTitleElement(hold: Hold) {
@@ -42,40 +41,42 @@ const RequestsTab = () => {
     "Pickup by",
     "Manage request",
   ]
-  const holdsData = holds.map((hold, i) => [
-    formatTitleElement(hold),
-    getStatusBadge(hold.status),
-    <>
-      <Text>{hold.pickupLocation.name}</Text>
-      {!hold.isResearch && hold.status === "REQUEST PENDING" && (
-        <UpdateLocation
-          pickupLocationOptions={pickupLocations}
-          patronId={patron.id}
-          hold={hold}
-          key={i}
-        />
-      )}
-    </>,
-    hold.pickupByDate,
-    hold ? (
-      <Box
-        sx={{
-          display: "flex",
-          gap: "4px",
-          flexDirection: { base: "column", md: "row" },
-        }}
-      >
-        <CancelButton
-          setFocusOnRequestTab={setFocusOnRequestTab}
-          hold={hold}
-          patron={patron}
-        />
-        {hold.canFreeze && hold.status === "REQUEST PENDING" && (
-          <FreezeButton hold={hold} patron={patron} />
+  const holdsData = holds.map((hold, i) => {
+    return [
+      formatTitleElement(hold),
+      getStatusBadge(hold.status),
+      <>
+        <Text>{hold.pickupLocation.name}</Text>
+        {!hold.isResearch && hold.status === "REQUEST PENDING" && (
+          <UpdateLocation
+            pickupLocationOptions={pickupLocations}
+            patronId={patron.id}
+            hold={hold}
+            key={hold.pickupLocation.code}
+          />
         )}
-      </Box>
-    ) : null,
-  ])
+      </>,
+      hold.pickupByDate,
+      hold ? (
+        <Box
+          sx={{
+            display: "flex",
+            gap: "4px",
+            flexDirection: { base: "column", md: "row" },
+          }}
+        >
+          <CancelButton
+            setFocusOnRequestTab={setFocusOnRequestTab}
+            hold={hold}
+            patron={patron}
+          />
+          {hold.canFreeze && hold.status === "REQUEST PENDING" && (
+            <FreezeButton hold={hold} patron={patron} />
+          )}
+        </Box>
+      ) : null,
+    ]
+  })
 
   useEffect(() => {
     if (focusOnRequestTab) {

--- a/src/components/MyAccount/RequestsTab/RequestsTab.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.tsx
@@ -1,9 +1,4 @@
-import {
-  Box,
-  StatusBadge,
-  Text,
-  SkeletonLoader,
-} from "@nypl/design-system-react-components"
+import { Box, StatusBadge, Text } from "@nypl/design-system-react-components"
 
 import ExternalLink from "../../Links/ExternalLink/ExternalLink"
 import type { Hold } from "../../../types/myAccountTypes"
@@ -42,7 +37,7 @@ const RequestsTab = () => {
     "Pickup by",
     "Manage request",
   ]
-  const holdsData = holds.map((hold, i) => {
+  const holdsData = holds.map((hold) => {
     return [
       formatTitleElement(hold),
       getStatusBadge(hold.status),

--- a/src/components/MyAccount/RequestsTab/RequestsTab.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.tsx
@@ -18,6 +18,7 @@ import { PatronDataContext } from "../../../context/PatronDataContext"
 const RequestsTab = () => {
   const tabRef = useRef(null)
   const [focusOnRequestTab, setFocusOnRequestTab] = useState(false)
+  const [lastUpdatedHoldId, setLastUpdatedHoldId] = useState<string>(null)
   const {
     updatedAccountData: { holds, patron, pickupLocations },
   } = useContext(PatronDataContext)
@@ -49,6 +50,8 @@ const RequestsTab = () => {
         <Text>{hold.pickupLocation.name}</Text>
         {!hold.isResearch && hold.status === "REQUEST PENDING" && (
           <UpdateLocation
+            setLastUpdatedHoldId={setLastUpdatedHoldId}
+            focus={lastUpdatedHoldId === hold.id}
             pickupLocationOptions={pickupLocations}
             patronId={patron.id}
             hold={hold}

--- a/src/components/MyAccount/RequestsTab/UpdateLocation.test.tsx
+++ b/src/components/MyAccount/RequestsTab/UpdateLocation.test.tsx
@@ -26,7 +26,9 @@ describe("UpdateLocation modal trigger", () => {
           data-testId="click me"
           hold={processedHolds[0]}
           patronId={1234567}
-          key={1}
+          key={processedHolds[0].pickupLocation.code}
+          focus={false}
+          setLastUpdatedHoldId={() => "spaghetti"}
         />
       </PatronDataProvider>
     )
@@ -103,42 +105,6 @@ describe("UpdateLocation modal trigger", () => {
       const errorMessage = screen.getByText("Location change failed")
       expect(errorMessage).toBeInTheDocument()
       await userEvent.click(screen.getByText("OK"))
-    })
-  })
-  describe("focus", () => {
-    it("focuses on update location button after updating and closing", async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        json: async () => JSON.stringify({ id: "spaghetti" }),
-        status: 200,
-      } as Response)
-      await openModal()
-      const select = screen.getByLabelText("Pickup location")
-      await userEvent.selectOptions(select, "mp   ")
-      const submitButton = screen.getByText("Confirm location")
-      await userEvent.click(submitButton)
-      await userEvent.click(screen.getByText("OK"))
-      const updateLocation = screen.getByTestId("change-location-button")
-      expect(updateLocation).toHaveFocus()
-    })
-    it("focuses on update location button after closing modal without updating", async () => {
-      await openModal()
-      await userEvent.click(screen.getByText("Cancel"))
-      const updateLocation = screen.getByTestId("change-location-button")
-      expect(updateLocation).toHaveFocus()
-    })
-    it("focuses on update location button after failed update and closing modal", async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        json: async () => JSON.stringify({ id: "spaghetti" }),
-        status: 500,
-      } as Response)
-      await openModal()
-      const select = screen.getByLabelText("Pickup location")
-      await userEvent.selectOptions(select, "mp   ")
-      const submitButton = screen.getByText("Confirm location")
-      await userEvent.click(submitButton)
-      await userEvent.click(screen.getByText("OK"))
-      const updateLocation = screen.getByTestId("change-location-button")
-      expect(updateLocation).toHaveFocus()
     })
   })
 })

--- a/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
+++ b/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
@@ -22,7 +22,7 @@ import { PatronDataContext } from "../../../context/PatronDataContext"
 interface UpdateLocationPropsType {
   hold: Hold
   pickupLocationOptions: SierraCodeName[]
-  key: number
+  key: string
   patronId: number
 }
 

--- a/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
+++ b/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
@@ -15,7 +15,7 @@ import {
 } from "@nypl/design-system-react-components"
 import type { Hold, SierraCodeName } from "../../../types/myAccountTypes"
 import styles from "../../../../styles/components/MyAccount.module.scss"
-import { useContext, useRef, useState, useEffect } from "react"
+import { useContext, useRef, useState, useEffect, type Dispatch } from "react"
 import { BASE_URL } from "../../../config/constants"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 
@@ -24,6 +24,8 @@ interface UpdateLocationPropsType {
   pickupLocationOptions: SierraCodeName[]
   key: string
   patronId: number
+  setLastUpdatedHoldId: Dispatch<string>
+  focus: boolean
 }
 
 const UpdateLocation = ({
@@ -31,12 +33,14 @@ const UpdateLocation = ({
   patronId,
   hold,
   key,
+  setLastUpdatedHoldId,
+  focus,
 }: UpdateLocationPropsType) => {
   const selectRef = useRef(null)
   const updateLocationButtonRef = useRef(null)
 
   const [focusOnChangeLocationButton, setFocusOnChangeLocationButton] =
-    useState(false)
+    useState(focus)
 
   const { getMostUpdatedSierraAccountData } = useContext(PatronDataContext)
   const { Modal, onOpen: openModal, onClose: closeModal } = useModal()
@@ -67,6 +71,7 @@ const UpdateLocation = ({
     )
     if (response.status == 200) {
       setModalProps(successModalProps(newLocation) as DefaultModalProps)
+      setLastUpdatedHoldId(hold.id)
     } else setModalProps(failureModalProps as DefaultModalProps)
   }
 

--- a/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
+++ b/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
@@ -151,7 +151,6 @@ const UpdateLocation = ({
       </h5>
     ),
     onClose: () => {
-      setModalProps(confirmLocationChangeModalProps as DefaultModalProps)
       closeModal()
       getMostUpdatedSierraAccountData()
       setFocusOnChangeLocationButton(true)
@@ -171,7 +170,6 @@ const UpdateLocation = ({
       </Box>
     ),
     onClose: () => {
-      setModalProps(confirmLocationChangeModalProps as DefaultModalProps)
       closeModal()
       setFocusOnChangeLocationButton(true)
     },


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4196](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4196)

## This PR does the following:

- Fixes the issue of the location not updating on the second opening of the modal. I solved it by using hold.pickupLocation.code as a key. When the key updates, the component completely rerenders from scratch (thanks [@thedocs](https://react.dev/learn/preserving-and-resetting-state#resetting-a-form-with-a-key)).
- because the component is completely rerendering, I had to replace the focus on the update button by having some state controlled outside of the updateLocation. this means I can probably replace the skeleton loader! which i will work on as i await review on this initial work.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Moved focus tests to Request Tab tests. Added additional test to ensure value updates.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
