### PR TITLE
Add launch profile for debugging in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Debug in Chrome",
+      "url": "http://local.nypl.org:8080/research/research-catalog",
+      "webRoot": "${workspaceFolder}",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## This PR does the following:

- Launch profile for debugging Next apps in VSCode, very convenient way to inspect variables with breakpoints instead of using console.log.
