### PR TITLE
SCC-4277 - Fix undefined error on display string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix bug where "undefined" appears in the search results heading (SCC-4277)
 - VQA second pass miscellaneous fixes (SCC-4264)
 - Fixed accessibility issue on Bib page where focus moves to Displaying text when filters are controlled via MultiSelect. This will change when dynamic updates are replaced with an apply button (SCC-4246)
 

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -64,6 +64,7 @@ export function getSearchResultsHeading(
   } of ${totalResults.toLocaleString()} results ${queryDisplayString}`
 }
 
+// Shows the final part of the search query string (e.g. "for keyword 'cats'")
 function buildQueryDisplayString(searchParams: SearchParams): string {
   const searchFields = advSearchFields
     // Lowercase the adv search field labels:
@@ -110,11 +111,9 @@ function buildQueryDisplayString(searchParams: SearchParams): string {
 
   const displayStringArray = Object.values(paramsStringCollection)
 
-  return `for ${
-    displayStringArray.length > 1
-      ? displayStringArray.join(" and ")
-      : displayStringArray[0]
-  }`
+  return displayStringArray.length
+    ? `for ${displayStringArray.join(" and ")}`
+    : ""
 }
 
 /**

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -61,7 +61,7 @@ export function getSearchResultsHeading(
     totalResults > RESULTS_PER_PAGE
       ? `${resultsStart}-${resultsEnd}`
       : totalResults.toLocaleString()
-  } of ${totalResults.toLocaleString()} results ${queryDisplayString}`
+  } of ${totalResults.toLocaleString()} results${queryDisplayString}`
 }
 
 // Shows the final part of the search query string (e.g. "for keyword 'cats'")
@@ -112,7 +112,7 @@ function buildQueryDisplayString(searchParams: SearchParams): string {
   const displayStringArray = Object.values(paramsStringCollection)
 
   return displayStringArray.length
-    ? `for ${displayStringArray.join(" and ")}`
+    ? ` for ${displayStringArray.join(" and ")}`
     : ""
 }
 

--- a/src/utils/utilsTests/searchUtils.test.ts
+++ b/src/utils/utilsTests/searchUtils.test.ts
@@ -239,6 +239,10 @@ describe("searchUtils", () => {
         'Displaying 201-250 of 1,200 results for keyword "cats"'
       )
     })
+    it("doesn't display the 'for' part of the display text when the q param is absent", () => {
+      const heading = getSearchResultsHeading({ page: 5 }, 1200)
+      expect(heading).toEqual("Displaying 201-250 of 1,200 results")
+    })
 
     describe("identifier searches", () => {
       it("returns the correct heading string for OCLC searches", () => {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4277](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4277)

## This PR does the following:

- Fixes a bug where the search results display string reads "Displaying x results for undefined" when there are no fields in the search query string.
- This scenario is reproducible by going to the search results page with only filters in the query string: https://www.nypl.org/research/research-catalog/search?filters[subjectLiteral]=Intellectual%20life
- Removed the redundant length check on displayStringArray since .join doesn't add a separator when the array length is 1.

## How has this been tested?

- Added a unit test for this scenario

## Accessibility concerns or updates

NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4277]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ