### PR TITLE
Scc 4212/bib holds only

### DIFF
--- a/src/components/MyAccount/RequestsTab/CancelButton.tsx
+++ b/src/components/MyAccount/RequestsTab/CancelButton.tsx
@@ -110,12 +110,11 @@ const CancelButton = ({
     headingText: <h5 className={styles["noIconHeading"]}>Cancel request?</h5>,
     onConfirm: async () => {
       setModalProps({
-        ...checkModalProps,
+        type: "default",
         bodyContent: <SkeletonLoader showImage={false} />,
-        onCancel: () => null,
-        onConfirm: () => null,
+        onClose: () => null,
         closeButtonLabel: "Loading",
-      } as ConfirmationModalProps)
+      } as DefaultModalProps)
       const response = await fetch(
         `${BASE_URL}/api/account/holds/cancel/${hold.id}`,
         {

--- a/src/models/MyAccount.ts
+++ b/src/models/MyAccount.ts
@@ -95,7 +95,7 @@ export default class MyAccount {
   }
 
   async fetchBibData(
-    holdsOrCheckouts: any[],
+    holdsOrCheckouts: (SierraHold | SierraCheckout)[],
     itemOrRecord: string
   ): Promise<{
     total?: number
@@ -106,17 +106,18 @@ export default class MyAccount {
     const itemLevelHoldsorCheckouts = []
     const bibLevelHolds = []
 
-    // Separating bib level and item level records so we only fetch bib data for item level holds/checkouts.
+    // Separating bib level holds so we only fetch bib data for
+    // item level holds/checkouts.
     holdsOrCheckouts.forEach((holdOrCheckout) => {
       if (holdOrCheckout[itemOrRecord].bibIds) {
         itemLevelHoldsorCheckouts.push(holdOrCheckout[itemOrRecord].bibIds[0])
       } else {
-        bibLevelHolds.push(holdOrCheckout.record)
+        bibLevelHolds.push((holdOrCheckout as SierraHold).record)
       }
     })
 
     const bibData = { entries: bibLevelHolds }
-    let itemLevelBibData
+    let itemLevelBibData: { entries: SierraBibEntry[] }
     if (itemLevelHoldsorCheckouts.length) {
       try {
         itemLevelBibData = await this.client.get(

--- a/src/models/MyAccount.ts
+++ b/src/models/MyAccount.ts
@@ -66,7 +66,7 @@ export default class MyAccount {
     try {
       holdBibData = await this.fetchBibData(holds.entries, "record")
     } catch (e) {
-      console.error("MyAccount#fetchBibData error: " + e.message)
+      console.error("MyAccount#fetchBibData error: " + e.message || e)
     }
 
     const holdsWithBibData = this.buildHolds(holds.entries, holdBibData.entries)
@@ -114,10 +114,19 @@ export default class MyAccount {
         bibLevelHolds.push(holdOrCheckout.record)
       }
     })
-    const bibData = await this.client.get(
-      `bibs?id=${itemLevelHoldsorCheckouts}&fields=default,varFields`
-    )
-    bibData.entries = bibData.entries.concat(bibLevelHolds)
+
+    const bibData = { entries: bibLevelHolds }
+    let itemLevelBibData
+    if (itemLevelHoldsorCheckouts.length) {
+      try {
+        itemLevelBibData = await this.client.get(
+          `bibs?id=${itemLevelHoldsorCheckouts}&fields=default,varFields`
+        )
+      } catch (e) {
+        throw `error getting bibs?id=${itemLevelHoldsorCheckouts}&fields=default,varFields`
+      }
+      bibData.entries = bibData.entries.concat(itemLevelBibData.entries)
+    }
     return bibData
   }
 

--- a/src/models/modelTests/MyAccount.test.ts
+++ b/src/models/modelTests/MyAccount.test.ts
@@ -248,5 +248,13 @@ describe("MyAccountModel", () => {
         entries: bibHolds.map((hold) => hold.record),
       })
     })
+    it("requests bib info for item level holds", async () => {
+      const fetchSpy = jest.fn().mockResolvedValue({ entries: [{ id: "123" }] })
+      const account = new MyAccount({ get: fetchSpy }, "1234567")
+
+      await account.fetchBibData(holds.entries, "record")
+
+      expect(fetchSpy).toHaveBeenCalled()
+    })
   })
 })

--- a/src/models/modelTests/MyAccount.test.ts
+++ b/src/models/modelTests/MyAccount.test.ts
@@ -15,7 +15,7 @@ import {
   checkoutBibs,
   empty,
 } from "../../../__test__/fixtures/rawSierraAccountData"
-import type { Hold } from "../../types/myAccountTypes"
+import type { Hold, SierraHold } from "../../types/myAccountTypes"
 
 describe("MyAccountModel", () => {
   const fetchBibs = MyAccount.prototype.fetchBibData
@@ -243,7 +243,10 @@ describe("MyAccountModel", () => {
     it("can handle bib level holds with no item level holds", async () => {
       const account = new MyAccount({ get: () => "spaghetti" }, "1234567")
       const bibHolds = holds.entries.filter((hold) => !hold.record.bibIds)
-      const processedBibHolds = await account.fetchBibData(bibHolds, "record")
+      const processedBibHolds = await account.fetchBibData(
+        bibHolds as SierraHold[],
+        "record"
+      )
       expect(processedBibHolds).toStrictEqual({
         entries: bibHolds.map((hold) => hold.record),
       })
@@ -252,7 +255,7 @@ describe("MyAccountModel", () => {
       const fetchSpy = jest.fn().mockResolvedValue({ entries: [{ id: "123" }] })
       const account = new MyAccount({ get: fetchSpy }, "1234567")
 
-      await account.fetchBibData(holds.entries, "record")
+      await account.fetchBibData(holds.entries as SierraHold[], "record")
 
       expect(fetchSpy).toHaveBeenCalled()
     })

--- a/src/models/modelTests/MyAccount.test.ts
+++ b/src/models/modelTests/MyAccount.test.ts
@@ -19,7 +19,7 @@ import type { Hold } from "../../types/myAccountTypes"
 
 describe("MyAccountModel", () => {
   const fetchBibs = MyAccount.prototype.fetchBibData
-  afterAll(() => {
+  afterEach(() => {
     MyAccount.prototype.fetchBibData = fetchBibs
   })
 
@@ -237,6 +237,16 @@ describe("MyAccountModel", () => {
       expect(patronWithFails.holds).not.toHaveLength(0)
       expect(patronWithFails.fines.total).toEqual(0)
       expect(patronWithFails.patron.name).toEqual("Strega Nonna")
+    })
+  })
+  describe("fetchBibData", () => {
+    it("can handle bib level holds with no item level holds", async () => {
+      const account = new MyAccount({ get: () => "spaghetti" }, "1234567")
+      const bibHolds = holds.entries.filter((hold) => !hold.record.bibIds)
+      const processedBibHolds = await account.fetchBibData(bibHolds, "record")
+      expect(processedBibHolds).toStrictEqual({
+        entries: bibHolds.map((hold) => hold.record),
+      })
     })
   })
 })


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4212](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4212)

## This PR does the following:

- Addresses bug where if there are only bib level holds, the requests construction errors.

## How has this been tested?

unit tests and removing requests so there are only bib holds left and verifying that the requests still display.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.


[SCC-4212]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ