### PR TITLE
Hotfix - Fix layout grid styling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Hotfixes 2024-08-29
+
+- Remove gridColumnEnd style from Layout to fix DRB sidebar right alignment
+
 ## [1.2.3] 2024-08-26
 
 ### Added

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -47,7 +47,7 @@ const Layout = ({
       <TemplateAppContainer
         // This is a workaround to fix a text-wrapping issue when page is zoomed in on
         // TODO: Address this issue in the DS
-        sx={{ "main > div": { maxWidth: "100vw", gridColumnEnd: "none" } }}
+        sx={{ "main > div": { maxWidth: "100vw" } }}
         breakout={
           showHeader && (
             <>


### PR DESCRIPTION
## Ticket:

NA

## This PR does the following:

- Removed gridColumnEnd that was added as an accessibility fix (turns out it wasn't necessary) to fix DRB sidebar right alignemnt

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
