### PR TITLE
Account settings focus and -1 bug

### DIFF
--- a/src/components/MyAccount/Settings/AccountSettingsButtons.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsButtons.tsx
@@ -14,9 +14,12 @@ const AccountSettingsButtons = ({
   formValid,
   setCurrentlyEditing,
   editButtonRef,
+  setFocusOnAccountSettingsButton,
 }: AccountSettingsButtonsPropsType) => {
-  const toggleCurrentlyEditing = (doWeWantToEdit: boolean) =>
+  const toggleCurrentlyEditing = (doWeWantToEdit: boolean) => {
     setCurrentlyEditing(doWeWantToEdit)
+    setFocusOnAccountSettingsButton(!doWeWantToEdit)
+  }
   const editButton = (
     <Button
       ref={editButtonRef}

--- a/src/components/MyAccount/Settings/AccountSettingsButtons.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsButtons.tsx
@@ -7,6 +7,7 @@ interface AccountSettingsButtonsPropsType {
   formValid: boolean
   setCurrentlyEditing: Dispatch<React.SetStateAction<boolean>>
   editButtonRef: MutableRefObject<HTMLButtonElement>
+  setFocusOnAccountSettingsButton: Dispatch<React.SetStateAction<boolean>>
 }
 
 const AccountSettingsButtons = ({

--- a/src/components/MyAccount/Settings/AccountSettingsTab.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsTab.tsx
@@ -53,7 +53,6 @@ const AccountSettingsTab = () => {
     if (currentlyEditing) {
       firstInputRef.current?.focus()
     } else if (!patronDataLoading && focusOnAccountSettingsButton) {
-      console.log("spaghetti")
       editButtonRef.current?.focus()
     }
   }, [currentlyEditing, focusOnAccountSettingsButton, patronDataLoading])

--- a/src/components/MyAccount/Settings/AccountSettingsTab.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsTab.tsx
@@ -22,6 +22,7 @@ import { PatronDataContext } from "../../../context/PatronDataContext"
 
 const AccountSettingsTab = () => {
   const {
+    patronDataLoading,
     getMostUpdatedSierraAccountData,
     updatedAccountData: { patron, pickupLocations },
   } = useContext(PatronDataContext)
@@ -46,11 +47,16 @@ const AccountSettingsTab = () => {
   ) : (
     <AccountSettingsDisplay patron={patron} />
   )
+  const [focusOnAccountSettingsButton, setFocusOnAccountSettingButton] =
+    useState(false)
   useEffect(() => {
     if (currentlyEditing) {
       firstInputRef.current?.focus()
-    } else editButtonRef.current?.focus()
-  }, [currentlyEditing])
+    } else if (!patronDataLoading && focusOnAccountSettingsButton) {
+      console.log("spaghetti")
+      editButtonRef.current?.focus()
+    }
+  }, [currentlyEditing, focusOnAccountSettingsButton, patronDataLoading])
 
   const submitAccountSettings = async (e) => {
     e.preventDefault()
@@ -85,7 +91,10 @@ const AccountSettingsTab = () => {
         <Modal
           {...{
             ...modalProps,
-            onClose: closeModal,
+            onClose: () => {
+              closeModal()
+              setFocusOnAccountSettingButton(true)
+            },
           }}
         />
       )}
@@ -103,6 +112,7 @@ const AccountSettingsTab = () => {
         </List>
         <Spacer display={{ sm: "none", base: "none", md: "inline-block" }} />
         <AccountSettingsButtons
+          setFocusOnAccountSettingsButton={setFocusOnAccountSettingButton}
           editButtonRef={editButtonRef}
           currentlyEditing={currentlyEditing}
           setCurrentlyEditing={setCurrentlyEditing}

--- a/src/components/MyAccount/TimedLogoutModal.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.tsx
@@ -58,7 +58,7 @@ const TimedLogoutModal = ({
   // Theoretically, accountPageExp should disappear after 5mins, causing
   // logOutAndRedirect() to be fired above, but let's make sure a failure
   // there never allows the timer to pass zero:
-  if (timeUntilExpiration.minutes <= 0 && timeUntilExpiration.seconds <= 0) {
+  if (timeUntilExpiration.minutes === 0 && timeUntilExpiration.seconds === 0) {
     logOutAndRedirect()
   }
   if (!open) return null

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -25,12 +25,18 @@ const deleteCookie = (cookieName: string) =>
 
 export const buildTimeLeft = (expirationTime) => {
   const left =
-    (new Date(expirationTime).getTime() - new Date().getTime()) / 1000
+    // Math.floor isn't really necessary for this to work in the wild,
+    // but it facilitates local testing by allowing for timeout windows that are less than a minute
+    Math.floor(new Date(expirationTime).getTime() - new Date().getTime()) / 1000
   const minutes = Math.floor(left / 60)
   const seconds = Math.ceil(left) % 60
   // edge case of 1 minute left
   if (left > 0 && minutes === 0 && seconds === 0) {
     return { minutes: 1, seconds: 0 }
+  }
+  // seconds have to be Math.ceil'd, which makes it very unlikely to actually hit zero
+  if (Math.floor(left) === 0) {
+    return { minutes: 0, seconds: 0 }
   }
   return { minutes, seconds }
 }

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -26,15 +26,20 @@ const deleteCookie = (cookieName: string) =>
 export const buildTimeLeft = (expirationTime) => {
   const left =
     // Math.floor isn't really necessary for this to work in the wild,
-    // but it facilitates local testing by allowing for timeout windows that are less than a minute
+    // but it facilitates local testing by allowing for timeout windows that are
+    // less than a minute
     Math.floor(new Date(expirationTime).getTime() - new Date().getTime()) / 1000
-  const minutes = Math.floor(left / 60)
   const seconds = Math.ceil(left) % 60
-  // edge case of 1 minute left
-  if (left > 0 && minutes === 0 && seconds === 0) {
-    return { minutes: 1, seconds: 0 }
+  let minutes
+  if (seconds === 0) {
+    // this is to cover the case where minutes ends up at 1.98 and seconds are
+    // zero. in this case, we want minutes to be 2 and not 1.
+    minutes = Math.ceil(left / 60)
+  } else {
+    // otherwise, if minutes is 1.2 and seconds is 30, we want minutes to be 1
+    minutes = Math.floor(left / 60)
   }
-  // seconds have to be Math.ceil'd, which makes it very unlikely to actually hit zero
+  // seconds are Math.ceil'd, which makes it very unlikely to hit exactly zero
   if (Math.floor(left) === 0) {
     return { minutes: 0, seconds: 0 }
   }

--- a/src/utils/utilsTests/cookieUtils.test.ts
+++ b/src/utils/utilsTests/cookieUtils.test.ts
@@ -6,6 +6,20 @@ describe("cookie utils", () => {
     beforeAll(() => {
       jest.useFakeTimers().setSystemTime(new Date(now))
     })
+    it("returns 2 minutes and 0 seconds at the start of the timer", () => {
+      const expirationTime = now + 2 * 60 * 1000
+      expect(buildTimeLeft(expirationTime)).toStrictEqual({
+        minutes: 2,
+        seconds: 0,
+      })
+    })
+    it("returns 2 minutes and 0 seconds when there are not exactly 2 minutes left", () => {
+      const expirationTime = now + 2 * 60 * 1000 - 500
+      expect(buildTimeLeft(expirationTime)).toStrictEqual({
+        minutes: 2,
+        seconds: 0,
+      })
+    })
     it("returns 1 minute and 0 seconds when there are 59.7 seconds left", () => {
       // expiration time is just under 1 minute to make sure that rounding is
       // happening properly
@@ -25,9 +39,16 @@ describe("cookie utils", () => {
       })
     })
     it("returns 0 minute and 0 seconds when there are 0 seconds left", () => {
-      // expiration time is just under 1 minute to make sure that rounding is
-      // happening properly
       const expirationTime = now
+      expect(buildTimeLeft(expirationTime)).toStrictEqual({
+        minutes: 0,
+        seconds: 0,
+      })
+    })
+    it("returns 0 minute and 0 seconds when there are 0 seconds left", () => {
+      // expiration time is a fraction of a second ahead of now to check for
+      // rounding
+      const expirationTime = now + 500
       expect(buildTimeLeft(expirationTime)).toStrictEqual({
         minutes: 0,
         seconds: 0,


### PR DESCRIPTION
## Ticket:

these QA comments: 
- https://docs.google.com/document/d/1rx8pHljNYFhItXtpEjaKPB9MHtqTfdxeEs7Nw8QpEuM/edit#heading=h.2cttxp3f1v48
- https://docs.google.com/document/d/1rx8pHljNYFhItXtpEjaKPB9MHtqTfdxeEs7Nw8QpEuM/edit#heading=h.6cbe9vt5qn6x

## This PR does the following:

- Ensures that focus does not jump to account settings button after using the arrows to navigate to the settings tab
- fix timer skipping 0:00 and showing -1:00 minutes left 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
