### PR TITLE
SCC-4299 - Fix Item widths on search results

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add optional chaining to value in isRtl util to fix 500 error when bib detail url is missing a label (SCC-4308)
-- Adjust Item table css to make columns the same width in search results (SCC-4299)
+- Adjust ItemTable CSS to make columns the same width in search results (SCC-4299)
 
 ## [1.3.2] 2024-10-7
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add optional chaining to value in isRtl util to fix 500 error when bib detail url is missing a label (SCC-4308)
+- Adjust Item table css to make columns the same width in search results (SCC-4299)
 
 ## [1.3.2] 2024-10-7
 

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -33,11 +33,12 @@
       th,
       td {
         padding-top: 0;
+        padding-left: 0;
         box-sizing: border-box;
 
-        &:nth-child(2) {
-          padding-left: 0;
-        }
+        // &:first-of-type {
+        //   padding-left: 0;
+        // }
       }
     }
   }

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -35,10 +35,6 @@
         padding-top: 0;
         padding-left: 0;
         box-sizing: border-box;
-
-        // &:first-of-type {
-        //   padding-left: 0;
-        // }
       }
     }
   }

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -25,15 +25,19 @@
 
   &.inSearchResult {
     margin-top: 0;
+    width: fit-content;
 
     tr {
       border: 0 !important;
 
       th,
-      td,
-      th:first-of-type,
-      td:first-of-type {
+      td {
         padding-top: 0;
+        box-sizing: border-box;
+
+        &:nth-child(2) {
+          padding-left: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4299](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4299)

## This PR does the following:

- Updates CSS to make the Item Table widths the same in search results

## How has this been tested?

NA

## Accessibility concerns or updates

NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4299]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ