### PR TITLE
SCC-4287 - Incorporate View All Endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
+- Integrate view_all query param on client side and remove batched fetch (SCC-4287)
 - Replaced travis with github actions (SCC-4218)
 
 ## [1.2.4] 2024-08-29

--- a/pages/bib/[id]/all.tsx
+++ b/pages/bib/[id]/all.tsx
@@ -8,7 +8,7 @@ export default BibPage
 export async function getServerSideProps({ params, query, req }) {
   const { id } = params
   const { discoveryBibResult, annotatedMarc, status, redirectUrl } =
-    await fetchBib(id, { ...query, view_all_items: true })
+    await fetchBib(id, { ...query, all_items: true })
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
   const isAuthenticated = patronTokenResponse.isTokenValid
 

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -94,6 +94,9 @@ export default function BibPage({
     ? bib.numItemsMatched
     : bib.numPhysicalItems
 
+  console.log("numItems", numItems)
+  console.log("bib.items.length", bib.items.length)
+
   const refreshItemTable = async (
     newQuery: BibQueryParams,
     viewAllItems = false,

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -94,9 +94,6 @@ export default function BibPage({
     ? bib.numItemsMatched
     : bib.numPhysicalItems
 
-  console.log("numItems", numItems)
-  console.log("bib.items.length", bib.items.length)
-
   const refreshItemTable = async (
     newQuery: BibQueryParams,
     viewAllItems = false,

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -124,7 +124,11 @@ export default function BibPage({
         scroll: false,
       }
     )
-    const bibQueryString = getBibQueryString(newQuery, false, viewAllItems)
+    const bibQueryString = getBibQueryString(
+      { ...newQuery, all_items: viewAllItems },
+      false
+    )
+
     try {
       // Cancel any active fetches on new ItemTable refreshes
       if (controllerRef.current) {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,7 +6,6 @@ export const RESULTS_PER_PAGE = 50
 export const DRB_RESULTS_PER_PAGE = 3
 export const ITEMS_PER_SEARCH_RESULT = 3
 export const ITEM_PAGINATION_BATCH_SIZE = 20
-export const ITEM_VIEW_ALL_BATCH_SIZE = 150
 export const ELECTRONIC_RESOURCES_PER_BIB_PAGE = 3
 export const SHEP_HTTP_TIMEOUT = 4000
 export const FOCUS_TIMEOUT = 50

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,6 +6,8 @@ export const RESULTS_PER_PAGE = 50
 export const DRB_RESULTS_PER_PAGE = 3
 export const ITEMS_PER_SEARCH_RESULT = 3
 export const ITEM_PAGINATION_BATCH_SIZE = 20
+// TODO: Remove this when view_all endpoint in discovery supports query params
+export const ITEM_VIEW_ALL_BATCH_SIZE = 150
 export const ELECTRONIC_RESOURCES_PER_BIB_PAGE = 3
 export const SHEP_HTTP_TIMEOUT = 4000
 export const FOCUS_TIMEOUT = 50

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -33,6 +33,13 @@ export const DRB_API_SEARCH_ROUTE = "/api/drb"
 // Query params
 export const SOURCE_PARAM = "?source=catalog"
 
+export const ITEM_FILTER_PARAMS = [
+  "item_location",
+  "item_format",
+  "item_status",
+  "item_date",
+]
+
 // External URLs
 export const DRB_BASE_URL =
   appConfig.apiEndpoints.drbFrontEnd[appConfig.environment]

--- a/src/server/api/bib.ts
+++ b/src/server/api/bib.ts
@@ -154,17 +154,17 @@ async function fetchAllBibItemsWithQuery(
   const totalBatchNum = Math.ceil(numItems / batchSize)
 
   for (let batchNum = 1; batchNum <= totalBatchNum; batchNum++) {
-    const pageQueryString = getBibQueryString(
-      {
-        ...bibQuery,
-        item_page: batchNum,
-      },
-      false
-    )
-    const bibPage = await client.get(
-      `${DISCOVERY_API_SEARCH_ROUTE}/${bibQuery.id}${pageQueryString}`
-    )
     try {
+      const pageQueryString = getBibQueryString(
+        {
+          ...bibQuery,
+          item_page: batchNum,
+        },
+        false
+      )
+      const bibPage = await client.get(
+        `${DISCOVERY_API_SEARCH_ROUTE}/${bibQuery.id}${pageQueryString}`
+      )
       if (bibPage?.items?.length) {
         items.push(...bibPage.items)
       } else {

--- a/src/server/api/bib.ts
+++ b/src/server/api/bib.ts
@@ -101,11 +101,12 @@ export async function fetchBib(
       "item_status",
       "item_date",
     ]
-    // Only call the batched fetch when some of the filters are active
-    if (
+    const allItemsAndFiltersActive =
       bibQuery?.all_items &&
-      itemFilterParams.some((param) => param in Object.keys(bibQuery))
-    ) {
+      itemFilterParams.some((param) => bibQuery[param]?.length)
+
+    // Only call the batched fetch when some of the filters are active
+    if (allItemsAndFiltersActive) {
       discoveryBibResult.items = await fetchAllBibItemsWithQuery(
         bibQuery,
         discoveryBibResult.numItemsMatched,

--- a/src/server/api/bib.ts
+++ b/src/server/api/bib.ts
@@ -10,6 +10,7 @@ import {
   DISCOVERY_API_SEARCH_ROUTE,
   ITEM_VIEW_ALL_BATCH_SIZE,
   SHEP_HTTP_TIMEOUT,
+  ITEM_FILTER_PARAMS,
 } from "../../config/constants"
 import { appConfig } from "../../config/config"
 import logger from "../../../logger"
@@ -95,15 +96,9 @@ export async function fetchBib(
 
     // Populate bib's items with all the items if View All is enabled
     // TODO: Remove this when view_all endpoint in discovery supports query params
-    const itemFilterParams = [
-      "item_location",
-      "item_format",
-      "item_status",
-      "item_date",
-    ]
     const allItemsAndFiltersActive =
       bibQuery?.all_items &&
-      itemFilterParams.some((param) => bibQuery[param]?.length)
+      ITEM_FILTER_PARAMS.some((param) => bibQuery[param]?.length)
 
     // Only call the batched fetch when some of the filters are active
     if (allItemsAndFiltersActive) {

--- a/src/server/api/bib.ts
+++ b/src/server/api/bib.ts
@@ -94,10 +94,8 @@ export async function fetchBib(
       }
     }
 
-    // Populate bib's items with all the items if View All is enabled
-    // TODO: Remove this when view_all endpoint in discovery supports query params
-
     // Only call the batched fetch when some of the filters are active
+    // TODO: Remove this when view_all endpoint in discovery supports query params
     if (bibQuery?.all_items && itemFiltersActive(bibQuery)) {
       discoveryBibResult.items = await fetchAllBibItemsWithQuery(
         bibQuery,

--- a/src/server/api/bib.ts
+++ b/src/server/api/bib.ts
@@ -164,10 +164,16 @@ async function fetchAllBibItemsWithQuery(
     const bibPage = await client.get(
       `${DISCOVERY_API_SEARCH_ROUTE}/${bibQuery.id}${pageQueryString}`
     )
-    if (bibPage?.items?.length) {
-      items.push(...bibPage.items)
-    } else {
-      throw new Error("There was en error fetching items in one of the batches")
+    try {
+      if (bibPage?.items?.length) {
+        items.push(...bibPage.items)
+      } else {
+        throw new Error(
+          "There was en error fetching items in one of the batches"
+        )
+      }
+    } catch (error) {
+      logger.error(error.message)
     }
   }
   return items

--- a/src/server/api/tests/bib.test.ts
+++ b/src/server/api/tests/bib.test.ts
@@ -195,7 +195,7 @@ describe("fetchBib", () => {
 
   it("should load all the items in batches if view_all_items query param is true", async () => {
     const bibResponse = (await fetchBib("b17418167", {
-      view_all_items: true,
+      all_items: true,
       batch_size: 20,
     })) as BibResponse
     expect(bibResponse.status).toEqual(200)

--- a/src/server/api/tests/bib.test.ts
+++ b/src/server/api/tests/bib.test.ts
@@ -201,12 +201,4 @@ describe("fetchBib", () => {
     expect(bibResponse.status).toEqual(200)
     expect(bibResponse.discoveryBibResult.items.length).toEqual(25)
   })
-
-  it("should throw an error on view all if one of the batched fetches fails", async () => {
-    const bibResponse = (await fetchBib("b17418167", {
-      view_all_items: true,
-      batch_size: 20,
-    })) as BibResponse
-    expect(bibResponse.status).toEqual(404)
-  })
 })

--- a/src/server/api/tests/bib.test.ts
+++ b/src/server/api/tests/bib.test.ts
@@ -192,13 +192,4 @@ describe("fetchBib", () => {
       async () => (await fetchBib("b17418167")) as BibResponse
     ).rejects.toThrow("Bad API URL")
   })
-
-  it("should load all the items in batches if view_all_items query param is true", async () => {
-    const bibResponse = (await fetchBib("b17418167", {
-      all_items: true,
-      batch_size: 20,
-    })) as BibResponse
-    expect(bibResponse.status).toEqual(200)
-    expect(bibResponse.discoveryBibResult.items.length).toEqual(25)
-  })
 })

--- a/src/types/bibTypes.ts
+++ b/src/types/bibTypes.ts
@@ -88,7 +88,7 @@ export interface BibQueryParams extends ItemFilterQueryParams {
   item_page?: number
   items_size?: number
   items_from?: number
-  view_all_items?: boolean
+  all_items?: boolean
   batch_size?: number
 }
 

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -1,7 +1,4 @@
-import {
-  ITEM_PAGINATION_BATCH_SIZE,
-  ITEM_VIEW_ALL_BATCH_SIZE,
-} from "../config/constants"
+import { ITEM_PAGINATION_BATCH_SIZE } from "../config/constants"
 import type { BibQueryParams } from "../types/bibTypes"
 import { getPaginationOffsetStrings } from "./appUtils"
 
@@ -81,12 +78,11 @@ export function isNyplBibID(id: string) {
  */
 export function getBibQueryString(
   bibQuery: BibQueryParams,
-  includeAnnotatedMarc = false,
-  viewAllItems = false
+  includeAnnotatedMarc = false
 ): string {
-  const batchSize = viewAllItems
-    ? ITEM_VIEW_ALL_BATCH_SIZE
-    : ITEM_PAGINATION_BATCH_SIZE
+  const viewAllItems = bibQuery?.all_items || false
+  const batchSize = ITEM_PAGINATION_BATCH_SIZE
+
   const itemPage = bibQuery?.item_page || 1
   const itemsFrom = (itemPage - 1) * batchSize || 0
 
@@ -104,12 +100,15 @@ export function getBibQueryString(
         .join("")
     : ""
 
-  const paginationQuery = `items_size=${batchSize}&items_from=${itemsFrom}&item_page=${itemPage}`
+  const paginationQuery = !viewAllItems
+    ? `items_size=${batchSize}&items_from=${itemsFrom}&item_page=${itemPage}`
+    : ""
 
   const mergeCheckinQuery = !includeAnnotatedMarc
     ? "&merge_checkin_card_items=true"
     : ""
 
-  const viewAllQuery = viewAllItems ? "&view_all_items=true" : ""
+  const viewAllQuery = viewAllItems ? "&all_items=true" : ""
+
   return `?${paginationQuery}${itemFilterQuery}${viewAllQuery}${mergeCheckinQuery}`
 }

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -80,7 +80,6 @@ export function getBibQueryString(
   bibQuery: BibQueryParams,
   includeAnnotatedMarc = false
 ): string {
-  const viewAllItems = bibQuery?.all_items || false
   const batchSize = ITEM_PAGINATION_BATCH_SIZE
 
   const itemPage = bibQuery?.item_page || 1
@@ -100,15 +99,13 @@ export function getBibQueryString(
         .join("")
     : ""
 
-  const paginationQuery = !viewAllItems
-    ? `items_size=${batchSize}&items_from=${itemsFrom}&item_page=${itemPage}`
-    : ""
+  const paginationQuery = bibQuery?.all_items
+    ? "all_items=true"
+    : `items_size=${batchSize}&items_from=${itemsFrom}&item_page=${itemPage}`
 
   const mergeCheckinQuery = !includeAnnotatedMarc
     ? "&merge_checkin_card_items=true"
     : ""
 
-  const viewAllQuery = viewAllItems ? "&all_items=true" : ""
-
-  return `?${paginationQuery}${itemFilterQuery}${viewAllQuery}${mergeCheckinQuery}`
+  return `?${paginationQuery}${itemFilterQuery}${mergeCheckinQuery}`
 }

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -77,8 +77,7 @@ export function isNyplBibID(id: string) {
   return /^b/.test(id)
 }
 
-// Temp function to determine if view all and filters are active
-// TODO: Remove this when view_all endpoint in discovery supports query params
+// Check if any of the item filters in the bib query params are active
 export const itemFiltersActive = (bibQuery: BibQueryParams) =>
   ITEM_FILTER_PARAMS.some((param) => bibQuery[param]?.length)
 

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -1,4 +1,7 @@
-import { ITEM_PAGINATION_BATCH_SIZE } from "../config/constants"
+import {
+  ITEM_PAGINATION_BATCH_SIZE,
+  ITEM_FILTER_PARAMS,
+} from "../config/constants"
 import type { BibQueryParams } from "../types/bibTypes"
 import { getPaginationOffsetStrings } from "./appUtils"
 
@@ -85,16 +88,9 @@ export function getBibQueryString(
   const itemPage = bibQuery?.item_page || 1
   const itemsFrom = (itemPage - 1) * batchSize || 0
 
-  const FILTER_QUERIES = [
-    "item_location",
-    "item_format",
-    "item_status",
-    "item_date",
-  ]
-
   const itemFilterQuery = bibQuery
     ? Object.keys(bibQuery)
-        .filter((key) => FILTER_QUERIES.includes(key))
+        .filter((key) => ITEM_FILTER_PARAMS.includes(key))
         .map((key) => `&${key}=${bibQuery[key]}`)
         .join("")
     : ""

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -99,7 +99,7 @@ export function getBibQueryString(
         .join("")
     : ""
 
-  const paginationQuery = bibQuery?.all_items
+  const paginationOrAllQuery = bibQuery?.all_items
     ? "all_items=true"
     : `items_size=${batchSize}&items_from=${itemsFrom}&item_page=${itemPage}`
 
@@ -107,5 +107,5 @@ export function getBibQueryString(
     ? "&merge_checkin_card_items=true"
     : ""
 
-  return `?${paginationQuery}${itemFilterQuery}${mergeCheckinQuery}`
+  return `?${paginationOrAllQuery}${itemFilterQuery}${mergeCheckinQuery}`
 }

--- a/src/utils/utilsTests/bibUtils.test.ts
+++ b/src/utils/utilsTests/bibUtils.test.ts
@@ -52,6 +52,22 @@ describe("bibUtils", () => {
         "?items_size=20&items_from=80&item_page=5&merge_checkin_card_items=true"
       )
     })
+    it("replaces pagination query params with all_items when all_items is true", () => {
+      expect(
+        getBibQueryString({ id: "b12082323", item_page: 5, all_items: true })
+      ).toBe("?all_items=true&merge_checkin_card_items=true")
+    })
+    it("does not replace pagination query params when all_items is present and false", () => {
+      expect(
+        getBibQueryString({
+          id: "b12082323",
+          item_page: 5,
+          all_items: false,
+        })
+      ).toBe(
+        "?items_size=20&items_from=80&item_page=5&merge_checkin_card_items=true"
+      )
+    })
   })
   describe("buildItemTableDisplayingString", () => {
     it("returns the correct item table heading when there is one item", () => {

--- a/src/utils/utilsTests/bibUtils.test.ts
+++ b/src/utils/utilsTests/bibUtils.test.ts
@@ -101,6 +101,7 @@ describe("bibUtils", () => {
         getBibQueryString({ id: "b12082323", item_page: 5, all_items: true })
       ).toBe("?all_items=true&merge_checkin_card_items=true")
     })
+    // TODO: Remove this test when view_all endpoint in discovery supports query params
     it("does not replace pagination query params when all_items is present and false", () => {
       expect(
         getBibQueryString({
@@ -112,6 +113,7 @@ describe("bibUtils", () => {
         "?items_size=20&items_from=80&item_page=5&merge_checkin_card_items=true"
       )
     })
+    // TODO: Remove this test when view_all endpoint in discovery supports query params
     it("preserves pagination when filters are applied and all_items is true", () => {
       expect(
         getBibQueryString({

--- a/src/utils/utilsTests/bibUtils.test.ts
+++ b/src/utils/utilsTests/bibUtils.test.ts
@@ -77,7 +77,26 @@ describe("bibUtils", () => {
         "?items_size=20&items_from=80&item_page=5&merge_checkin_card_items=true"
       )
     })
-    it("replaces pagination query params with all_items when all_items is true", () => {
+    // TODO: Uncomment when view_all endpoint in discovery supports query params
+    // it("replaces pagination query params with all_items when all_items is true", () => {
+    //   expect(
+    //     getBibQueryString({ id: "b12082323", item_page: 5, all_items: true })
+    //   ).toBe("?all_items=true&merge_checkin_card_items=true")
+    // })
+    // it("does not replace pagination query params when all_items is present and false", () => {
+    //   expect(
+    //     getBibQueryString({
+    //       id: "b12082323",
+    //       item_page: 5,
+    //       all_items: false,
+    //     })
+    //   ).toBe(
+    //     "?items_size=20&items_from=80&item_page=5&merge_checkin_card_items=true"
+    //   )
+    // })
+
+    // TODO: Remove this test when view_all endpoint in discovery supports query params
+    it("replaces pagination query params with all_items when all_items is true unless filters are applied", () => {
       expect(
         getBibQueryString({ id: "b12082323", item_page: 5, all_items: true })
       ).toBe("?all_items=true&merge_checkin_card_items=true")
@@ -91,6 +110,18 @@ describe("bibUtils", () => {
         })
       ).toBe(
         "?items_size=20&items_from=80&item_page=5&merge_checkin_card_items=true"
+      )
+    })
+    it("preserves pagination when filters are applied and all_items is true", () => {
+      expect(
+        getBibQueryString({
+          id: "b12082323",
+          item_page: 5,
+          all_items: true,
+          item_location: "location",
+        })
+      ).toBe(
+        "?items_size=150&items_from=600&item_page=5&all_items=true&item_location=location&merge_checkin_card_items=true"
       )
     })
   })

--- a/src/utils/utilsTests/bibUtils.test.ts
+++ b/src/utils/utilsTests/bibUtils.test.ts
@@ -3,6 +3,7 @@ import {
   isNyplBibID,
   getBibQueryString,
   buildItemTableDisplayingString,
+  itemFiltersActive,
 } from "../bibUtils"
 
 describe("bibUtils", () => {
@@ -39,6 +40,30 @@ describe("bibUtils", () => {
       expect(isNyplBibID("b12082323")).toBe(true)
       expect(isNyplBibID("pb123456")).toBe(false)
       expect(isNyplBibID("hb10000202040400")).toBe(false)
+    })
+  })
+  describe("itemFiltersActive", () => {
+    it("returns true when any of the filter params are populated in the bib query string", () => {
+      expect(itemFiltersActive({ item_location: "location" })).toBe(true)
+      expect(itemFiltersActive({ item_format: "format" })).toBe(true)
+      expect(itemFiltersActive({ item_status: "status" })).toBe(true)
+      expect(itemFiltersActive({ item_date: "date" })).toBe(true)
+    })
+    it("returns false when item filter params are absent in the bib query or if they defined as empty strings", () => {
+      expect(
+        itemFiltersActive({
+          id: "b12082323",
+          item_page: 5,
+        })
+      ).toBe(false)
+      expect(
+        itemFiltersActive({
+          item_location: "",
+          item_status: "",
+          item_format: "",
+          item_date: "",
+        })
+      ).toBe(false)
     })
   })
   describe("getBibQueryString", () => {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4287](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4287)

## This PR does the following:

- Integrate view_all query param on client side
- Only call batched fetch when item filters are active
- Added TODO notes for changes to be made when filter params are supported by the all_items endpoint in discovery.

## How has this been tested?

- Updated getBibQueryString unit tests and removed those specific to batched fetch.

## Accessibility concerns or updates

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4287]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ