### PR TITLE
SCC-4264 - Small styling tweaks following DS version bump

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Small styling fixes after DS version bump (SCC-4264)
 - Fix bug where "undefined" appears in the search results heading (SCC-4277)
 - VQA second pass miscellaneous fixes (SCC-4264)
 - Fixed accessibility issue on Bib page where focus moves to Displaying text when filters are controlled via MultiSelect. This will change when dynamic updates are replaced with an apply button (SCC-4246)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Small styling fixes after DS version bump (SCC-4264)
+- Small styling fixes after DS version bump to 3.4.0-rc (SCC-4264)
 - Fix bug where "undefined" appears in the search results heading (SCC-4277)
 - VQA second pass miscellaneous fixes (SCC-4264)
 - Fixed accessibility issue on Bib page where focus moves to Displaying text when filters are controlled via MultiSelect. This will change when dynamic updates are replaced with an apply button (SCC-4246)

--- a/src/components/ItemTable/ItemAvailability.tsx
+++ b/src/components/ItemTable/ItemAvailability.tsx
@@ -106,6 +106,7 @@ const ItemAvailability = ({ item }: ItemAvailabilityProps) => {
             fontSize: "inherit",
             p: 0,
             height: "auto",
+            textAlign: "left",
           }}
           onClick={() =>
             onContact({

--- a/src/components/ItemTable/ItemTable.tsx
+++ b/src/components/ItemTable/ItemTable.tsx
@@ -1,4 +1,8 @@
-import { Box, Table } from "@nypl/design-system-react-components"
+import {
+  Box,
+  Table,
+  useNYPLBreakpoints,
+} from "@nypl/design-system-react-components"
 
 import type ItemTableData from "../../models/ItemTableData"
 import StatusLinks from "./StatusLinks"
@@ -13,6 +17,8 @@ interface ItemTableProps {
  */
 const ItemTable = ({ itemTableData }: ItemTableProps) => {
   const { tableHeadings, tableData, items, inSearchResult } = itemTableData
+  const { isLargerThanSmall } = useNYPLBreakpoints()
+
   return (
     <Box>
       <Table
@@ -22,6 +28,7 @@ const ItemTable = ({ itemTableData }: ItemTableProps) => {
         columnHeaders={tableHeadings}
         tableData={tableData}
         showRowDividers={!inSearchResult}
+        isScrollable={!isLargerThanSmall}
         my={{ base: 0, md: "s" }}
         data-testid={
           !inSearchResult

--- a/src/components/ItemTable/ItemTable.tsx
+++ b/src/components/ItemTable/ItemTable.tsx
@@ -17,7 +17,7 @@ interface ItemTableProps {
  */
 const ItemTable = ({ itemTableData }: ItemTableProps) => {
   const { tableHeadings, tableData, items, inSearchResult } = itemTableData
-  const { isLargerThanSmall } = useNYPLBreakpoints()
+  const { isLargerThanMobile } = useNYPLBreakpoints()
 
   return (
     <Box>
@@ -28,7 +28,7 @@ const ItemTable = ({ itemTableData }: ItemTableProps) => {
         columnHeaders={tableHeadings}
         tableData={tableData}
         showRowDividers={!inSearchResult}
-        isScrollable={!isLargerThanSmall}
+        isScrollable={!isLargerThanMobile}
         my={{ base: 0, md: "s" }}
         data-testid={
           !inSearchResult

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -1,57 +1,16 @@
 .itemTable {
   margin-top: var(--nypl-space-m);
   margin-bottom: var(--nypl-space-s);
-  width: unset !important;
-
-  thead {
-    margin-bottom: var(--nypl-space-xs);
-  }
 
   tr {
-    th,
-    td {
-      padding: null var(--nypl-space-xs);
-    }
-
-    th {
-      text-transform: uppercase;
-    }
-
     td:first-of-type,
     th:first-of-type {
-      padding: var(--nypl-space-s) var(--nypl-space-xs) var(--nypl-space-s) 0;
+      padding-left: 0;
     }
 
     td:last-of-type,
     th:last-of-type {
-      padding: var(--nypl-space-s) 0 var(--nypl-space-s) var(--nypl-space-xs);
-    }
-
-    th,
-    td,
-    td:first-of-type,
-    th:first-of-type {
-      // These min-widths are here temporarily to fix an issue with the table that causes the Format and Call number columns to appear to narrow
-      // TODO: These can be removed if the issue is addressed in the DS or during VQA.
-      @media screen and (min-width: 600px) {
-        min-width: 80px;
-      }
-
-      @media screen and (min-width: 900px) {
-        min-width: 100px;
-
-        &:first-child {
-          min-width: 340px;
-        }
-      }
-
-      // Fix for extra whitespace added by non-table cell styling on span coming from DS
-      // TODO: Bring this issue up with DS team and potentially fix there
-      > span + span {
-        @media screen and (min-width: 600px) {
-          display: table-cell;
-        }
-      }
+      padding-right: 0;
     }
   }
 

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -7,13 +7,16 @@
     margin-bottom: var(--nypl-space-xs);
   }
 
+  th {
+    text-transform: uppercase;
+  }
+
   tr {
     th,
     td,
     td:first-of-type,
     th:first-of-type {
-      text-transform: none;
-      padding: var(--nypl-space-s) 0;
+      padding: var(--nypl-space-s) var(--nypl-space-xs);
 
       // These min-widths are here temporarily to fix an issue with the table that causes the Format and Call number columns to appear to narrow
       // TODO: These can be removed if the issue is addressed in the DS or during VQA.

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -7,17 +7,30 @@
     margin-bottom: var(--nypl-space-xs);
   }
 
-  th {
-    text-transform: uppercase;
-  }
-
   tr {
+    th,
+    td {
+      padding: null var(--nypl-space-xs);
+    }
+
+    th {
+      text-transform: uppercase;
+    }
+
+    td:first-of-type,
+    th:first-of-type {
+      padding: var(--nypl-space-s) var(--nypl-space-xs) var(--nypl-space-s) 0;
+    }
+
+    td:last-of-type,
+    th:last-of-type {
+      padding: var(--nypl-space-s) 0 var(--nypl-space-s) var(--nypl-space-xs);
+    }
+
     th,
     td,
     td:first-of-type,
     th:first-of-type {
-      padding: var(--nypl-space-s) var(--nypl-space-xs);
-
       // These min-widths are here temporarily to fix an issue with the table that causes the Format and Call number columns to appear to narrow
       // TODO: These can be removed if the issue is addressed in the DS or during VQA.
       @media screen and (min-width: 600px) {
@@ -25,10 +38,10 @@
       }
 
       @media screen and (min-width: 900px) {
-        min-width: 130px;
+        min-width: 100px;
 
         &:first-child {
-          min-width: 370px;
+          min-width: 340px;
         }
       }
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4264](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4264)

## This PR does the following:

- Adds isScrollable to ItemTable on mobile
- Miscellaneous fixes to styling following DS version bump (padding, text-alignment, matching column headings to design)

## How has this been tested?

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4264]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ