### PR TITLE
SCC-4187 - Server render ItemTable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,8 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
+- Updated Bib Page to server-render the item table by default when accessed via the /all route (SCC-4187)
 - Created update patron settings functionality via the Settings tab in My Account. Currently only supports phone, email, and notification preference updates. (SCC-3928)
-
 - Extracted SearchResultsSort into its own component to render it in a different location on mobile.
 - No longer hiding the Item Location in the ItemTable on mobile.
 - Updated to DS v3.1.1 (as part of SCC-4090)

--- a/pages/bib/[id]/all.tsx
+++ b/pages/bib/[id]/all.tsx
@@ -8,7 +8,7 @@ export default BibPage
 export async function getServerSideProps({ params, query, req }) {
   const { id } = params
   const { discoveryBibResult, annotatedMarc, status, redirectUrl } =
-    await fetchBib(id, query)
+    await fetchBib(id, { ...query, view_all_items: true })
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
   const isAuthenticated = patronTokenResponse.isTokenValid
 

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -92,14 +92,6 @@ export default function BibPage({
     ? bib.numItemsMatched
     : bib.numPhysicalItems
 
-  // Load all items via client-side fetch if page is first loaded with viewAllItems prop passed in
-  // Namely, when the page is accessed with the /all route
-  useEffect(() => {
-    if (viewAllItems) void refreshItemTable(query, true)
-    // Disable eslint exhaustive-deps rule because we only want this to run once on page load
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   const refreshItemTable = async (
     newQuery: BibQueryParams,
     viewAllItems = false


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4187](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4187)

## This PR does the following:

- Removes the useEffect that was initializing the client-side fetch on first render.
- Passes the view_all_item query param in the server side fetch in the /all page component.

## How has this been tested?

- Tested locally, not sure if we need unit tests since server-rendering should be the default.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4187]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ