### PR TITLE
set modal props outside of fetch callback

### DIFF
--- a/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
+++ b/src/components/MyAccount/CheckoutsTab/RenewButton.tsx
@@ -28,6 +28,7 @@ const RenewButton = ({
   const [isButtonDisabled, setButtonDisabled] = useState(false)
   const { onOpen, onClose, Modal } = useModal()
   const [modalProps, setModalProps] = useState(null)
+  const [renewalSuccess, setRenewalSuccess] = useState(null)
   const {
     getMostUpdatedSierraAccountData,
     patronDataLoading,
@@ -57,7 +58,6 @@ const RenewButton = ({
       </h5>
     ),
     onClose: async () => {
-      getMostUpdatedSierraAccountData()
       onClose()
     },
   }
@@ -114,18 +114,26 @@ const RenewButton = ({
     const responseData = await response.json()
     if (responseData.message == "Renewed") {
       setButtonDisabled(true)
-      setModalProps(successModalProps)
+      await getMostUpdatedSierraAccountData()
       localStorage.setItem(
         `lastDisabledTime-${checkout.id}`,
         new Date().getTime().toString()
       )
+      setRenewalSuccess(true)
     } else {
-      setModalProps(failureModalProps)
+      setRenewalSuccess(false)
       //TO-DO: Log error console.log("error", responseData)
     }
-    onOpen()
   }
   const showLoadingState = patronDataLoading && isCheckoutRenewing
+
+  useEffect(() => {
+    // default state is null. We don't want this code to run on the inital render
+    if (renewalSuccess === null) return
+    if (renewalSuccess) setModalProps(successModalProps)
+    if (renewalSuccess === false) setModalProps(failureModalProps)
+    onOpen()
+  }, [renewalSuccess])
 
   return (
     <>

--- a/src/context/PatronDataContext.tsx
+++ b/src/context/PatronDataContext.tsx
@@ -20,9 +20,11 @@ export const PatronDataProvider = ({
   value: MyAccountPatronData
   testSpy?: () => void
 }) => {
-  const [patronDataLoading, setPatronDataLoading] = useState(false)
+  const [patronDataLoading, setPatronDataLoading] = useState(null)
   const [updatedAccountData, setUpdatedAccountData] = useState(value)
   const getMostUpdatedSierraAccountData = async () => {
+    // this method is only invoked to test that this method is being called
+    // during testing
     if (testSpy) testSpy()
     setPatronDataLoading(true)
     const resp = await fetch(

--- a/src/types/myAccountTypes.ts
+++ b/src/types/myAccountTypes.ts
@@ -13,7 +13,7 @@ export interface PatronDataContextType {
   patronDataLoading: boolean
   setUpdatedAccountData: Dispatch<SetStateAction<MyAccountPatronData>>
   updatedAccountData: MyAccountPatronData
-  getMostUpdatedSierraAccountData: () => void
+  getMostUpdatedSierraAccountData: () => Promise<void>
 }
 export interface SierraAccountData {
   checkouts: SierraCheckout[]


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4207](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4207)

## This PR does the following:

- Renewal success modal was showing stale due date. Updated the code so the modal doesn't open until the data has been refreshed.

## How has this been tested?

Due to the annoying as heck nature of testing checkout renewals, I hacked it by hardcoding the response of `renewCheckout` in `/pages/api/account/helpers.ts` to return this body:
`{
    "id": "https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/patrons/checkouts/66527526",
    "patron": "https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/patrons/6742743",
    "item": "https://nypl-sierra-test.nypl.org/iii/sierra-api/v6/items/38427966",
    "barcode": "33333418738239",
    "dueDate": "2024-08-20T08:00:00Z",
    "callNumber": "B CLARE M",
    "numberOfRenewals": 5,
    "outDate": "2024-07-19T18:39:33Z",
    "isRenewable": true
}`
If the modal displays with due date 8/20, then it is working.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.


[SCC-4207]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ