### PR TITLE
Hotfix/view fewer link not rendering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## Hotfix
+
+- Fix bug where the "View fewer" button was not appearing when filters weren't applied
+
 ### Fixed
 
 - Fix bug where "undefined" appears in the search results heading (SCC-4277)

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -89,11 +89,6 @@ export default function BibPage({
 
   const filtersAreApplied = areFiltersApplied(appliedFilters)
 
-  // If filters are applied, show the matching number of items, otherwise show the total number of items
-  const numItems = filtersAreApplied
-    ? bib.numItemsMatched
-    : bib.numPhysicalItems
-
   const refreshItemTable = async (
     newQuery: BibQueryParams,
     viewAllItems = false,
@@ -273,7 +268,7 @@ export default function BibPage({
                   >
                     {buildItemTableDisplayingString(
                       itemTablePage,
-                      numItems,
+                      bib.numItems(filtersAreApplied),
                       viewAllExpanded,
                       filtersAreApplied
                     )}
@@ -292,7 +287,7 @@ export default function BibPage({
                   handlePageChange={handlePageChange}
                   handleViewAllClick={handleViewAllClick}
                   viewAllLoadingTextRef={viewAllLoadingTextRef}
-                  numItemsTotal={numItems}
+                  numItemsTotal={bib.numItems(filtersAreApplied)}
                   filtersAreApplied={filtersAreApplied}
                 />
               ) : null}

--- a/src/components/ItemTable/ItemTableControls.tsx
+++ b/src/components/ItemTable/ItemTableControls.tsx
@@ -54,7 +54,7 @@ const ItemTableControls = ({
           mb={{ base: "m", md: 0 }}
         />
       ) : null}
-      {bib.showViewAllItemsLink &&
+      {bib.showViewAllItemsLink(filtersAreApplied) &&
         (itemsLoading && viewAllExpanded ? (
           <Box
             ml="auto"

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -61,7 +61,7 @@ const SearchResult = ({ bib }: SearchResultProps) => {
                   key={`search-results-item-${itemTableData.items[0].id}`}
                 />
               ))}
-              {bib.showViewAllItemsLink && (
+              {bib.showViewAllItemsLink() && (
                 <CardActions>
                   <RCLink
                     href={`${bib.url}#item-table`}

--- a/src/models/Bib.ts
+++ b/src/models/Bib.ts
@@ -55,12 +55,6 @@ export default class Bib {
     return this.electronicResources?.length || 0
   }
 
-  get numItems() {
-    return this.hasPhysicalItems
-      ? this.numPhysicalItems
-      : this.numElectronicResources
-  }
-
   get hasPhysicalItems() {
     return this.numPhysicalItems > 0
   }
@@ -86,10 +80,6 @@ export default class Bib {
     )
   }
 
-  get showViewAllItemsLink() {
-    return this.numItemsMatched > ITEM_PAGINATION_BATCH_SIZE
-  }
-
   get resourceType() {
     return this.hasPhysicalItems ? "Item" : "Resource"
   }
@@ -102,8 +92,16 @@ export default class Bib {
     )
   }
 
+  numItems(filtersAreApplied = false) {
+    return filtersAreApplied ? this.numItemsMatched : this.numPhysicalItems
+  }
+
+  showViewAllItemsLink(filtersAreApplied = false) {
+    return this.numItems(filtersAreApplied) > ITEM_PAGINATION_BATCH_SIZE
+  }
+
   getNumItemsMessage(filtersAreApplied = false) {
-    const totalItems = filtersAreApplied ? this.numItemsMatched : this.numItems
+    const totalItems = this.numItems(filtersAreApplied)
     return `${totalItems} ${
       filtersAreApplied ? "matching " : ""
     }${this.resourceType.toLowerCase()}${totalItems !== 1 ? "s" : ""}`

--- a/src/models/SearchResultsBib.ts
+++ b/src/models/SearchResultsBib.ts
@@ -26,7 +26,7 @@ export default class SearchResultsBib extends Bib {
       : null
   }
 
-  get showViewAllItemsLink() {
+  showViewAllItemsLink() {
     return this.numPhysicalItems > ITEMS_PER_SEARCH_RESULT
   }
 

--- a/src/models/SearchResultsBib.ts
+++ b/src/models/SearchResultsBib.ts
@@ -43,6 +43,12 @@ export default class SearchResultsBib extends Bib {
       : null
   }
 
+  numItems() {
+    return this.hasPhysicalItems
+      ? this.numPhysicalItems
+      : this.numElectronicResources
+  }
+
   getYearFromResult(result: DiscoveryBibResult) {
     const { dateStartYear, dateEndYear } = result
 

--- a/src/models/modelTests/SearchResultsBib.test.ts
+++ b/src/models/modelTests/SearchResultsBib.test.ts
@@ -38,7 +38,7 @@ describe("SearchResultsBib model", () => {
 
   describe("showViewAllItemsLink", () => {
     it("returns true if the number of physical items is greater than ITEMS_PER_SEARCH_RESULT", () => {
-      expect(searchResultsBib.showViewAllItemsLink).toBe(true)
+      expect(searchResultsBib.showViewAllItemsLink()).toBe(true)
     })
   })
 


### PR DESCRIPTION
## This PR does the following:

- Updates numItems on Bib model to account for filtersAreApplied
- This was causing the showViewAllItemsLink to always be false since it wasn't accounting for the filters being applied or not.

## How has this been tested?

- We have some tests for this but we didn't account for all the cases. Will add these as a follow up.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
