### PR TITLE
SCC-4253: Edit email My Account 2.0 **With no js

### DIFF
--- a/pages/account/[[...index]].tsx
+++ b/pages/account/[[...index]].tsx
@@ -1,4 +1,4 @@
-import { Banner, Text } from "@nypl/design-system-react-components"
+import { Text } from "@nypl/design-system-react-components"
 import Head from "next/head"
 
 import Layout from "../../src/components/Layout/Layout"
@@ -123,7 +123,6 @@ export async function getServerSideProps({ req, res }) {
   const tabsPathRegex = /\/account\/(.+)/
   const match = req.url.match(tabsPathRegex)
   const queryString = req.url.split("?")[1] || null
-  console.log(queryString)
   const tabsPath = match ? match[1] : null
   const id = patronTokenResponse.decodedPatron.sub
 
@@ -154,7 +153,7 @@ export async function getServerSideProps({ req, res }) {
         const matchedPath = allowedPaths.find((path) =>
           tabsPath.startsWith(path)
         )
-        if (tabsPath !== matchedPath) {
+        if (tabsPath != matchedPath) {
           return {
             redirect: {
               destination: "/account/" + matchedPath,
@@ -165,8 +164,8 @@ export async function getServerSideProps({ req, res }) {
       }
     }
 
+    // Saving the string and removing the cookie so it doesn't persist on reload.
     const storedQueryString = req.cookies.queryParams || ""
-    // Removing query string cookie so it doesn't persist on reload.
     res.setHeader("Set-Cookie", "queryParams=; Path=/; HttpOnly; Max-Age=0")
     return {
       props: {

--- a/pages/api/account/settings/[id].ts
+++ b/pages/api/account/settings/[id].ts
@@ -22,6 +22,42 @@ export default async function handler(
   if (req.method == "GET") {
     responseMessage = "Please make a PUT request to this endpoint."
   }
+  if (req.method === "POST" && req.body._method === "PUT") {
+    const patronId = req.query.id as string
+    const patronData = req.body.emails
+
+    const emailRegex = /^[^@]+@[^@]+\.[^@]+$/
+    const invalidEmails = patronData.filter((email) => !emailRegex.test(email))
+
+    if (invalidEmails.length > 0) {
+      const errorMessage = `Please enter a valid email. Invalid emails: ${invalidEmails.join(
+        ", "
+      )}`
+      res.writeHead(302, {
+        Location: `/research/research-catalog/account/settings?error=${encodeURIComponent(
+          errorMessage
+        )}`,
+      })
+      res.end()
+      return
+    }
+
+    if (patronId == cookiePatronId) {
+      const response = await updatePatronSettings(patronId, {
+        emails: patronData,
+      })
+      responseStatus = response.status
+      responseMessage = response.message
+    } else {
+      responseStatus = 403
+      responseMessage = "Authenticated patron does not match request"
+    }
+    res.writeHead(302, {
+      Location: "/research/research-catalog/account/settings?success=true",
+    })
+    res.end()
+    return
+  }
   if (req.method == "PUT") {
     /**  We get the patron id from the request: */
     const patronId = req.query.id as string

--- a/pages/api/account/settings/[id].ts
+++ b/pages/api/account/settings/[id].ts
@@ -58,9 +58,9 @@ export default async function handler(
 
     // Remove duplicate emails while keeping the first
     const uniqueEmails = patronData.reduce((acc, email) => {
-      const normalizedEmail = email.toLowerCase()
-      if (!acc.includes(normalizedEmail)) {
-        acc.push(normalizedEmail)
+      const lowercaseEmail = email.toLowerCase()
+      if (!acc.includes(lowercaseEmail)) {
+        acc.push(lowercaseEmail)
       }
       return acc
     }, [])

--- a/src/components/MyAccount/NewSettings/EmailForm.test.tsx
+++ b/src/components/MyAccount/NewSettings/EmailForm.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import EmailForm from "./EmailForm"
+import { filteredPickupLocations } from "../../../../__test__/fixtures/processedMyAccountData"
+import { PatronDataProvider } from "../../../context/PatronDataContext"
+import { processedPatron } from "../../../../__test__/fixtures/processedMyAccountData"
+
+describe("email form", () => {
+  const mockSetIsLoading = jest.fn()
+  const mockSetIsSuccess = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => {
+        console.log("Updated")
+      },
+      status: 200,
+    } as Response)
+  })
+
+  const component = (
+    <PatronDataProvider
+      value={{
+        patron: processedPatron,
+        pickupLocations: filteredPickupLocations,
+      }}
+    >
+      <EmailForm
+        patronData={processedPatron}
+        setIsLoading={mockSetIsLoading}
+        setIsSuccess={mockSetIsSuccess}
+      />
+    </PatronDataProvider>
+  )
+
+  it("renders correctly with initial email", () => {
+    render(component)
+
+    expect(screen.getByText("streganonna@gmail.com")).toBeInTheDocument()
+
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument()
+  })
+
+  it("allows editing when edit button is clicked", () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    expect(screen.getAllByLabelText("Update email")[0]).toBeInTheDocument()
+    expect(
+      screen.getByDisplayValue("streganonna@gmail.com")
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /save changes/i })
+    ).toBeInTheDocument()
+  })
+
+  it("validates email input correctly", () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    const input = screen.getAllByLabelText("Update email")[0]
+    fireEvent.change(input, { target: { value: "invalid-email" } })
+
+    expect(
+      screen.getByText("Please enter a valid email address.")
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled()
+  })
+
+  it("allows adding a new email field", () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /\+ add an email address/i })
+    )
+
+    expect(screen.getAllByLabelText("Update email").length).toBe(3)
+  })
+
+  it("removes an email when delete icon is clicked", () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    fireEvent.click(screen.getByLabelText("Remove email"))
+
+    expect(
+      screen.queryByDisplayValue("spaghettigrandma@gmail.com")
+    ).not.toBeInTheDocument()
+  })
+
+  it("calls submitEmails with valid data", async () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    const input = screen.getAllByLabelText("Update email")[0]
+    fireEvent.change(input, { target: { value: "newemail@example.com" } })
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/research/research-catalog/api/account/settings/6742743",
+      expect.objectContaining({
+        body: '{"emails":["newemail@example.com","spaghettigrandma@gmail.com"]}',
+        headers: { "Content-Type": "application/json" },
+        method: "PUT",
+      })
+    )
+  })
+
+  it("cancels editing and reverts state", () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    const input = screen.getAllByLabelText("Update email")[0]
+    fireEvent.change(input, { target: { value: "modified@example.com" } })
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    expect(screen.getByText("streganonna@gmail.com")).toBeInTheDocument()
+    expect(
+      screen.queryByDisplayValue("modified@example.com")
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/MyAccount/NewSettings/EmailForm.tsx
+++ b/src/components/MyAccount/NewSettings/EmailForm.tsx
@@ -149,7 +149,12 @@ const EmailForm = ({ patronData, setIsLoading, setIsSuccess }) => {
             id="add-button"
             buttonType="text"
             onClick={addEmailField}
-            sx={{ justifyContent: "flex-start", width: "300px" }}
+            size="large"
+            sx={{
+              justifyContent: "flex-start",
+              width: "300px",
+              padding: "xxs",
+            }}
           >
             + Add an email address
           </Button>

--- a/src/components/MyAccount/NewSettings/EmailForm.tsx
+++ b/src/components/MyAccount/NewSettings/EmailForm.tsx
@@ -1,0 +1,159 @@
+import {
+  Icon,
+  TextInput,
+  Text,
+  Flex,
+  Button,
+} from "@nypl/design-system-react-components"
+import { useState } from "react"
+
+const EmailForm = ({ patronData }) => {
+  console.log(patronData.emails)
+  const [emails, setEmails] = useState(patronData?.emails || [])
+  const [isEditing, setIsEditing] = useState(false)
+  const [error, setError] = useState(false)
+  const [tempEmails, setTempEmails] = useState([...emails])
+
+  const validateEmail = (email) => {
+    const emailRegex = /^[^@]+@[^@]+\.[^@]+$/
+    return emailRegex.test(email)
+  }
+
+  const handleInputChange = (e, index) => {
+    const { value } = e.target
+    const updatedEmails = [...tempEmails]
+    updatedEmails[index] = value
+    setTempEmails(updatedEmails)
+    setError(!validateEmail(value))
+  }
+
+  const saveEmails = () => {
+    const hasInvalidEmail = tempEmails.some((email) => !validateEmail(email))
+    if (hasInvalidEmail) {
+      setError(true)
+      return
+    }
+    submitEmails(tempEmails)
+    setEmails(tempEmails)
+    setIsEditing(false)
+  }
+
+  const submitEmails = async (emails) => {
+    const response = await fetch(
+      `/research/research-catalog/api/account/settings/${patronData.id}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ emails }),
+      }
+    )
+    if (response.status === 200) {
+      console.log("yay")
+    } else {
+      console.log(response)
+    }
+  }
+
+  const cancelEditing = () => {
+    setTempEmails([...emails])
+    setIsEditing(false)
+    setError(false)
+  }
+
+  const addEmailField = () => {
+    setTempEmails([...tempEmails, ""])
+  }
+
+  return (
+    <>
+      <Flex gap="xs" alignItems="center">
+        <Icon name="communicationEmail" size="medium" />
+        <Text
+          size="body1"
+          sx={{ fontWeight: "500", width: "305px", marginBottom: 0 }}
+        >
+          Email
+        </Text>
+      </Flex>
+      <Flex gap="xs" alignItems="center" flexDir="column">
+        {isEditing ? (
+          <Flex flexDir={"column"}>
+            {tempEmails.map((email, index) => (
+              <Flex key={index} mb="s">
+                <TextInput
+                  name={`email-${index}`}
+                  value={email}
+                  id={`email-text-input-${index}`}
+                  labelText="Update email"
+                  showLabel={false}
+                  isInvalid={error && !validateEmail(email)}
+                  invalidText="Please enter a valid email address."
+                  onChange={(e) => handleInputChange(e, index)}
+                  isRequired
+                  isClearable
+                  sx={{ marginRight: "xl", width: "300px" }}
+                />
+                {index !== 0 && (
+                  <Button
+                    aria-label="Remove email"
+                    buttonType="text"
+                    id="remove-email-btn"
+                    onClick={() =>
+                      setTempEmails(tempEmails.filter((_, i) => i !== index))
+                    }
+                  >
+                    <Icon name="arrow" iconRotation="rotate270" size="small" />
+                  </Button>
+                )}
+              </Flex>
+            ))}
+            <Button
+              id="add-button"
+              buttonType="text"
+              onClick={addEmailField}
+              sx={{ justifyContent: "flex-start" }}
+            >
+              + Add an email address
+            </Button>
+          </Flex>
+        ) : (
+          <Flex flexDir={"row"} alignItems="center">
+            <Text sx={{ marginBottom: 0 }}>{emails[0]}</Text>
+            <Button
+              id="edit-email-button"
+              buttonType="text"
+              onClick={() => setIsEditing(true)}
+            >
+              <Icon name="editorMode" align="left" size="medium" />
+              Edit
+            </Button>
+          </Flex>
+        )}
+      </Flex>
+      {isEditing && (
+        <Flex>
+          <Button
+            sx={{ marginRight: "s" }}
+            id="cancel-button"
+            buttonType="secondary"
+            onClick={cancelEditing}
+          >
+            Cancel
+          </Button>
+          <Button
+            id="save-button"
+            isDisabled={error}
+            buttonType="primary"
+            onClick={saveEmails}
+          >
+            Save changes
+          </Button>
+        </Flex>
+      )}
+    </>
+  )
+}
+
+export default EmailForm

--- a/src/components/MyAccount/NewSettings/EmailForm.tsx
+++ b/src/components/MyAccount/NewSettings/EmailForm.tsx
@@ -21,15 +21,6 @@ const EmailForm = ({ patronData, setIsLoading, setIsSuccess }) => {
     return emailRegex.test(email)
   }
 
-  const handleRemoveEmail = (index) => {
-    const updatedEmails = tempEmails.filter((_, i) => i !== index)
-    setTempEmails(updatedEmails)
-
-    // Immediately revalidate remaining emails.
-    const hasInvalidEmail = updatedEmails.some((email) => !validateEmail(email))
-    setError(hasInvalidEmail)
-  }
-
   const handleInputChange = (e, index) => {
     const { value } = e.target
     const updatedEmails = [...tempEmails]
@@ -47,11 +38,35 @@ const EmailForm = ({ patronData, setIsLoading, setIsSuccess }) => {
     }
   }
 
+  const handleRemoveEmail = (index) => {
+    const updatedEmails = tempEmails.filter((_, i) => i !== index)
+    setTempEmails(updatedEmails)
+
+    // Immediately revalidate remaining emails.
+    const hasInvalidEmail = updatedEmails.some((email) => !validateEmail(email))
+    setError(hasInvalidEmail)
+  }
+
+  const handleAddEmail = () => {
+    const updatedEmails = [...tempEmails, ""]
+    setTempEmails(updatedEmails)
+
+    // Immediately revalidate all emails.
+    const hasInvalidEmail = updatedEmails.some((email) => !validateEmail(email))
+    setError(hasInvalidEmail)
+  }
+
   const handleClearableCallback = (index) => {
     const updatedEmails = [...tempEmails]
     updatedEmails[index] = ""
     setTempEmails(updatedEmails)
     setError(true)
+  }
+
+  const cancelEditing = () => {
+    setTempEmails([...emails])
+    setIsEditing(false)
+    setError(false)
   }
 
   const submitEmails = async () => {
@@ -82,21 +97,6 @@ const EmailForm = ({ patronData, setIsLoading, setIsSuccess }) => {
     } finally {
       setIsLoading(false)
     }
-  }
-
-  const cancelEditing = () => {
-    setTempEmails([...emails])
-    setIsEditing(false)
-    setError(false)
-  }
-
-  const addEmailField = () => {
-    const updatedEmails = [...tempEmails, ""]
-    setTempEmails(updatedEmails)
-
-    // Immediately revalidate all emails.
-    const hasInvalidEmail = updatedEmails.some((email) => !validateEmail(email))
-    setError(hasInvalidEmail)
   }
 
   return (
@@ -148,7 +148,7 @@ const EmailForm = ({ patronData, setIsLoading, setIsSuccess }) => {
           <Button
             id="add-button"
             buttonType="text"
-            onClick={addEmailField}
+            onClick={handleAddEmail}
             size="large"
             sx={{
               justifyContent: "flex-start",

--- a/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
+++ b/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
@@ -3,9 +3,10 @@ import {
   Flex,
   Banner,
 } from "@nypl/design-system-react-components"
-import { useContext, useState } from "react"
+import { useContext, useEffect, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import EmailForm from "./EmailForm"
+import NoJsEmailForm from "./NoJsEmailForm"
 
 const NewAccountSettingsTab = () => {
   const {
@@ -13,6 +14,11 @@ const NewAccountSettingsTab = () => {
   } = useContext(PatronDataContext)
   const [isLoading, setIsLoading] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
+  const [isJsEnabled, setIsJsEnabled] = useState(false)
+
+  useEffect(() => {
+    setIsJsEnabled(true)
+  }, [])
 
   return isLoading ? (
     <SkeletonLoader contentSize={2} showImage={false} headingSize={0} />
@@ -29,11 +35,15 @@ const NewAccountSettingsTab = () => {
         />
       )}
       <Flex sx={{ marginTop: "xl" }}>
-        <EmailForm
-          patronData={patron}
-          setIsLoading={setIsLoading}
-          setIsSuccess={setIsSuccess}
-        />
+        {isJsEnabled ? (
+          <EmailForm
+            patronData={patron}
+            setIsLoading={setIsLoading}
+            setIsSuccess={setIsSuccess}
+          />
+        ) : (
+          <NoJsEmailForm patronData={patron} />
+        )}
       </Flex>
     </>
   )

--- a/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
+++ b/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
@@ -1,0 +1,23 @@
+import { SkeletonLoader, Flex } from "@nypl/design-system-react-components"
+import { useContext, useState } from "react"
+import { PatronDataContext } from "../../../context/PatronDataContext"
+import EmailForm from "./EmailForm"
+
+const NewAccountSettingsTab = () => {
+  const {
+    patronDataLoading,
+    getMostUpdatedSierraAccountData,
+    updatedAccountData: { patron, pickupLocations },
+  } = useContext(PatronDataContext)
+  const [isLoading, setIsLoading] = useState(false)
+
+  return isLoading ? (
+    <SkeletonLoader showImage={false} />
+  ) : (
+    <Flex sx={{ marginTop: "xl" }}>
+      <EmailForm patronData={patron} />
+    </Flex>
+  )
+}
+
+export default NewAccountSettingsTab

--- a/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
+++ b/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
@@ -1,22 +1,41 @@
-import { SkeletonLoader, Flex } from "@nypl/design-system-react-components"
+import {
+  SkeletonLoader,
+  Flex,
+  Banner,
+} from "@nypl/design-system-react-components"
 import { useContext, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import EmailForm from "./EmailForm"
 
 const NewAccountSettingsTab = () => {
   const {
-    patronDataLoading,
-    getMostUpdatedSierraAccountData,
-    updatedAccountData: { patron, pickupLocations },
+    updatedAccountData: { patron },
   } = useContext(PatronDataContext)
   const [isLoading, setIsLoading] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
 
   return isLoading ? (
-    <SkeletonLoader showImage={false} />
+    <SkeletonLoader contentSize={2} showImage={false} headingSize={0} />
   ) : (
-    <Flex sx={{ marginTop: "xl" }}>
-      <EmailForm patronData={patron} />
-    </Flex>
+    <>
+      {isSuccess && (
+        <Banner
+          isDismissible
+          content={
+            <div style={{ alignItems: "center" }}>Your changes were saved.</div>
+          }
+          type="positive"
+          sx={{ marginTop: "m" }}
+        />
+      )}
+      <Flex sx={{ marginTop: "xl" }}>
+        <EmailForm
+          patronData={patron}
+          setIsLoading={setIsLoading}
+          setIsSuccess={setIsSuccess}
+        />
+      </Flex>
+    </>
   )
 }
 

--- a/src/components/MyAccount/NewSettings/NoJsEmailForm.tsx
+++ b/src/components/MyAccount/NewSettings/NoJsEmailForm.tsx
@@ -7,7 +7,6 @@ import {
 
 const NoJsEmailForm = ({ patronData }) => {
   const tempEmails = patronData?.emails || []
-
   return (
     <>
       <form
@@ -83,8 +82,7 @@ const NoJsEmailForm = ({ patronData }) => {
               </div>
             ))}
             <Text size="caption" sx={{ marginBottom: 0 }}>
-              {" "}
-              Add an email address:{" "}
+              Add an email address:
             </Text>
             <TextInput
               type="email"

--- a/src/components/MyAccount/NewSettings/NoJsEmailForm.tsx
+++ b/src/components/MyAccount/NewSettings/NoJsEmailForm.tsx
@@ -1,4 +1,9 @@
-import { Button, Icon, TextInput } from "@nypl/design-system-react-components"
+import {
+  Button,
+  Icon,
+  TextInput,
+  Text,
+} from "@nypl/design-system-react-components"
 
 const NoJsEmailForm = ({ patronData }) => {
   const tempEmails = patronData?.emails || []
@@ -10,52 +15,93 @@ const NoJsEmailForm = ({ patronData }) => {
         method="POST"
         style={{ width: "100%" }}
       >
-        <input type="hidden" name="_method" value="PUT" />
         <div
           style={{
             display: "flex",
             flexDirection: "row",
-            alignItems: "center",
+            alignItems: "flex-start",
           }}
         >
-          <h3
+          <div
             style={{
               display: "flex",
-              fontWeight: "500",
-              flexDirection: "row",
-              gap: "8px",
-              alignItems: "center",
             }}
           >
-            <Icon name="communicationEmail" size="medium" /> Email
-          </h3>
+            <h3
+              style={{
+                display: "flex",
+                fontWeight: "500",
+                flexDirection: "row",
+                width: "256px",
+                gap: "8px",
+                alignItems: "center",
+              }}
+            >
+              <Icon name="communicationEmail" size="medium" /> Email
+            </h3>
+          </div>
           <div
             style={{
               display: "flex",
               flexDirection: "column",
               paddingLeft: "24px",
               paddingRight: "8px",
-              width: "30%",
               gap: "8px",
             }}
           >
             {tempEmails.map((email, index) => (
-              <TextInput
+              <div
                 key={index}
-                type="email"
-                name={"emails"}
-                defaultValue={email}
-                required
-                id={`email-${index}`}
-                showLabel={false}
-                showHelperInvalidText={false}
-                labelText={"Email"}
-              />
+                style={{
+                  display: "flex",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: "8px",
+                }}
+              >
+                <TextInput
+                  type="email"
+                  name={"emails"}
+                  defaultValue={email}
+                  required
+                  id={`email-${index}`}
+                  showLabel={false}
+                  showHelperInvalidText={false}
+                  labelText={"Email"}
+                  sx={{ width: "300px" }}
+                />
+                {index === 0 && <span style={{ color: "gray" }}>(P)</span>}
+                {index > 0 && (
+                  <button type="submit" name="delete" value={index}>
+                    <Icon
+                      name="actionDelete"
+                      size="large"
+                      color="ui.link.primary"
+                    />
+                  </button>
+                )}
+              </div>
             ))}
+            <Text size="caption" sx={{ marginBottom: 0 }}>
+              {" "}
+              Add an email address:{" "}
+            </Text>
+            <TextInput
+              type="email"
+              name="emails"
+              defaultValue=""
+              id={"email-new"}
+              showLabel={false}
+              showHelperInvalidText={false}
+              labelText="Add new email"
+              sx={{ width: "300px" }}
+            />
           </div>
-          <Button type="submit" sx={{ marginLeft: "32px" }} id={""}>
-            Save changes
-          </Button>
+          <div style={{ justifySelf: "flex-end", marginLeft: "auto" }}>
+            <Button type="submit" id={"submit-emails"}>
+              Save changes
+            </Button>
+          </div>
         </div>
       </form>
     </>

--- a/src/components/MyAccount/NewSettings/NoJsEmailForm.tsx
+++ b/src/components/MyAccount/NewSettings/NoJsEmailForm.tsx
@@ -1,0 +1,65 @@
+import { Button, Icon, TextInput } from "@nypl/design-system-react-components"
+
+const NoJsEmailForm = ({ patronData }) => {
+  const tempEmails = patronData?.emails || []
+
+  return (
+    <>
+      <form
+        action={`/research/research-catalog/api/account/settings/${patronData.id}`}
+        method="POST"
+        style={{ width: "100%" }}
+      >
+        <input type="hidden" name="_method" value="PUT" />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+          }}
+        >
+          <h3
+            style={{
+              display: "flex",
+              fontWeight: "500",
+              flexDirection: "row",
+              gap: "8px",
+              alignItems: "center",
+            }}
+          >
+            <Icon name="communicationEmail" size="medium" /> Email
+          </h3>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              paddingLeft: "24px",
+              paddingRight: "8px",
+              width: "30%",
+              gap: "8px",
+            }}
+          >
+            {tempEmails.map((email, index) => (
+              <TextInput
+                key={index}
+                type="email"
+                name={"emails"}
+                defaultValue={email}
+                required
+                id={`email-${index}`}
+                showLabel={false}
+                showHelperInvalidText={false}
+                labelText={"Email"}
+              />
+            ))}
+          </div>
+          <Button type="submit" sx={{ marginLeft: "32px" }} id={""}>
+            Save changes
+          </Button>
+        </div>
+      </form>
+    </>
+  )
+}
+
+export default NoJsEmailForm

--- a/src/components/MyAccount/NewSettings/NoJsFormValidationMessage.tsx
+++ b/src/components/MyAccount/NewSettings/NoJsFormValidationMessage.tsx
@@ -6,7 +6,7 @@ const FormValidationMessage = ({ storedQueryString }) => {
   const message = queryString.split("=")[1] || ""
   return (
     <Banner
-      sx={{ paddingBottom: "24px", paddingTop: "24px" }}
+      sx={{ paddingBottom: "16px", paddingTop: "16px", marginBottom: "16px" }}
       content={type === "success" ? "Your changes were saved." : message}
       type={type === "success" ? "positive" : "warning"}
     />

--- a/src/components/MyAccount/NewSettings/NoJsFormValidationMessage.tsx
+++ b/src/components/MyAccount/NewSettings/NoJsFormValidationMessage.tsx
@@ -1,0 +1,26 @@
+import { Banner } from "@nypl/design-system-react-components"
+
+const FormValidationMessage = ({ storedQueryString }) => {
+  const queryString = decodeURIComponent(storedQueryString)
+  const type = queryString.split("=")[0] || ""
+  const message = queryString.split("=")[1] || ""
+  if (type === "success") {
+    return (
+      <Banner
+        sx={{ paddingBottom: "24px", paddingTop: "24px" }}
+        content={"Successfully updated settings."}
+        type="positive"
+      />
+    )
+  } else {
+    return (
+      <Banner
+        sx={{ paddingBottom: "24px", paddingTop: "24px" }}
+        content={message}
+        type="warning"
+      />
+    )
+  }
+}
+
+export default FormValidationMessage

--- a/src/components/MyAccount/NewSettings/NoJsFormValidationMessage.tsx
+++ b/src/components/MyAccount/NewSettings/NoJsFormValidationMessage.tsx
@@ -4,23 +4,13 @@ const FormValidationMessage = ({ storedQueryString }) => {
   const queryString = decodeURIComponent(storedQueryString)
   const type = queryString.split("=")[0] || ""
   const message = queryString.split("=")[1] || ""
-  if (type === "success") {
-    return (
-      <Banner
-        sx={{ paddingBottom: "24px", paddingTop: "24px" }}
-        content={"Successfully updated settings."}
-        type="positive"
-      />
-    )
-  } else {
-    return (
-      <Banner
-        sx={{ paddingBottom: "24px", paddingTop: "24px" }}
-        content={message}
-        type="warning"
-      />
-    )
-  }
+  return (
+    <Banner
+      sx={{ paddingBottom: "24px", paddingTop: "24px" }}
+      content={type === "success" ? "Your changes were saved." : message}
+      type={type === "success" ? "positive" : "warning"}
+    />
+  )
 }
 
 export default FormValidationMessage

--- a/src/components/MyAccount/ProfileTabs.tsx
+++ b/src/components/MyAccount/ProfileTabs.tsx
@@ -7,6 +7,7 @@ import RequestsTab from "./RequestsTab/RequestsTab"
 import FeesTab from "./FeesTab/FeesTab"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { useContext } from "react"
+import NewAccountSettingsTab from "./NewSettings/NewAccountSettingsTab"
 
 interface ProfileTabsPropsType {
   activePath: string
@@ -49,7 +50,7 @@ const ProfileTabs = ({ activePath }: ProfileTabsPropsType) => {
       : []),
     {
       label: "Account settings",
-      content: <AccountSettingsTab />,
+      content: <NewAccountSettingsTab />,
       urlPath: "settings",
     },
   ]

--- a/src/components/MyAccount/Settings/AccountSettingsTab.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsTab.tsx
@@ -61,6 +61,7 @@ const AccountSettingsTab = () => {
     e.preventDefault()
     setIsLoading(true)
     const payload = parseAccountSettingsPayload(e.target, patron)
+    console.log(payload)
     const response = await fetch(
       `/research/research-catalog/api/account/settings/${patron.id}`,
       {
@@ -71,6 +72,7 @@ const AccountSettingsTab = () => {
         body: JSON.stringify(payload),
       }
     )
+    console.log(response)
     if (response.status === 200) {
       await getMostUpdatedSierraAccountData()
       setCurrentlyEditing(false)

--- a/src/components/MyAccount/Settings/AccountSettingsTab.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsTab.tsx
@@ -61,7 +61,6 @@ const AccountSettingsTab = () => {
     e.preventDefault()
     setIsLoading(true)
     const payload = parseAccountSettingsPayload(e.target, patron)
-    console.log(payload)
     const response = await fetch(
       `/research/research-catalog/api/account/settings/${patron.id}`,
       {
@@ -72,7 +71,6 @@ const AccountSettingsTab = () => {
         body: JSON.stringify(payload),
       }
     )
-    console.log(response)
     if (response.status === 200) {
       await getMostUpdatedSierraAccountData()
       setCurrentlyEditing(false)

--- a/src/components/MyAccount/TimedLogoutModal.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.tsx
@@ -48,23 +48,23 @@ const TimedLogoutModal = ({
   //   logOutAndRedirect()
   // }
 
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      const { minutes, seconds } = buildTimeLeft(expirationTime)
-      if (minutes < timeoutWindow) setOpen(true)
-      setTimeUntilExpiration({
-        minutes,
-        seconds,
-      })
-    }, 1000)
-    return () => {
-      clearTimeout(timeout)
-    }
-  })
+  // useEffect(() => {
+  //   const timeout = setTimeout(() => {
+  //     const { minutes, seconds } = buildTimeLeft(expirationTime)
+  //     if (minutes < timeoutWindow) setOpen(true)
+  //     setTimeUntilExpiration({
+  //       minutes,
+  //       seconds,
+  //     })
+  //   }, 1000)
+  //   return () => {
+  //     clearTimeout(timeout)
+  //   }
+  // })
 
-  if (timeUntilExpiration.minutes <= 0 && timeUntilExpiration.seconds <= 0) {
-    logOutAndRedirect()
-  }
+  // if (timeUntilExpiration.minutes <= 0 && timeUntilExpiration.seconds <= 0) {
+  //   logOutAndRedirect()
+  // }
   if (!open) return null
 
   return (

--- a/src/components/MyAccount/TimedLogoutModal.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.tsx
@@ -41,30 +41,30 @@ const TimedLogoutModal = ({
     buildTimeLeft(expirationTime)
   )
 
-  // if (
-  //   typeof document !== "undefined" &&
-  //   !document.cookie.includes("accountPageExp")
-  // ) {
-  //   logOutAndRedirect()
-  // }
+  if (
+    typeof document !== "undefined" &&
+    !document.cookie.includes("accountPageExp")
+  ) {
+    logOutAndRedirect()
+  }
 
-  // useEffect(() => {
-  //   const timeout = setTimeout(() => {
-  //     const { minutes, seconds } = buildTimeLeft(expirationTime)
-  //     if (minutes < timeoutWindow) setOpen(true)
-  //     setTimeUntilExpiration({
-  //       minutes,
-  //       seconds,
-  //     })
-  //   }, 1000)
-  //   return () => {
-  //     clearTimeout(timeout)
-  //   }
-  // })
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const { minutes, seconds } = buildTimeLeft(expirationTime)
+      if (minutes < timeoutWindow) setOpen(true)
+      setTimeUntilExpiration({
+        minutes,
+        seconds,
+      })
+    }, 1000)
+    return () => {
+      clearTimeout(timeout)
+    }
+  })
 
-  // if (timeUntilExpiration.minutes <= 0 && timeUntilExpiration.seconds <= 0) {
-  //   logOutAndRedirect()
-  // }
+  if (timeUntilExpiration.minutes <= 0 && timeUntilExpiration.seconds <= 0) {
+    logOutAndRedirect()
+  }
   if (!open) return null
 
   return (


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [SCC-4253](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4253).

## This PR does the following:

- Creates individually editable form component for updating user's email addresses in My Account, `EmailForm`
- **Creates parallel form component that works without JS, `NoJsEmailForm`**
    - **Adds a query string prop to `account/[[...index]]` so that the noJS form can pass success/error messages back in the URL**
    - **Adds component (`NoJsFormValidationMessage`) that displays those messages as a banner at the top of the profile tabs**
- Writes tests for `EmailForm`

NOTE!! With the expectation this will only be merged in once My Account 2.0 work is complete, the email form is not integrated with the rest of the existing fields, it's just standalone for now in `MyAccount/NewSettings`. I'll remove `MyAccount/Settings` once everything has been migrated over. 

## How has this been tested?

Locally, with this [Toggle Javascript](https://chromewebstore.google.com/detail/toggle-javascript/cidlcjdalomndpeagkjpnefhljffbnlo) Chrome extension

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4253]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ