### PR TITLE
add title default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Prerelease
+
+## Updated
+
+- Better handling of bibs with no titles in SearchResultsBib model
+
 ## 1.3.5 2024-10-23
 
 ### Updated
@@ -23,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved closedLocations from environment variables to appConfig (SCC-3759)
 
 ### Fixed
+
 ### [1.3.4] Hotfix 2024-10-17
 
 - Fix 500 error caused by assumption in buildHoldingDetails that location field will be present in the bib holdings returned from discovery (SCC-4314)

--- a/src/models/Bib.ts
+++ b/src/models/Bib.ts
@@ -33,7 +33,7 @@ export default class Bib {
 
   constructor(result: DiscoveryBibResult) {
     this.id = result["@id"] ? result["@id"].substring(4) : ""
-    this.title = result.title[0] || ""
+    this.title = result.title?.[0] || result.titleDisplay?.[0] || "[Untitled]"
     this.titleDisplay = this.getTitleDisplayFromResult(result)
     this.electronicResources = result.electronicResources || null
     this.numPhysicalItems = result.numItemsTotal || 0

--- a/src/models/modelTests/SearchResultsBib.test.ts
+++ b/src/models/modelTests/SearchResultsBib.test.ts
@@ -24,6 +24,22 @@ describe("SearchResultsBib model", () => {
         { "@id": "urn:biblevel:s", prefLabel: "serial" },
       ])
     })
+    it("defaults to title display when no title", () => {
+      const bibWithNoTitle = new SearchResultsBib({
+        ...bibWithItems.resource,
+        title: undefined,
+        titleDisplay: ["Display title"],
+      })
+      expect(bibWithNoTitle.title).toBe("Display title")
+    })
+    it("defaults to '[Untitled]' when no title or titleDisplay", () => {
+      const bibWithNoTitle = new SearchResultsBib({
+        ...bibWithItems.resource,
+        title: undefined,
+        titleDisplay: undefined,
+      })
+      expect(bibWithNoTitle.title).toBe("[Untitled]")
+    })
 
     it("initializes the yearPublished based on dateStartYear and dateEndYear", () => {
       expect(searchResultsBib.yearPublished).toBe("1999-present")


### PR DESCRIPTION
## Ticket:

NA - regarding bug reported during RC office hours.

## This PR does the following:

This query https://www.nypl.org/research/research-catalog/search?q=*T-mss&search_scope=callnumber
Returns some bibs with no title, which was breaking the bib model construction. To ameliorate, I added optional chaining as well as a default of title display and clear fallback.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- updated unit tests for searchResultsBib model

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.
