### PR TITLE
SCC-4230 - Filter out null values in feedback metadata

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Prerelease
+
+### Fixed
+
+- Fix feedback bug caused by null values in item metadata
+
 ## [1.2.3] 2024-08-26
 
 ### Added

--- a/src/utils/feedbackUtils.ts
+++ b/src/utils/feedbackUtils.ts
@@ -11,6 +11,7 @@ export const getFeedbackEmailText = (
   fields: FeedbackMetadataAndComment
 ) => {
   const submissionText = Object.keys(fields)
+    .filter((label) => fields[label])
     .map((label) => `${label}: ${encodeHTML(fields[label])}`)
     .join(", ")
   return `Question/Feedback from Research Catalog (SCC): ${submissionText} URL: ${fullUrl}`
@@ -28,6 +29,7 @@ export const getFeedbackEmailHTML = (
         <h1>Question/Feedback from Research Catalog (SCC):</h1>
         <dl>
           ${Object.keys(fields)
+            .filter((label) => fields[label])
             .map(
               (label) => `
             <dt>${label}:</dt>

--- a/src/utils/utilsTests/feedbackUtils.test.ts
+++ b/src/utils/utilsTests/feedbackUtils.test.ts
@@ -98,5 +98,35 @@ describe("feedbackUtils", () => {
         ReplyToAddresses: ["replyTo@email.com"],
       })
     })
+
+    it("strips null values from item metadata", () => {
+      const body = JSON.stringify({
+        category: "comment",
+        comment: "Body text",
+        email: "replyTo@email.com",
+        barcode: null,
+      })
+      const referer = "http://localhost:8080"
+      expect(
+        getEmailParams(body, referer, "to@email.com", "source@email.com")
+      ).toStrictEqual({
+        Destination: { ToAddresses: ["to@email.com"] },
+        Message: {
+          Body: {
+            Html: {
+              Charset: "UTF-8",
+              Data: getFeedbackEmailHTML(referer, JSON.parse(body)),
+            },
+            Text: {
+              Charset: "UTF-8",
+              Data: getFeedbackEmailText(referer, JSON.parse(body)),
+            },
+          },
+          Subject: { Charset: "UTF-8", Data: "SCC Feedback" },
+        },
+        Source: "source@email.com",
+        ReplyToAddresses: ["replyTo@email.com"],
+      })
+    })
   })
 })


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4230](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4230)

## This PR does the following:

- Fixes a server-side error when posting to the feedback endpoint in the Next app, where null values in the metadata were unable to be parsed as json.
- This strips the null values on the server side, open to suggestions on where we should  be doing this.

## How has this been tested?

- Added a unit test with a null value in the metadata

## Accessibility concerns or updates

NA

### Checklist:

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4230]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ