### PR TITLE
Add check for bib holding field in buildHoldingDetails

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Prerelease
+
+### Fixed
+
+- Fix 500 error caused by assumption in buildHoldingDetails that location field will be present in the bib holdings returned from discovery (SCC-4314)
+
 ## [1.3.3] 2024-10-10
 
 ### Fixed

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -159,6 +159,7 @@ export default class BibDetails {
   }
 
   buildHoldingDetail(holding, fieldMapping: FieldMapping) {
+    if (!holding[fieldMapping.field]) return null
     const bibFieldValue =
       fieldMapping.field === "location"
         ? // "location" is the only holding field that is an array of


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4314](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4314)

## This PR does the following:

- Code assumed the location field is present in the bib.holdings attribute in the discovery API response. This adds a check to see if it's there.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
