### PR TITLE
math.floor minutes for timed logout

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -76,7 +76,7 @@ const Layout = ({
                 {showSearch && <SearchForm aggregations={searchAggregations} />}
               </div>
               {showNotification && bannerNotification && (
-                <Box sx={{ display: "flex", "justify-content": "center" }}>
+                <Box sx={{ display: "flex", justifyContent: "center" }}>
                   <Banner
                     sx={{ maxWidth: "1248px", margin: "2em 2em .5em 2em" }}
                     heading="New Service Announcement"

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -26,7 +26,7 @@ const deleteCookie = (cookieName: string) =>
 export const buildTimeLeft = (expirationTime) => {
   const left =
     (new Date(expirationTime).getTime() - new Date().getTime()) / 1000
-  const minutes = Math.ceil(left / 60)
+  const minutes = Math.floor(left / 60)
   const seconds = Math.ceil(left) % 60
   return { minutes, seconds }
 }


### PR DESCRIPTION
Fix for timed logout modal bug that was causing an extra minute to still be displayed. The modal displays -1:00 before logging out. I don't think it's a blocker, though.