### PR TITLE
Scc 4233/add username to account header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added ElectronicResources component (SCC-4227)
 - Added check for hasElectronicResources in Bib Page before rendering ElectronicResources (SCC-4227).
+- Add username to account profile header ([SCC-4233](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4233))
 
 ## [1.2.2] 2024-08-14
 

--- a/__test__/fixtures/processedMyAccountData.ts
+++ b/__test__/fixtures/processedMyAccountData.ts
@@ -317,7 +317,7 @@ export const filteredPickupLocations = [
 
 export const processedPatron = {
   notificationPreference: "z",
-  username: "spaghettimaster",
+  username: "pastadisciple",
   name: "Strega Nonna",
   barcode: "23333121538324",
   formattedBarcode: "2 3333 12153 8324",

--- a/__test__/fixtures/processedMyAccountData.ts
+++ b/__test__/fixtures/processedMyAccountData.ts
@@ -317,6 +317,7 @@ export const filteredPickupLocations = [
 
 export const processedPatron = {
   notificationPreference: "z",
+  username: "spaghettimaster",
   name: "Strega Nonna",
   barcode: "23333121538324",
   formattedBarcode: "2 3333 12153 8324",

--- a/__test__/fixtures/rawSierraAccountData.ts
+++ b/__test__/fixtures/rawSierraAccountData.ts
@@ -1960,7 +1960,7 @@ export const patron = {
       type: "t",
     },
   ],
-  varFields: [{ fieldTag: "u", content: "spaghettimaster" }],
+  varFields: [{ fieldTag: "u", content: "pastadisciple" }],
   fixedFields: {
     "268": { label: "notification preference", value: "z" } as FixedField,
   },

--- a/__test__/fixtures/rawSierraAccountData.ts
+++ b/__test__/fixtures/rawSierraAccountData.ts
@@ -1960,6 +1960,7 @@ export const patron = {
       type: "t",
     },
   ],
+  varFields: [{ fieldTag: "u", content: "spaghettimaster" }],
   fixedFields: {
     "268": { label: "notification preference", value: "z" } as FixedField,
   },

--- a/__test__/pages/account/account.test.tsx
+++ b/__test__/pages/account/account.test.tsx
@@ -232,7 +232,7 @@ describe("MyAccount page", () => {
     expect(result.props.tabsPath).toBe("overdues")
   })
   it("can handle no username", () => {
-    const component = render(
+    render(
       <MyAccount
         isAuthenticated={true}
         accountData={{
@@ -244,7 +244,8 @@ describe("MyAccount page", () => {
         }}
       />
     )
-    expect(component.baseElement).toBeInTheDocument()
+    const username = screen.queryByText("Username")
+    expect(username).toBeNull()
   })
   it("renders notification banner if user has fines", () => {
     render(

--- a/__test__/pages/account/account.test.tsx
+++ b/__test__/pages/account/account.test.tsx
@@ -231,6 +231,21 @@ describe("MyAccount page", () => {
     const result = await getServerSideProps({ req: req, res: mockRes })
     expect(result.props.tabsPath).toBe("overdues")
   })
+  it("can handle no username", () => {
+    const component = render(
+      <MyAccount
+        isAuthenticated={true}
+        accountData={{
+          checkouts: processedCheckouts,
+          holds: processedHolds,
+          patron: { ...processedPatron, username: undefined },
+          fines: processedFines,
+          pickupLocations: filteredPickupLocations,
+        }}
+      />
+    )
+    expect(component.baseElement).toBeInTheDocument()
+  })
   it("renders notification banner if user has fines", () => {
     render(
       <MyAccount

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -18,6 +18,11 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
     [
       { icon: "actionIdentityFilled", term: "Name", description: patron.name },
       {
+        icon: "actionIdentity",
+        term: "Username",
+        description: patron.username,
+      },
+      {
         icon: "actionPayment",
         term: "Card number",
         description: patron.formattedBarcode,

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -48,7 +48,9 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
         description: patron.expirationDate,
       },
     ] as IconListElementPropType[]
-  ).map(buildListElementsWithIcons)
+  )
+    .filter((data) => data.description)
+    .map(buildListElementsWithIcons)
 
   return (
     <List

--- a/src/models/MyAccount.ts
+++ b/src/models/MyAccount.ts
@@ -76,7 +76,7 @@ export default class MyAccount {
 
   async fetchPatron() {
     return await this.client.get(
-      `${this.baseQuery}?fields=names,barcodes,expirationDate,homeLibrary,emails,phones,fixedFields`
+      `${this.baseQuery}?fields=names,barcodes,expirationDate,homeLibrary,emails,phones,fixedFields,varFields`
     )
   }
 

--- a/src/models/modelTests/MyAccount.test.ts
+++ b/src/models/modelTests/MyAccount.test.ts
@@ -193,13 +193,14 @@ describe("MyAccountModel", () => {
       expect(account.checkouts).toStrictEqual(processedCheckouts)
       expect(account.fines).toStrictEqual(processedFines)
     })
-    it("builds empty Account data model with empty phones and email", async () => {
+    it("builds empty Account data model with empty phones, email, username", async () => {
       MyAccount.prototype.fetchCheckouts = async () => empty
       MyAccount.prototype.fetchHolds = async () => empty
       MyAccount.prototype.fetchPatron = async () => ({
         ...patron,
         phones: [],
         emails: [],
+        varFields: [{ fieldtag: "not u", content: "irrelevant" }],
       })
       MyAccount.prototype.fetchFines = async () => ({ total: 0, entries: [] })
       MyAccount.prototype.fetchBibData = async () => ({ total: 0, entries: [] })

--- a/src/types/myAccountTypes.ts
+++ b/src/types/myAccountTypes.ts
@@ -74,8 +74,10 @@ export interface SierraRecord {
 }
 
 export type FixedField = { label: string; value: "z" | "p" }
+export type VarField = { fieldTag: string; content: string }
 
 export interface SierraPatron {
+  varFields?: VarField[]
   fixedFields?: Record<"268", FixedField>
   id?: number
   names?: string[]
@@ -120,6 +122,7 @@ export interface Hold {
 }
 
 export interface Patron {
+  username?: string
   notificationPreference: "z" | "p"
   name: string
   barcode: string

--- a/src/utils/myAccountUtils.ts
+++ b/src/utils/myAccountUtils.ts
@@ -52,7 +52,10 @@ export function formatDate(date: string | number | Date) {
 // importing the MyAccount files.
 export const buildPatron = (patron: SierraPatron): Patron => {
   const notificationPreference = patron.fixedFields?.["268"].value
-  return {
+  const username = patron.varFields?.find(
+    (field) => field.fieldTag === "u" && field.content.length
+  )?.content
+  const processedPatron = {
     notificationPreference,
     name: formatPatronName(patron.names?.[0]),
     barcode: patron.barcodes?.[0],
@@ -65,5 +68,7 @@ export const buildPatron = (patron: SierraPatron): Patron => {
     phones: patron.phones || [],
     homeLibrary: patron.homeLibrary || null,
     id: patron.id,
-  }
+  } as Patron
+  if (username) processedPatron.username = username
+  return processedPatron
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4233](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4233)

## This PR does the following:

- Fetches username from sierra
- displays username

## How has this been tested?

Updated unit tests and verified that usernames display. I don't have a patron account on hand with no username, so if anyone has one, that would be good to check!

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4233]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ