### PR TITLE
SCC-4305 - Fix incorrect subject heading urls bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,17 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.2] 2024-10-4
+## [1.3.2] 2024-10-7
 
 ### Fixed
 
 - Adjust ItemTable styles according to design (SCC-4299)
 - Remove border and padding from eResources link as part of post-Bib page launch VQA (SCC-4299)
+- Remove base url from finding aid urls (SCC-4306)
+- Fix incorrect subject heading urls in Bib Details (SCC-4305)
 
 ### [1.3.1] Hotfix
 
 - Fix Table column widths on Search Results after DS 3.4.0 update (SCC-4299)
-- Remove base url from finding aid urls
 
 ## [1.3.0] 2024-10-3
 

--- a/src/components/BibPage/BibDetail.tsx
+++ b/src/components/BibPage/BibDetail.tsx
@@ -7,7 +7,7 @@ import RCLink from "../Links/RCLink/RCLink"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
 import type {
   BibDetail,
-  Url,
+  BibDetailURL,
   LinkedBibDetail,
   SubjectHeadingDetail,
   AnyBibDetail,
@@ -77,7 +77,7 @@ const PlainTextElement = (field: BibDetail) => {
 
 const CompoundSubjectHeadingElement = (field: SubjectHeadingDetail) => {
   const subjectHeadingLinksPerSubject = field.value.map(
-    (subjectHeadingUrls: Url[]) => {
+    (subjectHeadingUrls: BibDetailURL[]) => {
       return SingleSubjectHeadingElement(subjectHeadingUrls)
     }
   )
@@ -89,27 +89,30 @@ const CompoundSubjectHeadingElement = (field: SubjectHeadingDetail) => {
   return DetailElement(field.label, values)
 }
 
-const SingleSubjectHeadingElement = (subjectHeadingUrls: Url[]) => {
-  return subjectHeadingUrls.reduce((linksPerSubject, url: Url, index) => {
-    const divider = (
-      // this span will render as > in between the divided subject heading links
-      <span data-testid="divider" key={`divider-${index}`}>
-        {" "}
-        &gt;{" "}
-      </span>
-    )
-    const link = LinkElement(url, "internal")
-    linksPerSubject.push(link)
-    if (!isItTheLastElement(index, subjectHeadingUrls)) {
-      linksPerSubject.push(divider)
-    }
-    return linksPerSubject
-  }, [] as ReactElement[])
+const SingleSubjectHeadingElement = (subjectHeadingUrls: BibDetailURL[]) => {
+  return subjectHeadingUrls.reduce(
+    (linksPerSubject, url: BibDetailURL, index) => {
+      const divider = (
+        // this span will render as > in between the divided subject heading links
+        <span data-testid="divider" key={`divider-${index}`}>
+          {" "}
+          &gt;{" "}
+        </span>
+      )
+      const link = LinkElement(url, "internal")
+      linksPerSubject.push(link)
+      if (!isItTheLastElement(index, subjectHeadingUrls)) {
+        linksPerSubject.push(divider)
+      }
+      return linksPerSubject
+    },
+    [] as ReactElement[]
+  )
 }
 
 const LinkedDetailElement = (field: LinkedBibDetail) => {
   const internalOrExternal = field.link
-  const values = field.value.map((urlInfo: Url, i) => {
+  const values = field.value.map((urlInfo: BibDetailURL, i) => {
     return (
       <li key={`${kebabCase(field.label)}-${i}`}>
         {LinkElement(urlInfo, internalOrExternal)}
@@ -119,7 +122,7 @@ const LinkedDetailElement = (field: LinkedBibDetail) => {
   return DetailElement(field.label, values)
 }
 
-const LinkElement = (url: Url, linkType: string) => {
+const LinkElement = (url: BibDetailURL, linkType: string) => {
   let Link: typeof RCLink | typeof ExternalLink
   if (linkType === "internal") Link = RCLink
   else if (linkType === "external") Link = ExternalLink

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -365,28 +365,26 @@ export default class BibDetails {
 
   buildSubjectHeadings(): SubjectHeadingDetail {
     if (!this.bib.subjectHeadings) return
-    const subjectHeadingsUrls = this.bib.subjectHeadings.map(
-      ({ label, uuid }) => {
-        if (!label || !uuid) return
-        const subject = label.replace(/\.$/, "")
-        // stackedSubjectHeadings: ["a", "a -- b", "a -- b -- c"]
-        const stackedSubjectHeadings =
-          this.constructSubjectHeadingsArray(subject)
-        const shepUrl = `/subject_headings/${uuid}`
-        // splitSubjectHeadings: ["a", "b", "c"]
-        const splitSubjectHeadings = subject.split(" -- ")
+    const subjectHeadingsUrls = this.bib.subjectHeadings.map((heading) => {
+      const { label, uuid } = heading
+      if (!label || !uuid) return
+      const subject = label.replace(/\.$/, "")
+      // stackedSubjectHeadings: ["a", "a -- b", "a -- b -- c"]
+      const stackedSubjectHeadings = this.constructSubjectHeadingsArray(subject)
+      const shepUrl = `/subject_headings/${uuid}`
+      // splitSubjectHeadings: ["a", "b", "c"]
+      const splitSubjectHeadings = subject.split(" -- ")
 
-        return splitSubjectHeadings.map((heading, index) => {
-          const urlWithLabelParam = `${shepUrl}?label=${encodeURI(
-            stackedSubjectHeadings[index]
-          )}`
-          return {
-            url: urlWithLabelParam,
-            urlLabel: heading,
-          }
-        })
-      }
-    )
+      return splitSubjectHeadings.map((heading, index) => {
+        const urlWithLabelParam = `${shepUrl}?label=${encodeURI(
+          stackedSubjectHeadings[index]
+        )}`
+        return {
+          url: urlWithLabelParam,
+          urlLabel: heading,
+        }
+      })
+    })
     return {
       label: "Subject",
       value: subjectHeadingsUrls,
@@ -435,5 +433,31 @@ export default class BibDetails {
 
         return stackedSubjectHeading
       })
+  }
+
+  /**
+   * Recurvisely create a list of subject heading links.
+   */
+  constructSubjectHeading(heading) {
+    const { uuid, parent, label } = heading
+    let subjectComponent
+
+    if (label) {
+      subjectComponent = label.split(" -- ").pop()
+    }
+    const subjectLink = {
+      url: this.getSubjectHeadingUrl(uuid, label),
+      subjectComponent: subjectComponent || null,
+    }
+
+    if (!parent) {
+      return subjectLink
+    }
+
+    return [this.constructSubjectHeading(parent), subjectLink]
+  }
+
+  getSubjectHeadingUrl(uuid: string, label: string) {
+    return `/subject_headings/${uuid}?label=${encodeURIComponent(label)}`
   }
 }

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -1,14 +1,10 @@
-import type {
-  DiscoveryBibResult,
-  Note,
-  SubjectHeading,
-} from "../types/bibTypes"
+import type { DiscoveryBibResult, Note } from "../types/bibTypes"
 import type {
   LinkedBibDetail,
   BibDetail,
   FieldMapping,
   AnnotatedMarcField,
-  Url,
+  BibDetailURL,
   SubjectHeadingDetail,
   AnnotatedMarc,
   AnyBibDetail,
@@ -211,7 +207,10 @@ export default class BibDetails {
     }
   }
 
-  buildExternalLinkedDetail(label: string, values: Url[]): LinkedBibDetail {
+  buildExternalLinkedDetail(
+    label: string,
+    values: BibDetailURL[]
+  ): LinkedBibDetail {
     if (!values.length) return null
     return {
       link: "external",
@@ -428,7 +427,7 @@ export default class BibDetails {
   /**
    * Flatten subject headings into a list of objects with a url and a label
    */
-  flattenSubjectHeadingUrls(heading): Url[] | null {
+  flattenSubjectHeadingUrls(heading): BibDetailURL[] | null {
     if (!heading.label || !heading.uuid) return null
     const subjectHeadingsArray = []
 
@@ -448,7 +447,7 @@ export default class BibDetails {
     return subjectHeadingsArray
   }
 
-  getSubjectHeadingUrl(uuid: string, label: string): Url {
+  getSubjectHeadingUrl(uuid: string, label: string): BibDetailURL {
     return {
       url: `/subject_headings/${uuid}?label=${encodeURIComponent(label)}`,
       urlLabel: label.split(" -- ").pop(),

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -370,10 +370,10 @@ export default class BibDetails {
       if (!label || !uuid) return
       const subject = label.replace(/\.$/, "")
       // stackedSubjectHeadings: ["a", "a -- b", "a -- b -- c"]
-      const stackedSubjectHeadings = this.constructSubjectHeadingsArray(subject)
-      const shepUrl = `/subject_headings/${uuid}`
+      const stackedSubjectHeadings = this.constructSubjectHeadingsArray(heading)
       // splitSubjectHeadings: ["a", "b", "c"]
       const splitSubjectHeadings = subject.split(" -- ")
+      const shepUrl = ""
 
       return splitSubjectHeadings.map((heading, index) => {
         const urlWithLabelParam = `${shepUrl}?label=${encodeURI(
@@ -398,7 +398,7 @@ export default class BibDetails {
         subject = subject.replace(/\.$/, "")
         // stackedSubjectHeadings: ["a", "a -- b", "a -- b -- c"]
         const stackedSubjectHeadings =
-          this.constructSubjectHeadingsArray(subject)
+          this.constructSubjectLiteralsArray(subject)
         const filterQueryForSubjectHeading = "/search?filters[subjectLiteral]="
         // splitSubjectHeadings: ["a", "b", "c"]
         const splitSubjectHeadings = subject.split(" -- ")
@@ -419,9 +419,9 @@ export default class BibDetails {
     }
   }
 
-  constructSubjectHeadingsArray(subject: string) {
+  constructSubjectLiteralsArray(subject: string) {
     // subject = "Italian food -- Spaghetti"
-    let stackedSubjectHeading = ""
+    let stackedSubjectLiteral = ""
 
     return subject
       .split(" -- ") // ["Italian food", "spaghetti"]
@@ -429,17 +429,18 @@ export default class BibDetails {
         const dashDivided = index !== 0 ? " -- " : ""
         // First iteration "Italian food"
         // Second iteration "Italian food -- spaghetti"
-        stackedSubjectHeading = `${stackedSubjectHeading}${dashDivided}${urlString}`
+        stackedSubjectLiteral = `${stackedSubjectLiteral}${dashDivided}${urlString}`
 
-        return stackedSubjectHeading
+        return stackedSubjectLiteral
       })
   }
 
   /**
-   * Recurvisely create a list of subject heading links.
+   * Flatten subject headings into a list of objects with a url and a label
    */
-  constructSubjectHeading(heading) {
+  constructSubjectHeadingsArray(heading) {
     const { uuid, parent, label } = heading
+    let subjectHeadingsArray = []
     let subjectComponent
 
     if (label) {
@@ -451,10 +452,11 @@ export default class BibDetails {
     }
 
     if (!parent) {
-      return subjectLink
+      subjectHeadingsArray.push(subjectLink)
+      return subjectHeadingsArray
     }
 
-    return [this.constructSubjectHeading(parent), subjectLink]
+    return [this.constructSubjectHeadingsArray(parent)].concat(subjectLink)
   }
 
   getSubjectHeadingUrl(uuid: string, label: string) {

--- a/src/models/modelTests/BibDetails.test.ts
+++ b/src/models/modelTests/BibDetails.test.ts
@@ -63,25 +63,25 @@ describe("Bib model", () => {
         value: [
           [
             {
-              url: "/subject_headings/74746d11-638b-4cfb-a72a-9a2bd296e6fd?label=Cortanze,%20G%C3%A9rard%20de",
+              url: "/subject_headings/cf347108-e1f2-4c0f-808a-ac4ace2f0765?label=Cortanze%2C%20G%C3%A9rard%20de",
               urlLabel: "Cortanze, Gérard de",
             },
             {
-              url: "/subject_headings/74746d11-638b-4cfb-a72a-9a2bd296e6fd?label=Cortanze,%20G%C3%A9rard%20de%20--%20Childhood%20and%20youth",
+              url: "/subject_headings/74746d11-638b-4cfb-a72a-9a2bd296e6fd?label=Cortanze%2C%20G%C3%A9rard%20de%20--%20Childhood%20and%20youth",
               urlLabel: "Childhood and youth",
             },
           ],
           [
             {
-              url: "/subject_headings/9391bc26-e44c-44ac-98cc-e3800da51926?label=Authors,%20French",
+              url: "/subject_headings/5fd065df-b4e9-48cb-b13c-ea15f36b96b4?label=Authors%2C%20French",
               urlLabel: "Authors, French",
             },
             {
-              url: "/subject_headings/9391bc26-e44c-44ac-98cc-e3800da51926?label=Authors,%20French%20--%2020th%20century",
+              url: "/subject_headings/e43674a7-5f02-44f1-95cd-dbcc776331b7?label=Authors%2C%20French%20--%2020th%20century",
               urlLabel: "20th century",
             },
             {
-              url: "/subject_headings/9391bc26-e44c-44ac-98cc-e3800da51926?label=Authors,%20French%20--%2020th%20century%20--%20Biography",
+              url: "/subject_headings/9391bc26-e44c-44ac-98cc-e3800da51926?label=Authors%2C%20French%20--%2020th%20century%20--%20Biography",
               urlLabel: "Biography",
             },
           ],

--- a/src/types/bibDetailsTypes.ts
+++ b/src/types/bibDetailsTypes.ts
@@ -1,7 +1,7 @@
 export type AnyBibDetail = BibDetail | LinkedBibDetail | SubjectHeadingDetail
 
 export interface SubjectHeadingDetail {
-  value: Url[][]
+  value: BibDetailURL[][]
   label: string
 }
 
@@ -13,7 +13,7 @@ export interface BibDetail {
 }
 
 export interface LinkedBibDetail {
-  value: Url[]
+  value: BibDetailURL[]
   // label is the formatted name of the field, such as "Author"
   label: string
   // indicates if a linked bib detail is internal, like a link to a creator
@@ -21,7 +21,7 @@ export interface LinkedBibDetail {
   link?: "internal" | "external"
 }
 
-export interface Url {
+export interface BibDetailURL {
   url: string
   urlLabel: string
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4305](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4305)

## This PR does the following:

- Fixes bug where the subject urls for "parent" subject elements are incorrect.
- Adds flattenSubjectHeadingUrls which iterates through subject heading's parent elements to build an array of subject heading urls.
- Simplifies buildSubjectHeadings
- Renames "Url" to BibDetailsURL. Wanted to make it more explicit since I was briefly tripped up by spelling it URL, which is built into Typescript.
- Renames constructSubjectHeadingsArray to constructSubjectLiteralsArray

## How has this been tested?

- We had tests for this but they were faulty, fixed now.

## Accessibility concerns or updates

- NA

### Checklist:

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4305]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ