### PR TITLE
timer fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Pre release
+
+### Updated
+
+- Fix timed logout modal negative countdown
+
 ## [1.2.0] 2024-08-07
 
 ### Added

--- a/src/components/MyAccount/TimedLogoutModal.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.tsx
@@ -55,10 +55,7 @@ const TimedLogoutModal = ({
     }
   })
 
-  // Theoretically, accountPageExp should disappear after 5mins, causing
-  // logOutAndRedirect() to be fired above, but let's make sure a failure
-  // there never allows the timer to pass zero:
-  if (timeUntilExpiration.minutes === 0 && timeUntilExpiration.seconds === 0) {
+  if (timeUntilExpiration.minutes <= 0 && timeUntilExpiration.seconds <= 0) {
     logOutAndRedirect()
   }
   if (!open) return null

--- a/src/components/MyAccount/TimedLogoutModal.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.tsx
@@ -41,6 +41,13 @@ const TimedLogoutModal = ({
     buildTimeLeft(expirationTime)
   )
 
+  if (
+    typeof document !== "undefined" &&
+    !document.cookie.includes("accountPageExp")
+  ) {
+    logOutAndRedirect()
+  }
+
   useEffect(() => {
     const timeout = setTimeout(() => {
       const { minutes, seconds } = buildTimeLeft(expirationTime)

--- a/src/components/MyAccount/TimedLogoutModal.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.tsx
@@ -41,12 +41,12 @@ const TimedLogoutModal = ({
     buildTimeLeft(expirationTime)
   )
 
-  if (
-    typeof document !== "undefined" &&
-    !document.cookie.includes("accountPageExp")
-  ) {
-    logOutAndRedirect()
-  }
+  // if (
+  //   typeof document !== "undefined" &&
+  //   !document.cookie.includes("accountPageExp")
+  // ) {
+  //   logOutAndRedirect()
+  // }
 
   useEffect(() => {
     const timeout = setTimeout(() => {


### PR DESCRIPTION
Leaving logout tab open in the background (on your phone or when your computer is asleep) doesn't trigger the auto logout. This corrects this behavior. I tested it by opening my account, closing my laptop, and returning to the browser after 6 minutes.
Adds:
- a <= instead of === for the timeout check