### PR TITLE
SCC-4235 - VQA Styling / Copy Fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ElectronicResources component (SCC-4227)
 - Added check for hasElectronicResources in Bib Page before rendering ElectronicResources (SCC-4227).
 
+### Fixed
+
+- Fixed visual and copy issues found in VQA (SCC-4235)
+
 ## [1.2.2] 2024-08-14
 
 ### Updated

--- a/__test__/pages/bib/bibPage.test.tsx
+++ b/__test__/pages/bib/bibPage.test.tsx
@@ -44,8 +44,9 @@ describe("Bib Page with items", () => {
     expect(screen.getByTestId("bib-details-item-table")).toBeInTheDocument()
   })
 
+  // TODO: Determine if this should be rendering twice
   it("renders the bottom bib details", () => {
-    expect(screen.getByTestId("publication-date")).toHaveTextContent(
+    expect(screen.getAllByTestId("publication-date")[0]).toHaveTextContent(
       "Vol. 1, issue 1-"
     )
     expect(screen.getByTestId("description")).toHaveTextContent(
@@ -246,7 +247,7 @@ describe("Bib Page Item Table", () => {
   })
 
   it("renders a view all button when there are more than 20 items and updates the url to /all when clicked", async () => {
-    const viewAllLink = screen.getByText("View All 26 Items").closest("a")
+    const viewAllLink = screen.getByText("View all 26 items").closest("a")
     expect(viewAllLink).toHaveAttribute(
       "href",
       "/research/research-catalog/bib/pb5579193/all"
@@ -269,7 +270,7 @@ describe("Bib Page Item Table", () => {
           }),
       })
     )
-    await userEvent.click(screen.getByText("View All 26 Items").closest("a"))
+    await userEvent.click(screen.getByText("View all 26 items").closest("a"))
     expect(screen.getByText("View fewer items")).toBeInTheDocument()
     expect(screen.getByTestId("bib-details-item-table")).toBeInTheDocument()
   })
@@ -281,7 +282,7 @@ describe("Bib Page Item Table", () => {
           setTimeout(resolve, 50)
         })
     )
-    await userEvent.click(screen.getByText("View All 26 Items").closest("a"))
+    await userEvent.click(screen.getByText("View all 26 items").closest("a"))
     expect(
       screen.getByText("Loading all 26 items. This may take a few moments...")
     ).toBeInTheDocument()
@@ -294,7 +295,7 @@ describe("Bib Page Item Table", () => {
         ok: false,
       })
     )
-    await userEvent.click(screen.getByText("View All 26 Items").closest("a"))
+    await userEvent.click(screen.getByText("View all 26 items").closest("a"))
     expect(
       screen.getByText(
         "There was an error fetching items. Please try again with a different query."

--- a/discoveryApiResearchNowMapping.md
+++ b/discoveryApiResearchNowMapping.md
@@ -131,7 +131,7 @@ e.g. `filters`) is used for the parameters the respective APIs except.
 | <ul>'Language'                                | <ul>`filters[language]`                               | <ul>`filters` `language`                        |
 | _Filters linked to from a bib page_           |
 | <ul>'Author'                                  | <ul>`filters[creatorLiteral]`                         | <ul>`queries` `"field":"author"`                |
-| <ul>'Additional Authors'                      | <ul>`filters[creatorLiteral]`                         | <ul>`queries` `"field":"author"`                |
+| <ul>'Additional authors'                      | <ul>`filters[creatorLiteral]`                         | <ul>`queries` `"field":"author"`                |
 | <ul>'Subject'                                 | <ul>`filters[subjectLiteral]`                         | <ul>`queries` `"field":"subject"`               |
 | _Pagination_                                  | `page`                                                | `page`                                          |
 |                                               | `per_page`                                            | `per_page`                                      |

--- a/src/components/BibPage/ElectronicResources.test.tsx
+++ b/src/components/BibPage/ElectronicResources.test.tsx
@@ -19,7 +19,7 @@ describe("ElectronicResources component", () => {
     })
 
     it("renders the correct heading", () => {
-      expect(screen.queryByText("Available Online")).toBeInTheDocument()
+      expect(screen.queryByText("Available online")).toBeInTheDocument()
     })
 
     it("renders 3 links and a View All button when there are more than 3 eResources", () => {
@@ -32,7 +32,7 @@ describe("ElectronicResources component", () => {
       const moreLink = screen.queryByTestId("see-more-eresources-button")
       expect(moreLink).toBeInTheDocument()
       expect(moreLink).toHaveTextContent(
-        "View all 368 Available Online resources"
+        "View all 368 available online resources"
       )
     })
 
@@ -46,7 +46,7 @@ describe("ElectronicResources component", () => {
 
       expect(eResourcesList.children).toHaveLength(368)
       expect(moreLink).toHaveTextContent(
-        "View fewer Available Online resources"
+        "View fewer available online resources"
       )
     })
   })
@@ -60,7 +60,7 @@ describe("ElectronicResources component", () => {
     })
 
     it("renders the correct heading", () => {
-      expect(screen.queryByText("Available Online")).toBeInTheDocument()
+      expect(screen.queryByText("Available online")).toBeInTheDocument()
     })
 
     it("renders all eResources and does not display a View All button", () => {

--- a/src/components/BibPage/ElectronicResources.tsx
+++ b/src/components/BibPage/ElectronicResources.tsx
@@ -54,7 +54,7 @@ const ElectronicResources = ({
       mt="l"
       data-testid="electronic-resources"
     >
-      <CardHeading level="three">Available Online</CardHeading>
+      <CardHeading level="three">Available online</CardHeading>
       <CardContent aria-expanded={!showMore}>
         <List
           type="ul"
@@ -83,7 +83,7 @@ const ElectronicResources = ({
             fontWeight="bold"
           >
             View {showMore ? `all ${electronicResources.length}` : "fewer"}{" "}
-            Available Online resources
+            available online resources
             <Icon
               ml="xs"
               iconRotation={`rotate${showMore ? 0 : 180}`}

--- a/src/components/BibPage/ElectronicResources.tsx
+++ b/src/components/BibPage/ElectronicResources.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   List,
   Box,
+  Text,
 } from "@nypl/design-system-react-components"
 
 import { ELECTRONIC_RESOURCES_PER_BIB_PAGE } from "../../config/constants"
@@ -54,19 +55,24 @@ const ElectronicResources = ({
       mt="l"
       data-testid="electronic-resources"
     >
-      <CardHeading level="three">Available online</CardHeading>
+      <CardHeading level="three" size="body1" mb="s">
+        Available online
+      </CardHeading>
       <CardContent aria-expanded={!showMore}>
         <List
           type="ul"
           noStyling
-          m={0}
+          mb="s"
           listItems={electronicResourcesToDisplay.map((resource) => (
-            <ExternalLink
-              href={resource.url}
-              py="x"
-              key={kebabCase(resource.title)}
-            >
-              <Box as="span" display="inline-block" my="xxs">
+            <ExternalLink href={resource.url} key={kebabCase(resource.title)}>
+              <Box
+                as="span"
+                display="inline-block"
+                fontSize={{
+                  base: "mobile.body.body2",
+                  md: "desktop.body.body2",
+                }}
+              >
                 {resource.title || resource.prefLabel || resource.url}
               </Box>
             </ExternalLink>
@@ -81,6 +87,7 @@ const ElectronicResources = ({
             buttonType="link"
             aria-expanded={!showMore}
             fontWeight="bold"
+            sx={{ textDecoration: "none", height: "auto" }}
           >
             View {showMore ? `all ${electronicResources.length}` : "fewer"}{" "}
             available online resources

--- a/src/components/ItemFilters/ItemFilters.test.tsx
+++ b/src/components/ItemFilters/ItemFilters.test.tsx
@@ -37,11 +37,11 @@ describe("ItemFilters", () => {
   })
 
   it("renders the year search form", async () => {
-    expect(screen.getByLabelText("Search by Year")).toBeInTheDocument()
+    expect(screen.getByLabelText("Search by year")).toBeInTheDocument()
   })
 
   it("closes open filters when user clicks outside of the filter", async () => {
-    const outsideOfTheFilter = screen.getByLabelText("Search by Year")
+    const outsideOfTheFilter = screen.getByLabelText("Search by year")
 
     const locationFilterButton = screen
       .getByTestId("location-multi-select")

--- a/src/components/ItemFilters/ItemFilters.test.tsx
+++ b/src/components/ItemFilters/ItemFilters.test.tsx
@@ -67,7 +67,7 @@ describe("ItemFilters", () => {
   })
 
   it("renders TagSet data when filters are applied and removes the filter when tag is clicked", async () => {
-    expect(screen.queryByText("Filters Applied")).toBeInTheDocument()
+    expect(screen.queryByText("Active filters")).toBeInTheDocument()
     await userEvent.click(
       screen.getByLabelText("Location > Offsite, click to remove filter")
     )

--- a/src/components/ItemFilters/ItemFilters.tsx
+++ b/src/components/ItemFilters/ItemFilters.tsx
@@ -75,6 +75,7 @@ const ItemFilters = ({
     if (id === "clear-filters") {
       await clearAllFilters()
     } else {
+      setYear("")
       const [newValues, field] = removeValueFromFilters(id, appliedFilters)
       await submitFilters(newValues, field)
     }

--- a/src/components/ItemFilters/ItemFilters.tsx
+++ b/src/components/ItemFilters/ItemFilters.tsx
@@ -181,7 +181,7 @@ const ItemFilters = ({
             lineHeight={2}
             display="table-cell"
           >
-            Filters Applied
+            Active filters
           </Text>
           <TagSet
             id="bib-details-applied-filters"

--- a/src/components/ItemFilters/ItemFilters.tsx
+++ b/src/components/ItemFilters/ItemFilters.tsx
@@ -111,7 +111,7 @@ const ItemFilters = ({
         />
         <Box minWidth="440">
           <Label id="year-filter-label" htmlFor="searchbar-form-year-filter">
-            Search by Year
+            Search by year
           </Label>
           <SearchBar
             id="year-filter"
@@ -121,7 +121,7 @@ const ItemFilters = ({
             textInputProps={{
               placeholder: "YYYY",
               isClearable: true,
-              labelText: "Search by year",
+              labelText: "Search by year form input",
               name: "year-filter",
               value: year,
               onChange: ({ target }) => setYear(target.value),

--- a/src/components/ItemTable/ItemAvailability.tsx
+++ b/src/components/ItemTable/ItemAvailability.tsx
@@ -36,7 +36,13 @@ const ItemAvailability = ({ item }: ItemAvailabilityProps) => {
       )
     } else if (item.aeonUrl && item.location?.endpoint) {
       return (
-        <Text mb="0">
+        <Text
+          mb="0"
+          fontSize={{
+            base: "mobile.body.body2",
+            md: "desktop.body.body2",
+          }}
+        >
           <Box as="span" color="ui.success.primary">
             Available by appointment
           </Box>
@@ -56,7 +62,13 @@ const ItemAvailability = ({ item }: ItemAvailabilityProps) => {
       // Available Onsite item
       const locationShort = item.location.prefLabel.split("-")[0]
       return (
-        <Text mb="0">
+        <Text
+          mb="0"
+          fontSize={{
+            base: "mobile.body.body2",
+            md: "desktop.body.body2",
+          }}
+        >
           <Box as="span" color="ui.success.primary">
             Available
           </Box>
@@ -73,7 +85,13 @@ const ItemAvailability = ({ item }: ItemAvailabilityProps) => {
   } else {
     // Not available
     return (
-      <Text mb="0">
+      <Text
+        mb="0"
+        fontSize={{
+          base: "mobile.body.body2",
+          md: "desktop.body.body2",
+        }}
+      >
         <Box as="span" color="ui.warning.tertiary">
           Not available
         </Box>

--- a/src/components/ItemTable/ItemTableCell.tsx
+++ b/src/components/ItemTable/ItemTableCell.tsx
@@ -1,0 +1,23 @@
+import { Text } from "@nypl/design-system-react-components"
+
+/**
+ * The ItemTableCell component renders a table cell for the ItemTable
+ *
+ * Its extraction into a separate component allows for styling and other overrides on plain text cells
+ * when rendered programatically in the ItemTableData class
+ */
+const ItemTableCell = ({ children }) => {
+  return (
+    <Text
+      fontSize={{
+        base: "mobile.body.body2",
+        md: "desktop.body.body2",
+      }}
+      noSpace
+    >
+      {children}
+    </Text>
+  )
+}
+
+export default ItemTableCell

--- a/src/components/ItemTable/ItemTableCell.tsx
+++ b/src/components/ItemTable/ItemTableCell.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@nypl/design-system-react-components"
+import { Box } from "@nypl/design-system-react-components"
 
 /**
  * The ItemTableCell component renders a table cell for the ItemTable
@@ -8,15 +8,15 @@ import { Text } from "@nypl/design-system-react-components"
  */
 const ItemTableCell = ({ children }) => {
   return (
-    <Text
+    <Box
+      as="span"
       fontSize={{
         base: "mobile.body.body2",
         md: "desktop.body.body2",
       }}
-      noSpace
     >
       {children}
-    </Text>
+    </Box>
   )
 }
 

--- a/src/components/ItemTable/ItemTableControls.tsx
+++ b/src/components/ItemTable/ItemTableControls.tsx
@@ -105,7 +105,7 @@ const ItemTableControls = ({
               <Box as="span" mr="xxs">
                 {viewAllExpanded
                   ? "View fewer items"
-                  : `View All ${bib.getNumItemsMessage(filtersAreApplied)}`}
+                  : `View all ${bib.getNumItemsMessage(filtersAreApplied)}`}
               </Box>
               <Icon
                 iconRotation={viewAllExpanded ? "rotate180" : "rotate0"}

--- a/src/components/ItemTable/RequestButtons.test.tsx
+++ b/src/components/ItemTable/RequestButtons.test.tsx
@@ -18,7 +18,7 @@ describe("RequestButtons", () => {
     render(<RequestButtons item={item} />)
     expect(
       screen.getByRole("link", {
-        name: "Request Appointment, A history of spaghetti eating and cooking for: spaghetti dinner.",
+        name: "Request appointment, A history of spaghetti eating and cooking for: spaghetti dinner.",
       })
     ).toHaveAttribute(
       "href",
@@ -42,7 +42,7 @@ describe("RequestButtons", () => {
     render(<RequestButtons item={item} />)
     expect(
       screen.getByRole("link", {
-        name: "Request Scan, A history of spaghetti eating and cooking for: spaghetti dinner.",
+        name: "Request scan, A history of spaghetti eating and cooking for: spaghetti dinner.",
       })
     ).toHaveAttribute(
       "href",

--- a/src/components/ItemTable/RequestButtons.test.tsx
+++ b/src/components/ItemTable/RequestButtons.test.tsx
@@ -30,7 +30,7 @@ describe("RequestButtons", () => {
     render(<RequestButtons item={item} />)
     expect(
       screen.getByRole("link", {
-        name: "Request for On-site Use, A history of spaghetti eating and cooking for: spaghetti dinner.",
+        name: "Request for on-site use, A history of spaghetti eating and cooking for: spaghetti dinner.",
       })
     ).toHaveAttribute(
       "href",

--- a/src/components/ItemTable/RequestButtons.tsx
+++ b/src/components/ItemTable/RequestButtons.tsx
@@ -33,12 +33,12 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
             <RCLink
               href={`/hold/request/${item.bibId}-${item.id}`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-              aria-label={`Request for On-site Use, ${item.bibTitle}`}
+              aria-label={`Request for on-site use, ${item.bibTitle}`}
               disabled={!item.isAvailable}
               mb="s"
               target="_self"
             >
-              Request for On-site Use
+              Request for on-site use
             </RCLink>
           )}
           {item.isEDDRequestable && (

--- a/src/components/ItemTable/RequestButtons.tsx
+++ b/src/components/ItemTable/RequestButtons.tsx
@@ -45,12 +45,12 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
             <RCLink
               href={`/hold/request/${item.bibId}-${item.id}/edd`}
               type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-              aria-label={`Request Scan, ${item.bibTitle}`}
+              aria-label={`Request scan, ${item.bibTitle}`}
               disabled={!item.isAvailable}
               mb="s"
               target="_self"
             >
-              Request Scan
+              Request scan
             </RCLink>
           )}
         </>

--- a/src/components/ItemTable/RequestButtons.tsx
+++ b/src/components/ItemTable/RequestButtons.tsx
@@ -20,12 +20,12 @@ const RequestButtons = ({ item }: RequestButtonsProps) => {
         <ExternalLink
           href={item.aeonUrl}
           type={!item.isAvailable ? "buttonDisabled" : "buttonSecondary"}
-          aria-label={`Request Appointment, ${item.bibTitle}`}
+          aria-label={`Request appointment, ${item.bibTitle}`}
           disabled={!item.isAvailable}
           mb="s"
           target="_self"
         >
-          Request Appointment
+          Request appointment
         </ExternalLink>
       ) : (
         <>

--- a/src/components/SearchResults/ElectronicResourcesLink.test.tsx
+++ b/src/components/SearchResults/ElectronicResourcesLink.test.tsx
@@ -20,7 +20,7 @@ describe("Electronic Resources Link with a single resource", () => {
   })
 
   it("renders the correct heading", async () => {
-    expect(screen.getByText("Available Online")).toBeInTheDocument()
+    expect(screen.getByText("Available online")).toBeInTheDocument()
   })
   it("renders the correct link with the label as the text when only one electronic resource is available", async () => {
     const link = screen.getByRole("link", {

--- a/src/components/SearchResults/ElectronicResourcesLink.tsx
+++ b/src/components/SearchResults/ElectronicResourcesLink.tsx
@@ -30,7 +30,7 @@ const ElectronicResourcesLink = ({
         fontSize={{ base: "mobile.body.body1", md: "desktop.body.body1" }}
         fontWeight="bold"
       >
-        Available Online
+        Available online
       </Text>
       {electronicResources.length === 1 ? (
         <ExternalLink

--- a/src/components/SearchResults/SearchResult.test.tsx
+++ b/src/components/SearchResults/SearchResult.test.tsx
@@ -27,7 +27,7 @@ describe("SearchResult with Physical Items", () => {
     screen.getByText("Material")
     screen.getByText("New York, Abelard-Schuman [1955]")
     screen.getByText("1955")
-    screen.getByText("2 Items")
+    screen.getByText("2 items")
   })
 })
 
@@ -41,7 +41,7 @@ describe("SearchResult with Many Physical Items", () => {
 
   it("renders a link to the bib page with the correct text when there are more than the set limit of items per search result", async () => {
     const resultTitleLink = screen.getByRole("link", {
-      name: "View All 4 Items",
+      name: "View all 4 items",
     })
     expect(resultTitleLink).toHaveAttribute(
       "href",
@@ -54,6 +54,6 @@ describe("SearchResult with Electronic Resources", () => {
   it("renders the correct item message for bib with electronic resources", async () => {
     const bib = new SearchResultsBib(searchResultElectronicResources)
     render(<SearchResult bib={bib} />)
-    screen.getByText("1 Resource")
+    screen.getByText("1 resource")
   })
 })

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -72,7 +72,7 @@ const SearchResult = ({ bib }: SearchResultProps) => {
                     fontWeight="medium"
                     type="standalone"
                   >
-                    {`View All ${bib.getNumItemsMessage()} `}
+                    {`View all ${bib.getNumItemsMessage()} `}
                   </RCLink>
                 </CardActions>
               )}

--- a/src/models/Bib.ts
+++ b/src/models/Bib.ts
@@ -94,9 +94,9 @@ export default class Bib {
 
   getNumItemsMessage(filtersAreApplied = false) {
     const totalItems = filtersAreApplied ? this.numItemsMatched : this.numItems
-    return `${totalItems} ${filtersAreApplied ? "matching " : ""}${
-      this.resourceType
-    }${totalItems !== 1 ? "s" : ""}`
+    return `${totalItems} ${
+      filtersAreApplied ? "matching " : ""
+    }${this.resourceType.toLowerCase()}${totalItems !== 1 ? "s" : ""}`
   }
 
   getItemsViewAllLoadingMessage(filtersAreApplied = false) {

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -125,7 +125,7 @@ export default class BibDetails {
         else if (fieldMapping.field === "extent") detail = this.extent
         else if (fieldMapping.field === "owner")
           detail = this.bib.owner && {
-            label: fieldMapping.label,
+            label: convertToSentenceCase(fieldMapping.label),
             value: [this.bib.owner?.prefLabel],
           }
         else detail = this.buildStandardDetail(fieldMapping)

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -9,6 +9,7 @@ import type {
   AnnotatedMarc,
   AnyBibDetail,
 } from "../types/bibDetailsTypes"
+import { convertToSentenceCase } from "../utils/appUtils"
 
 export default class BibDetails {
   bib: DiscoveryBibResult
@@ -163,17 +164,27 @@ export default class BibDetails {
           // Getting the first object in the array.
           [holding[fieldMapping.field][0].label]
         : holding[fieldMapping.field]
-    return this.buildDetail(fieldMapping.label, bibFieldValue)
+    return this.buildDetail(
+      convertToSentenceCase(fieldMapping.label),
+      bibFieldValue
+    )
   }
 
   buildStandardDetail(fieldMapping: FieldMapping) {
     const bibFieldValue = this.bib[fieldMapping.field]
-    return this.buildDetail(fieldMapping.label, bibFieldValue)
+    return this.buildDetail(
+      convertToSentenceCase(fieldMapping.label),
+      bibFieldValue
+    )
   }
 
   buildDetail(label: string, value: string[]): BibDetail {
     if (!value?.length) return null
-    return { label, value }
+
+    return {
+      label: convertToSentenceCase(label),
+      value,
+    }
   }
 
   buildInternalLinkedDetail(fieldMapping: {
@@ -184,7 +195,7 @@ export default class BibDetails {
     if (!value?.length) return null
     return {
       link: "internal",
-      label: fieldMapping.label,
+      label: convertToSentenceCase(fieldMapping.label),
       value: value.map((v: string) => {
         const internalUrl = `/search?filters[${
           fieldMapping.field
@@ -196,7 +207,11 @@ export default class BibDetails {
 
   buildExternalLinkedDetail(label: string, values: Url[]): LinkedBibDetail {
     if (!values.length) return null
-    return { link: "external", value: values, label }
+    return {
+      link: "external",
+      value: values,
+      label: convertToSentenceCase(label),
+    }
   }
 
   addNotes(details: AnyBibDetail[]) {
@@ -221,7 +236,10 @@ export default class BibDetails {
         }, {})
       const notesAsDetails = []
       Object.keys(notesGroupedByNoteType).forEach((key: string) => {
-        notesAsDetails.push({ label: key, value: notesGroupedByNoteType[key] })
+        notesAsDetails.push({
+          label: convertToSentenceCase(key),
+          value: notesGroupedByNoteType[key],
+        })
       })
       return notesAsDetails
     }
@@ -340,7 +358,7 @@ export default class BibDetails {
         urlLabel: sc.label,
       }
     })
-    return this.buildExternalLinkedDetail(label, values)
+    return this.buildExternalLinkedDetail(convertToSentenceCase(label), values)
   }
 
   buildSubjectHeadings(): SubjectHeadingDetail {

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -65,8 +65,8 @@ export default class BibDetails {
         return [
           { label: "Location", field: "location" },
           { label: "Format", field: "format" },
-          { label: "Call Number", field: "shelfMark" },
-          { label: "Library Has", field: "holdingStatement" },
+          { label: "Call number", field: "shelfMark" },
+          { label: "Library has", field: "holdingStatement" },
           { label: "Notes", field: "notes" },
         ]
           .map((fieldMapping) => this.buildHoldingDetail(holding, fieldMapping))
@@ -78,9 +78,9 @@ export default class BibDetails {
   buildTopDetails(): AnyBibDetail[] {
     return [
       { field: "titleDisplay", label: "Title" },
-      { field: "publicationStatement", label: "Published By" },
+      { field: "publicationStatement", label: "Published by" },
       // external link
-      { field: "supplementaryContent", label: "Supplementary Content" },
+      { field: "supplementaryContent", label: "Supplementary content" },
       // internal link
       { field: "creatorLiteral", label: "Author" },
     ]
@@ -95,25 +95,25 @@ export default class BibDetails {
   }
   buildBottomDetails(): AnyBibDetail[] {
     const resourceFields = [
-      { field: "contributorLiteral", label: "Additional Authors" },
-      { field: "partOf", label: "Found In" },
-      { field: "serialPublicationDates", label: "Publication Date" },
+      { field: "contributorLiteral", label: "Additional authors" },
+      { field: "partOf", label: "Found in" },
+      { field: "serialPublicationDates", label: "Publication date" },
       { field: "extent", label: "Description" },
       { field: "description", label: "Summary" },
       { field: "donor", label: "Donor/Sponsor" },
-      { field: "seriesStatement", label: "Series Statement" },
-      { field: "uniformTitle", label: "Uniform Title" },
-      { field: "titleAlt", label: "Alternative Title" },
-      { field: "formerTitle", label: "Former Title" },
+      { field: "seriesStatement", label: "Series statement" },
+      { field: "uniformTitle", label: "Uniform title" },
+      { field: "titleAlt", label: "Alternative title" },
+      { field: "formerTitle", label: "Former title" },
       { field: "subjectLiteral", label: "Subject" },
       { field: "genreForm", label: "Genre/Form" },
       { field: "tableOfContents", label: "Contents" },
-      { field: "shelfMark", label: "Call Number" },
+      { field: "shelfMark", label: "Call number" },
       { field: "isbn", label: "ISBN" },
       { field: "issn", label: "ISSN" },
       { field: "oclc", label: "OCLC" },
       { field: "lccn", label: "LCCN" },
-      { field: "owner", label: "Owning Institution" },
+      { field: "owner", label: "Owning institution" },
     ]
       .map((fieldMapping: FieldMapping): AnyBibDetail => {
         let detail: AnyBibDetail
@@ -333,7 +333,7 @@ export default class BibDetails {
     ) {
       return null
     }
-    const label = "Supplementary Content"
+    const label = "Supplementary content"
     const values = this.bib.supplementaryContent.map((sc) => {
       return {
         url: sc.url,

--- a/src/models/ItemTableData.ts
+++ b/src/models/ItemTableData.ts
@@ -3,6 +3,7 @@ import type { ReactElement } from "react"
 import type Item from "./Item"
 import type { ItemTableParams } from "../types/itemTypes"
 import StatusLinks from "../components/ItemTable/StatusLinks"
+import ItemTableCell from "../components/ItemTable/ItemTableCell"
 
 /**
  * The ItemTable class converts a Bib's item data to the format
@@ -40,15 +41,19 @@ export default class ItemTableData {
     ]
   }
 
-  get tableData(): (string | ReactElement)[][] {
+  get tableData(): ReactElement[][] {
     return this.items?.map((item) => {
       return [
         ...(this.showStatusColumn() ? [StatusLinks({ item })] : []),
-        ...(this.showVolumeColumn() ? [item.volume] : []),
-        item.format,
-        ...(this.showAccessColumn() ? [item.accessMessage] : []),
-        item.callNumber,
-        item.location.prefLabel,
+        ...(this.showVolumeColumn()
+          ? [ItemTableCell({ children: item.volume })]
+          : []),
+        ItemTableCell({ children: item.format }),
+        ...(this.showAccessColumn()
+          ? [ItemTableCell({ children: item.accessMessage })]
+          : []),
+        ItemTableCell({ children: item.callNumber }),
+        ItemTableCell({ children: item.location.prefLabel }),
       ]
     })
   }

--- a/src/models/ItemTableData.ts
+++ b/src/models/ItemTableData.ts
@@ -35,8 +35,8 @@ export default class ItemTableData {
       ...(this.showVolumeColumn() ? [this.volumeColumnHeading()] : []),
       "Format",
       ...(this.showAccessColumn() ? ["Access"] : []),
-      "Call Number",
-      "Item Location",
+      "Call number",
+      "Item location",
     ]
   }
 

--- a/src/models/modelTests/BibDetails.test.ts
+++ b/src/models/modelTests/BibDetails.test.ts
@@ -35,18 +35,18 @@ describe("Bib model", () => {
         },
         { label: "Language (note)", value: ["Serbian;"] },
         {
-          label: "Issued By (note)",
+          label: "Issued by (note)",
           value: ["Issued by: Narodna biblioteka Kraljevo."],
         },
         {
-          label: "Linking Entry (note)",
+          label: "Linking entry (note)",
           value: [
             "Has supplement, <2005-> : Preporučeno, ISSN 1452-3531",
             "Has supplement, <2006-> : Види чуда, ISSN 1452-7316",
             "Has supplement, <2006-> : Vidi čuda, ISSN 1452-7316",
           ],
         },
-        { label: "Source of Description (note)", value: ["G. 46, 3 (2016)."] },
+        { label: "Source of description (note)", value: ["G. 46, 3 (2016)."] },
       ])
     })
   })

--- a/src/models/modelTests/BibDetails.test.ts
+++ b/src/models/modelTests/BibDetails.test.ts
@@ -158,7 +158,7 @@ describe("Bib model", () => {
     it("can handle missing field", () => {
       expect(
         bibWithSupContentModel.bottomDetails.find(
-          (detail) => detail.label === "Call Number"
+          (detail) => detail.label === "Call number"
         )
       ).not.toBeDefined()
     })
@@ -189,7 +189,7 @@ describe("Bib model", () => {
     it("includes url in the field", () => {
       expect(bibWithSupContentModel.supplementaryContent).toStrictEqual({
         link: "external",
-        label: "Supplementary Content",
+        label: "Supplementary content",
         value: [
           {
             urlLabel: "Image",
@@ -207,7 +207,7 @@ describe("Bib model", () => {
       })
       expect(
         bogusBib.topDetails.find(
-          (detail) => detail.label === "Additional Author"
+          (detail) => detail.label === "Additional author"
         )
       ).not.toBeDefined()
     })

--- a/src/models/modelTests/SearchResultsBib.test.ts
+++ b/src/models/modelTests/SearchResultsBib.test.ts
@@ -44,17 +44,17 @@ describe("SearchResultsBib model", () => {
 
   describe("getNumItemsMessage", () => {
     it("returns a message populated with the correct resource type and pluralization", () => {
-      expect(searchResultsBib.getNumItemsMessage()).toBe("4 Items")
+      expect(searchResultsBib.getNumItemsMessage()).toBe("4 items")
     })
     it("works for single eResource", () => {
       const bibOneElectronicResource = new SearchResultsBib(
         bibWithOneElectronicResource.resource
       )
-      expect(bibOneElectronicResource.getNumItemsMessage()).toBe("1 Resource")
+      expect(bibOneElectronicResource.getNumItemsMessage()).toBe("1 resource")
     })
     it("works for a bib with no items", () => {
       const bibWithNoItems = new SearchResultsBib(bibNoItems.resource)
-      expect(bibWithNoItems.getNumItemsMessage()).toBe("0 Resources")
+      expect(bibWithNoItems.getNumItemsMessage()).toBe("0 resources")
     })
   })
 

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -131,3 +131,12 @@ export function getPaginationOffsetStrings(
  */
 export const encodeHTML = (str: string) =>
   str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;")
+
+/**
+ * convertToSentenceCase
+ * Return a sentence-cased version of the string if it's more than 2 words (to avoid sentence-casing acronyms).
+ */
+export const convertToSentenceCase = (str: string) =>
+  str.split(" ").length > 1
+    ? str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
+    : str

--- a/src/utils/utilsTests/appUtils.test.ts
+++ b/src/utils/utilsTests/appUtils.test.ts
@@ -2,6 +2,7 @@ import {
   adobeAnalyticsRouteToPageName,
   encodeHTML,
   getPaginationOffsetStrings,
+  convertToSentenceCase,
 } from "../appUtils"
 import {
   ADOBE_ANALYTICS_RC_PREFIX,
@@ -90,6 +91,21 @@ describe("appUtils", () => {
       const [start, end] = getPaginationOffsetStrings(24, 1195, 50)
       expect(start).toEqual("1,151")
       expect(end).toEqual("1,195")
+    })
+  })
+  describe("convertToSentenceCase", () => {
+    it("converts a capitalized string to sentence case", () => {
+      expect(convertToSentenceCase("Convert This Sentence.")).toEqual(
+        "Convert this sentence."
+      )
+    })
+    it("converts a fully uppercase string to sentence case", () => {
+      expect(convertToSentenceCase("CONVERT THIS SENTENCE.")).toEqual(
+        "Convert this sentence."
+      )
+    })
+    it("returns the string that is passed in if it's a single word, to avoid sentence-casing acronyms", () => {
+      expect(convertToSentenceCase("ISSN")).toEqual("ISSN")
     })
   })
 })

--- a/styles/components/BibDetails.module.scss
+++ b/styles/components/BibDetails.module.scss
@@ -1,5 +1,6 @@
 .bibDetails {
   margin-top: var(--nypl-space-xl) !important;
+  font-size: var(--nypl-fontSizes-desktop-body-body2);
 
   h3 {
     border: none;

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -14,7 +14,7 @@
     th:first-of-type {
       padding: var(--nypl-space-s) 0;
 
-      // These min-widths are here temporarily to fix an issue with the table that causes the Format and Call Number columns to appear to narrow
+      // These min-widths are here temporarily to fix an issue with the table that causes the Format and Call number columns to appear to narrow
       // TODO: These can be removed if the issue is addressed in the DS or during VQA.
       @media screen and (min-width: 600px) {
         min-width: 80px;


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4235](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4235)

## This PR does the following:

- Changes  copy to sentence case 
- Misc styling / copy tweaks from VQA doc
- Added a ItemTableCell component to allow styling the inner item table elements (programmatically rendering DS Text component in the ItemTableData model gave me problems with Typescript but there might be a solution)
- Note: the changes requested in the ticket for table heading and year button will be updated on the DS level

## How has this been tested?

- Changed copy in a lot of tests

## Accessibility concerns or updates

NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4235]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ