### PR TITLE
SCC-4234 - VQA Accessibility Issues

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed some accessibility issues including making Requeset button titles more specific and fixing a layout issue on zoom. (SCC-4234)
+- Fixed some accessibility issues including making Request button titles more specific and fixing a layout issue on zoom. (SCC-4234)
 
 ## [1.2.2] 2024-08-14
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ElectronicResources component (SCC-4227)
 - Added check for hasElectronicResources in Bib Page before rendering ElectronicResources (SCC-4227).
 
+### Fixed
+
+- Fixed some accessibility issues including making Requeset button titles more specific and fixing a layout issue on zoom. (SCC-4234)
+
 ## [1.2.2] 2024-08-14
 
 ### Updated

--- a/src/components/ItemFilters/ItemFilters.tsx
+++ b/src/components/ItemFilters/ItemFilters.tsx
@@ -109,7 +109,7 @@ const ItemFilters = ({
           labelText="Filter by"
           renderMultiSelect={renderMultiSelect}
         />
-        <Box minWidth="440">
+        <Box minWidth={{ md: 440 }}>
           <Label id="year-filter-label" htmlFor="searchbar-form-year-filter">
             Search by Year
           </Label>

--- a/src/components/ItemTable/RequestButtons.test.tsx
+++ b/src/components/ItemTable/RequestButtons.test.tsx
@@ -18,7 +18,7 @@ describe("RequestButtons", () => {
     render(<RequestButtons item={item} />)
     expect(
       screen.getByRole("link", {
-        name: "Request Appointment, A history of spaghetti eating and cooking for: spaghetti dinner.",
+        name: "Request Appointment, A history of spaghetti eating and cooking for: spaghetti dinner., no. 4 (2001)",
       })
     ).toHaveAttribute(
       "href",

--- a/src/components/ItemTable/RequestButtons.tsx
+++ b/src/components/ItemTable/RequestButtons.tsx
@@ -20,7 +20,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
         <ExternalLink
           href={item.aeonUrl}
           type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-          aria-label={`Request Appointment, ${item.bibTitle}`}
+          aria-label={`Request Appointment, ${item.requestTitle}`}
           disabled={!item.isAvailable}
           mb="s"
           target="_self"
@@ -33,7 +33,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
             <RCLink
               href={`/hold/request/${item.bibId}-${item.id}`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-              aria-label={`Request for On-site Use, ${item.bibTitle}`}
+              aria-label={`Request for On-site Use, ${item.requestTitle}`}
               disabled={!item.isAvailable}
               mb="s"
               target="_self"
@@ -45,7 +45,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
             <RCLink
               href={`/hold/request/${item.bibId}-${item.id}/edd`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-              aria-label={`Request Scan, ${item.bibTitle}`}
+              aria-label={`Request Scan, ${item.requestTitle}`}
               disabled={!item.isAvailable}
               mb="s"
               target="_self"

--- a/src/components/ItemTable/RequestButtons.tsx
+++ b/src/components/ItemTable/RequestButtons.tsx
@@ -20,7 +20,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
         <ExternalLink
           href={item.aeonUrl}
           type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-          aria-label={`Request Appointment, ${item.requestTitle}`}
+          aria-label={`Request Appointment, ${item.requestButtonAriaLabel}`}
           disabled={!item.isAvailable}
           mb="s"
           target="_self"
@@ -33,7 +33,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
             <RCLink
               href={`/hold/request/${item.bibId}-${item.id}`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-              aria-label={`Request for On-site Use, ${item.requestTitle}`}
+              aria-label={`Request for On-site Use, ${item.requestButtonAriaLabel}`}
               disabled={!item.isAvailable}
               mb="s"
               target="_self"
@@ -45,7 +45,7 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
             <RCLink
               href={`/hold/request/${item.bibId}-${item.id}/edd`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-              aria-label={`Request Scan, ${item.requestTitle}`}
+              aria-label={`Request Scan, ${item.requestButtonAriaLabel}`}
               disabled={!item.isAvailable}
               mb="s"
               target="_self"

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -45,6 +45,9 @@ const Layout = ({
   return (
     <DSProvider>
       <TemplateAppContainer
+        // This is a workaround to fix a text-wrapping issue when zoomed to 400%
+        // TODO: Address this issue in the DS
+        sx={{ "main > div": { maxWidth: "100vw", gridColumnEnd: "none" } }}
         breakout={
           showHeader && (
             <>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -45,7 +45,7 @@ const Layout = ({
   return (
     <DSProvider>
       <TemplateAppContainer
-        // This is a workaround to fix a text-wrapping issue when zoomed to 400%
+        // This is a workaround to fix a text-wrapping issue when page is zoomed in on
         // TODO: Address this issue in the DS
         sx={{ "main > div": { maxWidth: "100vw", gridColumnEnd: "none" } }}
         breakout={

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -64,7 +64,7 @@ export default class Item {
     return itemAvailableIds.includes(this?.status?.["@id"]) || false
   }
 
-  get requestTitle(): string {
+  get requestButtonAriaLabel(): string {
     return `${this.bibTitle}${this.volume ? `, ${this.volume}` : ""}`
   }
 

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -64,6 +64,10 @@ export default class Item {
     return itemAvailableIds.includes(this?.status?.["@id"]) || false
   }
 
+  get requestTitle(): string {
+    return `${this.bibTitle}${this.volume ? `, ${this.volume}` : ""}`
+  }
+
   get isReCAP(): boolean {
     return this.isPartnerReCAP() || this.isNYPLReCAP()
   }

--- a/src/models/modelTests/Item.test.ts
+++ b/src/models/modelTests/Item.test.ts
@@ -95,12 +95,12 @@ describe("Item model", () => {
       expect(unavailableItem.isAvailable).toBe(false)
     })
 
-    it("formats a title for the request buttons that includes the bib title and the volume if available", () => {
-      expect(item.requestTitle).toBe(
+    it("formats an aria label for the request buttons that includes the bib title and the volume if available", () => {
+      expect(item.requestButtonAriaLabel).toBe(
         "A history of spaghetti eating and cooking for: spaghetti dinner., no. 4 (2001)"
       )
       const itemWithoutVolume = new Item(itemUnavailable, parentBib)
-      expect(itemWithoutVolume.requestTitle).toBe(
+      expect(itemWithoutVolume.requestButtonAriaLabel).toBe(
         "A history of spaghetti eating and cooking for: spaghetti dinner."
       )
     })

--- a/src/models/modelTests/Item.test.ts
+++ b/src/models/modelTests/Item.test.ts
@@ -84,7 +84,7 @@ describe("Item model", () => {
     })
   })
 
-  describe("isAvailable", () => {
+  describe("Getter functions", () => {
     it("determines if an item is available based on the status label", () => {
       expect(item.isAvailable).toBe(true)
 
@@ -93,6 +93,16 @@ describe("Item model", () => {
 
       const unavailableItem = new Item(itemUnavailable, parentBib)
       expect(unavailableItem.isAvailable).toBe(false)
+    })
+
+    it("formats a title for the request buttons that includes the bib title and the volume if available", () => {
+      expect(item.requestTitle).toBe(
+        "A history of spaghetti eating and cooking for: spaghetti dinner., no. 4 (2001)"
+      )
+      const itemWithoutVolume = new Item(itemUnavailable, parentBib)
+      expect(itemWithoutVolume.requestTitle).toBe(
+        "A history of spaghetti eating and cooking for: spaghetti dinner."
+      )
     })
   })
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4234](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4234)

## This PR does the following:

- Fixes issues 3 and 4 from Clare's accessibility VQA doc. Added additional info about 1 & 2 in the ticket.
- Adds a getter to Item model for Request button titles that includes the volume if present.
- Adds a styling override to Layout.tsx that addresses the test wrapping on zoom.

## How has this been tested?

- Added a unit test for the request button text

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4234]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ