### PR TITLE
Scc 4190/loading feedback

### DIFF
--- a/src/components/MyAccount/CheckoutsTab/CheckoutsTab.tsx
+++ b/src/components/MyAccount/CheckoutsTab/CheckoutsTab.tsx
@@ -29,7 +29,7 @@ const CheckoutsTab = () => {
     "Due back by",
     "Manage checkout",
   ]
-  const [checkoutRenewing, setCheckoutRenewing] = useState<string>(null)
+  const [checkoutToRenew, setCheckoutToRenew] = useState<string>(null)
   const checkoutsData = checkouts.map((checkout) => [
     formatTitleElement(checkout),
     checkout.barcode,
@@ -37,8 +37,8 @@ const CheckoutsTab = () => {
     checkout.dueDate,
     checkout.isResearch ? null : (
       <RenewButton
-        setCheckoutRenewing={setCheckoutRenewing}
-        renewingLoading={checkoutRenewing === checkout.id}
+        setCheckoutToRenew={setCheckoutToRenew}
+        isCheckoutRenewing={checkoutToRenew === checkout.id}
         checkout={checkout}
         patron={patron}
       />

--- a/src/components/MyAccount/CheckoutsTab/CheckoutsTab.tsx
+++ b/src/components/MyAccount/CheckoutsTab/CheckoutsTab.tsx
@@ -3,7 +3,7 @@ import ExternalLink from "../../Links/ExternalLink/ExternalLink"
 import type { Checkout } from "../../../types/myAccountTypes"
 import RenewButton from "./RenewButton"
 import ItemsTab from "../ItemsTab"
-import { useContext } from "react"
+import { useContext, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 
 const CheckoutsTab = () => {
@@ -29,14 +29,19 @@ const CheckoutsTab = () => {
     "Due back by",
     "Manage checkout",
   ]
-
+  const [checkoutRenewing, setCheckoutRenewing] = useState<string>(null)
   const checkoutsData = checkouts.map((checkout) => [
     formatTitleElement(checkout),
     checkout.barcode,
     checkout.callNumber,
     checkout.dueDate,
     checkout.isResearch ? null : (
-      <RenewButton checkout={checkout} patron={patron} />
+      <RenewButton
+        setCheckoutRenewing={setCheckoutRenewing}
+        checkoutRenewing={checkoutRenewing === checkout.id}
+        checkout={checkout}
+        patron={patron}
+      />
     ),
   ])
   return (

--- a/src/components/MyAccount/CheckoutsTab/CheckoutsTab.tsx
+++ b/src/components/MyAccount/CheckoutsTab/CheckoutsTab.tsx
@@ -38,7 +38,7 @@ const CheckoutsTab = () => {
     checkout.isResearch ? null : (
       <RenewButton
         setCheckoutRenewing={setCheckoutRenewing}
-        checkoutRenewing={checkoutRenewing === checkout.id}
+        renewingLoading={checkoutRenewing === checkout.id}
         checkout={checkout}
         patron={patron}
       />

--- a/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
+++ b/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
@@ -17,11 +17,11 @@ import { PatronDataContext } from "../../../context/PatronDataContext"
 const RenewButton = ({
   checkout,
   patron,
-  renewingLoading,
-  setCheckoutRenewing,
+  isCheckoutRenewing,
+  setCheckoutToRenew,
 }: {
-  renewingLoading: boolean
-  setCheckoutRenewing: Dispatch<string>
+  isCheckoutRenewing: boolean
+  setCheckoutToRenew: Dispatch<string>
   checkout: Checkout
   patron: Patron
 }) => {
@@ -84,7 +84,7 @@ const RenewButton = ({
       </h5>
     ),
     onClose: () => {
-      setCheckoutRenewing(null)
+      setCheckoutToRenew(null)
       onClose()
     },
   }
@@ -102,7 +102,7 @@ const RenewButton = ({
   }, [])
 
   const handleClick = async () => {
-    setCheckoutRenewing(checkout.id)
+    setCheckoutToRenew(checkout.id)
     setPatronDataLoading(true)
     const response = await fetch(
       `${BASE_URL}/api/account/checkouts/renew/${checkout.id}`,
@@ -125,7 +125,7 @@ const RenewButton = ({
     }
     onOpen()
   }
-  const showLoadingState = patronDataLoading && renewingLoading
+  const showLoadingState = patronDataLoading && isCheckoutRenewing
 
   return (
     <>
@@ -142,7 +142,7 @@ const RenewButton = ({
         {showLoadingState && (
           <ProgressIndicator
             id={"renew-loading"}
-            labelText="Loading"
+            labelText="Renew"
             showLabel={false}
             size="small"
             indicatorType="circular"

--- a/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
+++ b/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react"
+import { type Dispatch, useContext, useEffect, useState } from "react"
 import {
   useModal,
   Box,
@@ -17,9 +17,11 @@ import { PatronDataContext } from "../../../context/PatronDataContext"
 const RenewButton = ({
   checkout,
   patron,
-  checkoutRenewing,
+  renewingLoading,
   setCheckoutRenewing,
 }: {
+  renewingLoading: boolean
+  setCheckoutRenewing: Dispatch<string>
   checkout: Checkout
   patron: Patron
 }) => {
@@ -82,6 +84,7 @@ const RenewButton = ({
       </h5>
     ),
     onClose: () => {
+      setCheckoutRenewing(null)
       onClose()
     },
   }
@@ -122,6 +125,7 @@ const RenewButton = ({
     }
     onOpen()
   }
+  const showLoadingState = patronDataLoading && renewingLoading
 
   return (
     <>
@@ -132,10 +136,10 @@ const RenewButton = ({
         buttonType="secondary"
         id={`renew-${checkout.id}`}
         onClick={handleClick}
-        aria-disabled={isButtonDisabled}
+        aria-disabled={isButtonDisabled || showLoadingState}
         aria-label={`Renew ${checkout.title}`}
       >
-        {patronDataLoading && checkoutRenewing && (
+        {showLoadingState && (
           <ProgressIndicator
             id={"renew-loading"}
             labelText="Renew"
@@ -146,7 +150,7 @@ const RenewButton = ({
             isIndeterminate
           />
         )}
-        Renew
+        {showLoadingState ? "Loading" : "Renew"}
       </Button>
       <Modal {...modalProps} />
     </>

--- a/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
+++ b/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
@@ -142,7 +142,7 @@ const RenewButton = ({
         {showLoadingState && (
           <ProgressIndicator
             id={"renew-loading"}
-            labelText="Renew"
+            labelText="Loading"
             showLabel={false}
             size="small"
             indicatorType="circular"

--- a/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
+++ b/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   Button,
   Text,
+  ProgressIndicator,
 } from "@nypl/design-system-react-components"
 
 import ExternalLink from "../../Links/ExternalLink/ExternalLink"
@@ -16,6 +17,8 @@ import { PatronDataContext } from "../../../context/PatronDataContext"
 const RenewButton = ({
   checkout,
   patron,
+  checkoutRenewing,
+  setCheckoutRenewing,
 }: {
   checkout: Checkout
   patron: Patron
@@ -23,7 +26,11 @@ const RenewButton = ({
   const [isButtonDisabled, setButtonDisabled] = useState(false)
   const { onOpen, onClose, Modal } = useModal()
   const [modalProps, setModalProps] = useState(null)
-  const { getMostUpdatedSierraAccountData } = useContext(PatronDataContext)
+  const {
+    getMostUpdatedSierraAccountData,
+    patronDataLoading,
+    setPatronDataLoading,
+  } = useContext(PatronDataContext)
 
   const successModalProps = {
     type: "default",
@@ -92,6 +99,8 @@ const RenewButton = ({
   }, [])
 
   const handleClick = async () => {
+    setCheckoutRenewing(checkout.id)
+    setPatronDataLoading(true)
     const response = await fetch(
       `${BASE_URL}/api/account/checkouts/renew/${checkout.id}`,
       {
@@ -126,6 +135,17 @@ const RenewButton = ({
         aria-disabled={isButtonDisabled}
         aria-label={`Renew ${checkout.title}`}
       >
+        {patronDataLoading && checkoutRenewing && (
+          <ProgressIndicator
+            id={"renew-loading"}
+            labelText="Renew"
+            showLabel={false}
+            size="small"
+            indicatorType="circular"
+            mr="xs"
+            isIndeterminate
+          />
+        )}
         Renew
       </Button>
       <Modal {...modalProps} />

--- a/src/components/MyAccount/RequestsTab/CancelButton.tsx
+++ b/src/components/MyAccount/RequestsTab/CancelButton.tsx
@@ -112,6 +112,9 @@ const CancelButton = ({
       setModalProps({
         ...checkModalProps,
         bodyContent: <SkeletonLoader showImage={false} />,
+        onCancel: () => null,
+        onConfirm: () => null,
+        closeButtonLabel: "Loading",
       } as ConfirmationModalProps)
       const response = await fetch(
         `${BASE_URL}/api/account/holds/cancel/${hold.id}`,

--- a/src/components/MyAccount/RequestsTab/FreezeButton.tsx
+++ b/src/components/MyAccount/RequestsTab/FreezeButton.tsx
@@ -121,7 +121,7 @@ const FreezeButton = ({ hold, patron }: { hold: Hold; patron: Patron }) => {
         {isDisabled && (
           <ProgressIndicator
             id={"freeze-loading"}
-            labelText="Renew"
+            labelText="Loading"
             showLabel={false}
             size="small"
             indicatorType="circular"

--- a/src/components/MyAccount/RequestsTab/FreezeButton.tsx
+++ b/src/components/MyAccount/RequestsTab/FreezeButton.tsx
@@ -1,4 +1,4 @@
-import { createRef, type Dispatch, useEffect, useState } from "react"
+import { createRef, useEffect, useState } from "react"
 import type { Hold, Patron } from "../../../types/myAccountTypes"
 import {
   Box,
@@ -121,7 +121,7 @@ const FreezeButton = ({ hold, patron }: { hold: Hold; patron: Patron }) => {
         {isDisabled && (
           <ProgressIndicator
             id={"freeze-loading"}
-            labelText="Loading"
+            labelText="Renew"
             showLabel={false}
             size="small"
             indicatorType="circular"

--- a/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
@@ -198,7 +198,8 @@ describe("RequestsTab", () => {
       json: async () => "Nooo",
       status: 400,
     } as Response)
-    const component = renderWithPatronDataContext()
+    const theoreticallyFreezableHold = processedHolds[2]
+    const component = renderWithPatronDataContext([theoreticallyFreezableHold])
     expect(
       component.queryByText("Hold freeze failed", { exact: false })
     ).not.toBeInTheDocument()
@@ -209,8 +210,9 @@ describe("RequestsTab", () => {
     expect(
       component.getByText("Hold freeze failed", { exact: false })
     ).toBeInTheDocument()
-    await userEvent.click(screen.getAllByText("OK", { exact: false })[0])
-    freezeButtons = component.getAllByText("Freeze")
+    const ok = screen.getByRole("button", { name: "OK" })
+    await userEvent.click(ok)
+    freezeButtons = await component.findAllByText("Freeze")
     expect(freezeButtons.length).toBe(1)
   })
 

--- a/src/components/MyAccount/RequestsTab/RequestsTab.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.tsx
@@ -19,7 +19,6 @@ const RequestsTab = () => {
   const tabRef = useRef(null)
   const [focusOnRequestTab, setFocusOnRequestTab] = useState(false)
   const [lastUpdatedHoldId, setLastUpdatedHoldId] = useState<string>(null)
-  const [holdToFreeze, setHoldToFreeze] = useState<string>(null)
 
   const {
     patronDataLoading,
@@ -48,19 +47,23 @@ const RequestsTab = () => {
   const holdsData = holds.map((hold, i) => [
     formatTitleElement(hold),
     getStatusBadge(hold.status),
-    <>
-      <Text>{hold.pickupLocation.name}</Text>
-      {!hold.isResearch && hold.status === "REQUEST PENDING" && (
-        <UpdateLocation
-          setLastUpdatedHoldId={setLastUpdatedHoldId}
-          focus={lastUpdatedHoldId === hold.id}
-          pickupLocationOptions={pickupLocations}
-          patronId={patron.id}
-          hold={hold}
-          key={hold.pickupLocation.code}
-        />
-      )}
-    </>,
+    lastUpdatedHoldId === hold.id && patronDataLoading ? (
+      <SkeletonLoader showImage={false} />
+    ) : (
+      <>
+        <Text>{hold.pickupLocation.name}</Text>
+        {!hold.isResearch && hold.status === "REQUEST PENDING" && (
+          <UpdateLocation
+            setLastUpdatedHoldId={setLastUpdatedHoldId}
+            focus={lastUpdatedHoldId === hold.id}
+            pickupLocationOptions={pickupLocations}
+            patronId={patron.id}
+            hold={hold}
+            key={hold.pickupLocation.code}
+          />
+        )}
+      </>
+    ),
     hold.pickupByDate,
     hold ? (
       <Box
@@ -103,7 +106,8 @@ const RequestsTab = () => {
       </StatusBadge>
     )
   }
-  const tabDisplay = patronDataLoading ? (
+  const awaitingPatronUpdateAfterCancel = patronDataLoading && focusOnRequestTab
+  const tabDisplay = awaitingPatronUpdateAfterCancel ? (
     <SkeletonLoader showImage={false} />
   ) : (
     <ItemsTab

--- a/src/components/MyAccount/RequestsTab/RequestsTab.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.tsx
@@ -42,6 +42,7 @@ const RequestsTab = () => {
     "Pickup by",
     "Manage request",
   ]
+  const [holdToFreeze, setHoldToFreeze] = useState<string>(null)
   const holdsData = holds.map((hold, i) => [
     formatTitleElement(hold),
     getStatusBadge(hold.status),
@@ -71,7 +72,12 @@ const RequestsTab = () => {
           patron={patron}
         />
         {hold.canFreeze && hold.status === "REQUEST PENDING" && (
-          <FreezeButton hold={hold} patron={patron} />
+          <FreezeButton
+            setHoldToFreeze={setHoldToFreeze}
+            freezing={holdToFreeze === hold.id}
+            hold={hold}
+            patron={patron}
+          />
         )}
       </Box>
     ) : null,

--- a/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
+++ b/src/components/MyAccount/RequestsTab/UpdateLocation.tsx
@@ -58,6 +58,8 @@ const UpdateLocation = ({
     setModalProps({
       ...confirmLocationChangeModalProps,
       bodyContent: <SkeletonLoader showImage={false} />,
+      onClose: () => null,
+      closeButtonLabel: "Loading",
     } as DefaultModalProps)
     const response = await fetch(
       `${BASE_URL}/api/account/holds/update/${hold.id}`,

--- a/src/components/MyAccount/Settings/PasswordChangeForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordChangeForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { type Dispatch, useState } from "react"
 import {
   Form,
   FormField,
@@ -12,9 +12,11 @@ import type { Patron } from "../../../types/myAccountTypes"
 const PasswordChangeForm = ({
   patron,
   updateModal,
+  updateModalToLoading,
 }: {
   patron: Patron
   updateModal: (errorMessage?: string) => void
+  updateModalToLoading: () => void
 }) => {
   const [formData, setFormData] = useState({
     oldPassword: "",
@@ -56,6 +58,7 @@ const PasswordChangeForm = ({
   }
 
   const handleSubmit = async () => {
+    updateModalToLoading()
     const res = await fetch(`${BASE_URL}/api/account/update-pin/${patron.id}`, {
       method: "PUT",
       headers: {

--- a/src/components/MyAccount/Settings/PasswordChangeForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordChangeForm.tsx
@@ -12,11 +12,11 @@ import type { Patron } from "../../../types/myAccountTypes"
 const PasswordChangeForm = ({
   patron,
   updateModal,
-  updateModalToLoading,
+  onModalSubmit,
 }: {
   patron: Patron
   updateModal: (errorMessage?: string) => void
-  updateModalToLoading: () => void
+  onModalSubmit: () => void
 }) => {
   const [formData, setFormData] = useState({
     oldPassword: "",
@@ -58,7 +58,7 @@ const PasswordChangeForm = ({
   }
 
   const handleSubmit = async () => {
-    updateModalToLoading()
+    onModalSubmit()
     const res = await fetch(`${BASE_URL}/api/account/update-pin/${patron.id}`, {
       method: "PUT",
       headers: {

--- a/src/components/MyAccount/Settings/PasswordModal.tsx
+++ b/src/components/MyAccount/Settings/PasswordModal.tsx
@@ -59,6 +59,8 @@ const PasswordModal = ({ patron }: { patron: Patron }) => {
   const loadingProps = {
     ...entryModalProps,
     bodyContent: <SkeletonLoader showImage={false} />,
+    onClose: () => null,
+    closeButtonLabel: "Loading",
   }
 
   const [modalProps, setModalProps] = useState(entryModalProps)

--- a/src/components/MyAccount/Settings/PasswordModal.tsx
+++ b/src/components/MyAccount/Settings/PasswordModal.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   List,
   Button,
+  SkeletonLoader,
 } from "@nypl/design-system-react-components"
 import { useState } from "react"
 
@@ -41,7 +42,11 @@ const PasswordModal = ({ patron }: { patron: Patron }) => {
           </li>
           <li> PINs and PASSWORDS must NOT contain a period.</li>
         </List>
-        <PasswordChangeForm patron={patron} updateModal={updateModal} />
+        <PasswordChangeForm
+          patron={patron}
+          updateModal={updateModal}
+          updateModalToLoading={() => setModalProps(loadingProps)}
+        />
       </Box>
     ),
     closeButtonLabel: "Cancel",
@@ -49,6 +54,11 @@ const PasswordModal = ({ patron }: { patron: Patron }) => {
     onClose: () => {
       closeModal()
     },
+  }
+
+  const loadingProps = {
+    ...entryModalProps,
+    bodyContent: <SkeletonLoader showImage={false} />,
   }
 
   const [modalProps, setModalProps] = useState(entryModalProps)

--- a/src/components/MyAccount/Settings/PasswordModal.tsx
+++ b/src/components/MyAccount/Settings/PasswordModal.tsx
@@ -45,7 +45,7 @@ const PasswordModal = ({ patron }: { patron: Patron }) => {
         <PasswordChangeForm
           patron={patron}
           updateModal={updateModal}
-          updateModalToLoading={() => setModalProps(loadingProps)}
+          onModalSubmit={() => setModalProps(loadingProps)}
         />
       </Box>
     ),


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4190](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4190)

## This PR does the following:

- Add loading indicator for freeze and renewal flows
- add skeleton loader just for update location cell
- update location loading modal cancel button no longer closes the modal
- add skeleton loader in update pin/password modal
- update pin cancel button no longer closes the modal

## How has this been tested?

These tests are time sensitive in a way that I don't think is possible to have unit tests. Running locally, I have seen all the loading states appear appropriately.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- loading modals no longer have functional close buttons, but the close/cancel buttons were confusing in the workflow anyway.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4190]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ