### PR TITLE
SCC-4308 - Fix error when bib detail url missing label

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add optional chaining to to value in isRtl util to fix 500 error when bib detail url is missing a label (SCC-4308)
+- Add optional chaining to value in isRtl util to fix 500 error when bib detail url is missing a label (SCC-4308)
 
 ## [1.3.2] 2024-10-7
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Prerelease
+## [1.3.3] 2024-10-10
 
 ### Fixed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Hotfixes 2024-10-10
+## Prerelease
 
 ### Fixed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Hotfixes 2024-10-10
+
+### Fixed
+
+- Add optional chaining to to value in isRtl util to fix 500 error when bib detail url is missing a label (SCC-4308)
+
 ## [1.3.2] 2024-10-7
 
 ### Fixed

--- a/src/types/bibDetailsTypes.ts
+++ b/src/types/bibDetailsTypes.ts
@@ -23,7 +23,7 @@ export interface LinkedBibDetail {
 
 export interface BibDetailURL {
   url: string
-  urlLabel: string
+  urlLabel?: string
 }
 
 export interface FieldMapping {

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -33,7 +33,7 @@ export const rtlOrLtr = (value: string) => {
 
 // The "\u200F" right-to-left mark is found at the beginning of fields known
 // to be written in a script that reads from right to left
-const isRtl = (value: string) => value.substring(0, 1) === "\u200F"
+const isRtl = (value: string): boolean => value?.substring(0, 1) === "\u200F"
 
 export const isItTheLastElement = (i, array) => !(i < array.length - 1)
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4308](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4308)

## This PR does the following:

- Adds optional chaining to value in isRtl to prevent 500 error when a bib url is missing a label.
- Makes the url label optional in the BibDetailURL type.

## How has this been tested?

- No tests existed for this function but this is a somewhat urgent fix so I'll open a ticket to add tests as a follow up.

## Accessibility concerns or updates

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4308]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ