### PR TITLE
QA and VQA for location filters

### DIFF
--- a/__test__/fixtures/searchResultsManyBibs.ts
+++ b/__test__/fixtures/searchResultsManyBibs.ts
@@ -9074,6 +9074,34 @@ export const aggregationsResults = {
   itemListElement: [
     {
       "@type": "nypl:Aggregation",
+      "@id": "res:buildingLocation",
+      id: "buildingLocation",
+      field: "buildingLocation",
+      values: [
+        {
+          value: "sc",
+          count: 26,
+          label: "Not the label you should see - sc",
+        },
+        {
+          value: "rc",
+          count: 26,
+          label: "Not the lable you should see - rc",
+        },
+        {
+          value: "pa",
+          count: 2,
+          label: "Not the label you should see - pa",
+        },
+        {
+          value: "ma",
+          count: 1,
+          label: "Not the label you should see - ma",
+        },
+      ],
+    },
+    {
+      "@type": "nypl:Aggregation",
       "@id": "res:materialType",
       id: "materialType",
       field: "materialType",

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event"
 import AdvancedSearch, {
   defaultEmptySearchErrorMessage,
 } from "../../../pages/search/advanced"
-import { searchAggregations } from "../../../src/config/aggregations"
+import { searchAggregations } from "../../../src/config/aggregations.tsx"
 
 // Mock next router
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -93,10 +93,13 @@ describe("Advanced Search Form", () => {
     await userEvent.click(notatedMusic)
     const cartographic = screen.getByLabelText("Cartographic")
     await userEvent.click(cartographic)
-    await userEvent.selectOptions(
-      screen.getByLabelText("Language"),
-      "Azerbaijani"
-    )
+    const selector = screen.getByLabelText("Language")
+    await userEvent.selectOptions(selector, "Azerbaijani")
+    const schomburg = screen.getByLabelText("Schomburg Center for", {
+      exact: false,
+    })
+
+    await userEvent.click(schomburg)
     const keywordInput = screen.getByLabelText("Keyword")
     const titleInput = screen.getByLabelText("Title")
     const contributorInput = screen.getByLabelText("Author")
@@ -107,7 +110,15 @@ describe("Advanced Search Form", () => {
     await userEvent.type(subjectInput, "italian food")
 
     await userEvent.click(screen.getByText("Clear fields"))
-    expect(notatedMusic).not.toBeChecked()
+    ;[notatedMusic, cartographic, schomburg].forEach((input) =>
+      expect(input).not.toBeChecked()
+    )
+    expect(selector).not.toHaveDisplayValue("Azerbaijani")
+    ;[subjectInput, keywordInput, titleInput, contributorInput].forEach(
+      (input) => {
+        expect(input).toBeEmptyDOMElement()
+      }
+    )
 
     submit()
     // presence of alert means the form was cleared before hitting submit

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event"
 import AdvancedSearch, {
   defaultEmptySearchErrorMessage,
 } from "../../../pages/search/advanced"
-import { searchAggregations } from "../../../src/config/aggregations.tsx"
+import { searchAggregations } from "../../../src/config/aggregations"
 
 // Mock next router
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -80,7 +80,7 @@ describe("Advanced Search Form", () => {
   it("can check location checkboxes", async () => {
     render(<AdvancedSearch isAuthenticated={true} />)
     const location = searchAggregations.buildingLocation[0]
-    await userEvent.click(screen.getByLabelText(location.label))
+    await userEvent.click(screen.getByLabelText(location.label as string))
     submit()
     expect(mockRouter.asPath).toBe(
       `/search?q=&filters%5BbuildingLocation%5D%5B0%5D=${location.value}`

--- a/__test__/pages/search/searchResults.test.tsx
+++ b/__test__/pages/search/searchResults.test.tsx
@@ -25,7 +25,7 @@ describe("Search Results page", () => {
           results={{ results, aggregations: aggregationsResults }}
         />
       )
-      const refine = screen.getByText("Refine Search")
+      const refine = screen.getByText("Filter results")
       await userEvent.click(refine)
       const field = screen.getByLabelText("Greek, Modern (1453-present)", {
         exact: false,
@@ -70,7 +70,7 @@ describe("Search Results page", () => {
       await userEvent.selectOptions(desktopSortBy, "Title (A - Z)")
       expect(desktopSortBy).toHaveFocus()
     })
-    it("focuses on cancel after clicking refine search", async () => {
+    it("focuses on cancel after clicking Filter results", async () => {
       mockRouter.push(`/search?q=${query}`)
       render(
         <SearchResults
@@ -79,12 +79,12 @@ describe("Search Results page", () => {
           results={{ results, aggregations: aggregationsResults }}
         />
       )
-      const refine = screen.getByText("Refine Search")
+      const refine = screen.getByText("Filter results")
       await userEvent.click(refine)
       const cancel = screen.getByText("Cancel")
       expect(cancel).toHaveFocus
     })
-    it("focuses on refine search after clicking cancel", async () => {
+    it("focuses on Filter results after clicking cancel", async () => {
       mockRouter.push(`/search?q=${query}`)
       render(
         <SearchResults
@@ -93,7 +93,7 @@ describe("Search Results page", () => {
           results={{ results, aggregations: aggregationsResults }}
         />
       )
-      const refine = screen.getByText("Refine Search")
+      const refine = screen.getByText("Filter results")
       await userEvent.click(refine)
       const cancel = screen.getByText("Cancel")
       await userEvent.click(cancel)

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -55,7 +55,7 @@ export default function AdvancedSearch({
   isAuthenticated,
   goBackHref,
 }: AdvancedSearchPropTypes) {
-  const metadataTitle = `Advanced Search | ${SITE_NAME}`
+  const metadataTitle = `Advanced search | ${SITE_NAME}`
   const router = useRouter()
   const inputRef = useRef<TextInputRefType>()
   const notificationRef = useRef<HTMLDivElement>()
@@ -153,7 +153,7 @@ export default function AdvancedSearch({
         <Box tabIndex={-1} ref={notificationRef}>
           {alert && <Banner type="negative" content={errorMessage} mb="s" />}
         </Box>
-        <Heading level="h2">Advanced Search</Heading>
+        <Heading level="h2">Advanced search</Heading>
         <Form
           id="advancedSearchForm"
           // We are using a post request on advanced search when JS is disabled

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -38,7 +38,7 @@ import DateForm from "../../src/components/SearchFilters/DateForm"
 import SearchFilterCheckboxField from "../../src/components/RefineSearch/SearchFilterCheckboxField"
 import CancelSubmitButtonGroup from "../../src/components/RefineSearch/CancelSubmitButtonGroup"
 import { materialTypeOptions } from "../../src/utils/advancedSearchUtils"
-import { searchAggregations } from "../../src/config/aggregations.tsx"
+import { searchAggregations } from "../../src/config/aggregations"
 import RCLink from "../../src/components/Links/RCLink/RCLink"
 
 export const defaultEmptySearchErrorMessage =

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -210,6 +210,7 @@ export default function AdvancedSearch({
                   handleCheckboxChange("buildingLocation", e)
                 }
                 searchFormState={searchFormState["filters"].buildingLocation}
+                gridOptions={{ min: 1, max: 1 }}
               />
               <SearchFilterCheckboxField
                 options={materialTypeOptions}

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -38,7 +38,7 @@ import DateForm from "../../src/components/SearchFilters/DateForm"
 import SearchFilterCheckboxField from "../../src/components/RefineSearch/SearchFilterCheckboxField"
 import CancelSubmitButtonGroup from "../../src/components/RefineSearch/CancelSubmitButtonGroup"
 import { materialTypeOptions } from "../../src/utils/advancedSearchUtils"
-import { searchAggregations } from "../../src/config/aggregations"
+import { searchAggregations } from "../../src/config/aggregations.tsx"
 import RCLink from "../../src/components/Links/RCLink/RCLink"
 
 export const defaultEmptySearchErrorMessage =

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -205,7 +205,7 @@ export default function AdvancedSearch({
               <SearchFilterCheckboxField
                 options={searchAggregations.buildingLocation}
                 name="location"
-                label="Location"
+                label="Item location"
                 handleCheckboxChange={(e) =>
                   handleCheckboxChange("buildingLocation", e)
                 }

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -164,7 +164,7 @@ export default function AdvancedSearch({
           onSubmit={handleSubmit}
         >
           <Flex flexDirection={{ base: "column", md: "row" }}>
-            <Box id="advancedSearchLeft" gap="grid.s">
+            <Flex id="advancedSearchLeft" gap="s" direction="column">
               {textInputFields.map(({ name, label }) => {
                 return (
                   <FormField key={name}>
@@ -200,7 +200,7 @@ export default function AdvancedSearch({
                 </Select>
               </FormField>
               <FormField>{<DateForm {...dateFormProps} />}</FormField>
-            </Box>
+            </Flex>
             <Flex direction="column" gap="l">
               <SearchFilterCheckboxField
                 options={searchAggregations.buildingLocation}

--- a/src/components/ItemFilters/ActiveFilters.tsx
+++ b/src/components/ItemFilters/ActiveFilters.tsx
@@ -1,9 +1,4 @@
-import {
-  Box,
-  TagSet,
-  Text,
-  type TagSetFilterDataProps,
-} from "@nypl/design-system-react-components"
+import { Box, TagSet, Text } from "@nypl/design-system-react-components"
 
 const ActiveFilters = ({ filterName, onClick, tagSetData }) => {
   return (

--- a/src/components/ItemFilters/ActiveFilters.tsx
+++ b/src/components/ItemFilters/ActiveFilters.tsx
@@ -7,7 +7,7 @@ import {
 
 const ActiveFilters = ({ filterName, onClick, tagSetData }) => {
   return (
-    <Box display="flex" flexDirection={{ base: "column", md: "row" }} mb="m">
+    <Box display="flex" flexDirection={{ base: "column", md: "row" }} mb="l">
       <Text
         display="block"
         fontSize="desktop.body.body2"

--- a/src/components/ItemFilters/ActiveFilters.tsx
+++ b/src/components/ItemFilters/ActiveFilters.tsx
@@ -9,7 +9,7 @@ const ActiveFilters = ({ filterName, onClick, tagSetData }) => {
         fontWeight="bold"
         mr={{ base: "0", md: "s" }}
         mb={{ base: "xxs", md: 0 }}
-        lineHeight={2}
+        lineHeight="--nypl-lineHeights-taller"
       >
         Active filters
       </Text>

--- a/src/components/ItemFilters/ActiveFilters.tsx
+++ b/src/components/ItemFilters/ActiveFilters.tsx
@@ -1,0 +1,32 @@
+import {
+  Box,
+  TagSet,
+  Text,
+  type TagSetFilterDataProps,
+} from "@nypl/design-system-react-components"
+
+const ActiveFilters = ({ filterName, onClick, tagSetData }) => {
+  return (
+    <Box display="flex" flexDirection={{ base: "column", md: "row" }} mb="m">
+      <Text
+        display="block"
+        fontSize="desktop.body.body2"
+        fontWeight="bold"
+        mr={{ base: "0", md: "s" }}
+        mb={{ base: "xxs", md: 0 }}
+        lineHeight={2}
+      >
+        Active filters
+      </Text>
+      <TagSet
+        id={`${filterName}-applied-filters`}
+        isDismissible
+        type="filter"
+        onClick={onClick}
+        tagSetData={tagSetData}
+      />
+    </Box>
+  )
+}
+
+export default ActiveFilters

--- a/src/components/ItemFilters/ItemFilters.tsx
+++ b/src/components/ItemFilters/ItemFilters.tsx
@@ -6,9 +6,7 @@ import {
   MultiSelect,
   SearchBar,
   Box,
-  Text,
   Label,
-  TagSet,
   type TagSetFilterDataProps,
 } from "@nypl/design-system-react-components"
 import type {
@@ -22,6 +20,7 @@ import {
   buildItemFilterQuery,
   removeValueFromFilters,
 } from "../../utils/itemFilterUtils"
+import ActiveFilters from "./ActiveFilters"
 
 interface ItemFilterContainerProps {
   itemAggregations: Aggregation[]
@@ -200,31 +199,13 @@ const ItemFilters = ({
         />
       </Box>
       {filtersAreApplied ? (
-        <Box
-          display="flex"
-          flexDirection={{ base: "column", md: "row" }}
-          mb="m"
-        >
-          <Text
-            display="block"
-            fontSize="desktop.body.body2"
-            fontWeight="bold"
-            mr={{ base: "0", md: "s" }}
-            mb={{ base: "xxs", md: 0 }}
-            lineHeight={2}
-          >
-            Active filters
-          </Text>
-          <TagSet
-            id="bib-details-applied-filters"
-            isDismissible
-            type="filter"
-            onClick={async (filterToRemove: TagSetFilterDataProps) => {
-              await handleRemoveFilter(filterToRemove.id)
-            }}
-            tagSetData={appliedFiltersTagSetData}
-          />
-        </Box>
+        <ActiveFilters
+          filterName="bib-details"
+          onClick={async (filterToRemove: TagSetFilterDataProps) => {
+            await handleRemoveFilter(filterToRemove.id)
+          }}
+          tagSetData={appliedFiltersTagSetData}
+        />
       ) : null}
     </>
   )

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -80,23 +80,25 @@ const Layout = ({
                 />
                 {showSearch && <SearchForm aggregations={searchAggregations} />}
               </div>
-              <Flex
-                gap="l"
-                align="center"
-                direction="column"
-                sx={{
-                  padding: "2em 2em .5em 2em",
-                }}
-              >
-                {showSearch && <EDSBanner />}
-                {showNotification && bannerNotification && (
-                  <Banner
-                    className={styles.banner}
-                    heading="New Service Announcement"
-                    content={bannerNotification}
-                  />
-                )}
-              </Flex>
+              {showSearch && (
+                <Flex
+                  gap="l"
+                  align="center"
+                  direction="column"
+                  sx={{
+                    padding: "2em 2em .5em 2em",
+                  }}
+                >
+                  <EDSBanner />
+                  {showNotification && bannerNotification && (
+                    <Banner
+                      className={styles.banner}
+                      heading="New Service Announcement"
+                      content={bannerNotification}
+                    />
+                  )}
+                </Flex>
+              )}
             </>
           )
         }

--- a/src/components/RefineSearch/CancelSubmitButtonGroup.tsx
+++ b/src/components/RefineSearch/CancelSubmitButtonGroup.tsx
@@ -20,7 +20,7 @@ const CancelSubmitButtonGroup = ({
     ? "actionSearch"
     : "check"
   return (
-    <ButtonGroup id={`${formName}-buttons`}>
+    <ButtonGroup mb={0} id={`${formName}-buttons`}>
       <Button
         data-testid={`clear-${formName}-button`}
         onClick={cancelHandler}

--- a/src/components/RefineSearch/CancelSubmitButtonGroup.tsx
+++ b/src/components/RefineSearch/CancelSubmitButtonGroup.tsx
@@ -20,7 +20,18 @@ const CancelSubmitButtonGroup = ({
     ? "actionSearch"
     : "check"
   return (
-    <ButtonGroup mb={0} id={`${formName}-buttons`}>
+    // @ts-ignore
+    <ButtonGroup mb={0} id={`${formName}-buttons`} layout="row-reverse">
+      <Button
+        data-testid={`submit-${formName}-button`}
+        id={`submit-${formName}`}
+        type="submit"
+        buttonType="primary"
+        isDisabled={disableSubmit}
+      >
+        <Icon name={submitIcon} align="left" size="large" />
+        {submitLabel}
+      </Button>
       <Button
         data-testid={`clear-${formName}-button`}
         onClick={cancelHandler}
@@ -31,16 +42,6 @@ const CancelSubmitButtonGroup = ({
       >
         <Icon name="actionDelete" align="left" size="large" />
         {cancelLabel}
-      </Button>
-      <Button
-        data-testid={`submit-${formName}-button`}
-        id={`submit-${formName}`}
-        type="submit"
-        buttonType="primary"
-        isDisabled={disableSubmit}
-      >
-        <Icon name={submitIcon} align="left" size="large" />
-        {submitLabel}
       </Button>
     </ButtonGroup>
   )

--- a/src/components/RefineSearch/RefineSearch.test.tsx
+++ b/src/components/RefineSearch/RefineSearch.test.tsx
@@ -12,7 +12,7 @@ import {
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 
 const openRefineSearch = async () => {
-  const refineButton = screen.getByText("Refine Search")
+  const refineButton = screen.getByText("Filter results")
   await userEvent.click(refineButton)
 }
 const apply = async () => {

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -170,6 +170,7 @@ const RefineSearch = ({
             justifyContent={{ md: "space-between", base: "center" }}
           >
             <Button
+              margin={0}
               onClick={toggleRefine}
               id="cancel-refine"
               buttonType="secondary"

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -156,7 +156,7 @@ const RefineSearch = ({
           id="refine-search"
           buttonType="secondary"
           backgroundColor="ui.white"
-          className={styles.refineSearchButton}
+          mt="xs"
         >
           <Icon />
           Filter results

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -1,5 +1,6 @@
 import type { TextInputRefType } from "@nypl/design-system-react-components"
 import {
+  Flex,
   Box,
   Button,
   HorizontalRule,
@@ -163,7 +164,7 @@ const RefineSearch = ({
       ) : (
         <Form id="refine-search" onSubmit={handleSubmit}>
           <HorizontalRule mb={0} mt="s" />
-          <Box className={styles.refineButtons}>
+          <Flex justifyContent="space-between">
             <Button
               onClick={toggleRefine}
               id="cancel-refine"
@@ -180,7 +181,7 @@ const RefineSearch = ({
               submitLabel="Apply filters"
               cancelLabel="Clear filters"
             />
-          </Box>
+          </Flex>
           <HorizontalRule m={0} />
           {filters}
         </Form>

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -27,7 +27,7 @@ import CancelSubmitButtonGroup from "./CancelSubmitButtonGroup"
 import SearchFilterCheckboxField from "./SearchFilterCheckboxField"
 
 const fields = [
-  { value: "buildingLocation", label: "Location" },
+  { value: "buildingLocation", label: "Item location" },
   { value: "materialType", label: "Format" },
   { value: "language", label: "Language" },
   { value: "dateAfter", label: "Start Year" },
@@ -153,7 +153,8 @@ const RefineSearch = ({
           backgroundColor="ui.white"
           className={styles.refineSearchButton}
         >
-          Refine Search
+          <Icon />
+          Filter results
         </Button>
       ) : (
         <Form

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -143,7 +143,11 @@ const RefineSearch = ({
   }
 
   return (
-    <Box className={styles.refineSearchContainer}>
+    <Box
+      mt={refineSearchClosed ? "-8" : 0}
+      alignSelf="left"
+      className={styles.refineSearchContainer}
+    >
       {refineSearchClosed ? (
         <Button
           ref={refineOrCancelRef}

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -145,18 +145,19 @@ const RefineSearch = ({
 
   return (
     <Box
-      mt={refineSearchClosed ? "-8" : 0}
+      mt={{ md: refineSearchClosed ? "-4" : 0, base: 0 }}
+      width={{ md: "fit-content" }}
       alignSelf="left"
       className={styles.refineSearchContainer}
     >
       {refineSearchClosed ? (
         <Button
+          width="100%"
           ref={refineOrCancelRef}
           onClick={toggleRefine}
           id="refine-search"
           buttonType="secondary"
           backgroundColor="ui.white"
-          mt="xs"
         >
           <Icon />
           Filter results
@@ -164,7 +165,10 @@ const RefineSearch = ({
       ) : (
         <Form id="refine-search" onSubmit={handleSubmit}>
           <HorizontalRule mb={0} mt="s" />
-          <Flex justifyContent="space-between">
+          <Flex
+            flexDirection={{ base: "column-reverse", md: "row" }}
+            justifyContent={{ md: "space-between", base: "center" }}
+          >
             <Button
               onClick={toggleRefine}
               id="cancel-refine"

--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -161,12 +161,8 @@ const RefineSearch = ({
           Filter results
         </Button>
       ) : (
-        <Form
-          className={styles.refineSearchInner}
-          id="refine-search"
-          onSubmit={handleSubmit}
-        >
-          <HorizontalRule mb={0} />
+        <Form id="refine-search" onSubmit={handleSubmit}>
+          <HorizontalRule mb={0} mt="s" />
           <Box className={styles.refineButtons}>
             <Button
               onClick={toggleRefine}

--- a/src/components/RefineSearch/SearchFilterCheckboxField.tsx
+++ b/src/components/RefineSearch/SearchFilterCheckboxField.tsx
@@ -38,7 +38,7 @@ const SearchFilterCheckboxField = ({
   }
 
   const checkboxes = options.map(({ value, label, count }) => {
-    const labelCount = count ? `(${count})` : ""
+    const labelCount = count ? ` (${count})` : ""
 
     return (
       <Checkbox
@@ -47,7 +47,8 @@ const SearchFilterCheckboxField = ({
         value={value}
         labelText={
           <>
-            {label} {labelCount}
+            {label}
+            {labelCount}
           </>
         }
       />

--- a/src/components/RefineSearch/SearchFilterCheckboxField.tsx
+++ b/src/components/RefineSearch/SearchFilterCheckboxField.tsx
@@ -38,12 +38,18 @@ const SearchFilterCheckboxField = ({
   }
 
   const checkboxes = options.map(({ value, label, count }) => {
+    const labelCount = count ? `(${count})` : ""
+
     return (
       <Checkbox
         id={value}
         key={value}
         value={value}
-        labelText={`${label} ${count ? `(${count})` : ""}`}
+        labelText={
+          <>
+            {label} {labelCount}
+          </>
+        }
       />
     )
   })

--- a/src/components/SearchFilters/AppliedFilters.tsx
+++ b/src/components/SearchFilters/AppliedFilters.tsx
@@ -25,6 +25,10 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
     appliedFilters
   )
 
+  // this type cast is happening because Option type had to be updated to
+  // account for Offsite's Element label. That label does
+  // not pass thru this part of the code, but this is to placate the
+  // compiler.
   const tagSetData = buildTagsetData(
     appliedFiltersWithLabels
   ) as TagSetFilterDataProps[]

--- a/src/components/SearchFilters/AppliedFilters.tsx
+++ b/src/components/SearchFilters/AppliedFilters.tsx
@@ -1,10 +1,6 @@
 import { useRouter } from "next/router"
-import {
-  TagSet,
-  type TagSetFilterDataProps,
-} from "@nypl/design-system-react-components"
+import { type TagSetFilterDataProps } from "@nypl/design-system-react-components"
 
-import styles from "../../../styles/components/Search.module.scss"
 import {
   getQueryWithoutFilters,
   buildFilterQuery,
@@ -16,6 +12,7 @@ import {
   addLabelPropAndParseFilters,
 } from "./appliedFilterUtils"
 import type { Aggregation } from "../../types/filterTypes"
+import ActiveFilters from "../ItemFilters/ActiveFilters"
 
 const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
   const router = useRouter()
@@ -56,12 +53,10 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
 
   if (!tagSetData.length) return null
   return (
-    <TagSet
-      className={styles.filterTags}
+    <ActiveFilters
       onClick={handleRemove}
       tagSetData={tagSetData}
-      isDismissible={true}
-      type="filter"
+      filterName="search-results"
     />
   )
 }

--- a/src/components/SearchFilters/AppliedFilters.tsx
+++ b/src/components/SearchFilters/AppliedFilters.tsx
@@ -25,7 +25,9 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
     appliedFilters
   )
 
-  const tagSetData = buildTagsetData(appliedFiltersWithLabels)
+  const tagSetData = buildTagsetData(
+    appliedFiltersWithLabels
+  ) as TagSetFilterDataProps[]
   const handleRemove = (tag: TagSetFilterDataProps) => {
     if (tag.label === "Clear filters") {
       router.push({

--- a/src/components/SearchFilters/DateForm.tsx
+++ b/src/components/SearchFilters/DateForm.tsx
@@ -3,6 +3,7 @@ import {
   Fieldset,
   TextInput,
   Notification,
+  Flex,
 } from "@nypl/design-system-react-components"
 import type { DateFormHookPropsType } from "../../hooks/useDateForm"
 
@@ -37,11 +38,7 @@ const DateForm = ({
         )}
       </div>
       <Fieldset id="date-fieldset" legendText="Date">
-        <Box
-          gridTemplateColumns="repeat(2, minmax(0, 1fr))"
-          display="grid"
-          gap="s"
-        >
+        <Flex gap="s">
           <TextInput
             id="date-from"
             labelText="Start"
@@ -60,7 +57,7 @@ const DateForm = ({
             onChange={(e) => changeHandler(e)}
             ref={inputRefs[1]}
           />
-        </Box>
+        </Flex>
       </Fieldset>
     </>
   )

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Flex,
   Icon,
   SearchBar,
   Text,
@@ -114,7 +115,11 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
             ".chakra-select__icon-wrapper": { "z-index": "999 !important" },
           }}
         />
-        <Box className={styles.auxSearchContainer}>
+        <Flex
+          direction={{ base: "column", md: "row-reverse" }}
+          justifyContent="space-between"
+          mt="xs"
+        >
           <RCLink
             className={styles.advancedSearch}
             href="/search/advanced"
@@ -130,7 +135,7 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
               aggregations={aggregations}
             />
           )}
-        </Box>
+        </Flex>
       </div>
     </div>
   )

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -82,7 +82,7 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
     <div className={styles.searchContainer}>
       <div className={styles.searchContainerInner}>
         <Text size="body2" className={styles.searchTip}>
-          <Icon size="medium" name="errorOutline" />
+          <Icon size="medium" name="errorOutline" iconRotation="rotate180" />
           <Box as="span" className={styles.searchTipText}>
             <span className={styles.searchTipTitle}>{"Search tip: "}</span>
             {searchTip}

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -115,11 +115,7 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
             ".chakra-select__icon-wrapper": { "z-index": "999 !important" },
           }}
         />
-        <Flex
-          direction={{ base: "column", md: "row-reverse" }}
-          justifyContent="space-between"
-          mt="xs"
-        >
+        <Flex direction="column" justifyContent="space-between" mt="xs">
           <RCLink
             className={styles.advancedSearch}
             href="/search/advanced"
@@ -130,6 +126,7 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
           </RCLink>
           {displayRefineResults && (
             <RefineSearch
+              align="left"
               setAppliedFilters={setAppliedFilters}
               appliedFilters={appliedFilters}
               aggregations={aggregations}

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -126,7 +126,6 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
           </RCLink>
           {displayRefineResults && (
             <RefineSearch
-              align="left"
               setAppliedFilters={setAppliedFilters}
               appliedFilters={appliedFilters}
               aggregations={aggregations}

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -121,7 +121,7 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
             isUnderlined={false}
             mb="xs"
           >
-            Advanced Search
+            Advanced search
           </RCLink>
           {displayRefineResults && (
             <RefineSearch

--- a/src/config/aggregations.ts
+++ b/src/config/aggregations.ts
@@ -2,7 +2,7 @@ export const searchAggregations = {
   buildingLocation: [
     {
       value: "sc",
-      label: "Schomburg Center - Research and Reference Division",
+      label: "Schomburg Center for Research in Black Culture",
     },
     {
       value: "ma",
@@ -10,9 +10,12 @@ export const searchAggregations = {
     },
     {
       value: "rc",
-      label: "Offsite (Deliverable to NYPL research libraries)",
+      label: "Offsite - Deliverable to NYPL research libraries",
     },
-    { value: "pa", label: "Performing Arts Library at Lincoln Center" },
+    {
+      value: "pa",
+      label: "Library for the Performing Arts",
+    },
   ],
   materialType: [
     {

--- a/src/config/aggregations.tsx
+++ b/src/config/aggregations.tsx
@@ -1,14 +1,6 @@
 export const searchAggregations = {
   buildingLocation: [
     {
-      value: "sc",
-      label: "Schomburg Center for Research in Black Culture",
-    },
-    {
-      value: "ma",
-      label: "Stephen A. Schwarzman Building",
-    },
-    {
       value: "rc",
       label: (
         <>
@@ -19,6 +11,14 @@ export const searchAggregations = {
     {
       value: "pa",
       label: "The New York Public Library for the Performing Arts",
+    },
+    {
+      value: "ma",
+      label: "Stephen A. Schwarzman Building",
+    },
+    {
+      value: "sc",
+      label: "Schomburg Center for Research in Black Culture",
     },
   ],
   materialType: [

--- a/src/config/aggregations.tsx
+++ b/src/config/aggregations.tsx
@@ -16,7 +16,7 @@ export const searchAggregations = {
       value: "rc",
       label: (
         <>
-          Off-site - <i>Deliverable to NYPL research Libraries</i>
+          Off-site - <i>Deliverable to NYPL all Research Libraries</i>
         </>
       ),
     },

--- a/src/config/aggregations.tsx
+++ b/src/config/aggregations.tsx
@@ -1,20 +1,20 @@
 export const searchAggregations = {
   buildingLocation: [
     {
-      value: "rc",
-      label: (
-        <>
-          Offsite - <i>Deliverable to NYPL research Libraries</i>
-        </>
-      ),
+      value: "ma",
+      label: "Stephen A. Schwarzman Building",
     },
     {
       value: "pa",
       label: "The New York Public Library for the Performing Arts",
     },
     {
-      value: "ma",
-      label: "Stephen A. Schwarzman Building",
+      value: "rc",
+      label: (
+        <>
+          Off-site - <i>Deliverable to NYPL research Libraries</i>
+        </>
+      ),
     },
     {
       value: "sc",

--- a/src/config/aggregations.tsx
+++ b/src/config/aggregations.tsx
@@ -10,7 +10,11 @@ export const searchAggregations = {
     },
     {
       value: "rc",
-      label: "Offsite - Deliverable to NYPL research libraries",
+      label: (
+        <>
+          Offsite - <i>Deliverable to NYPL research Libraries</i>
+        </>
+      ),
     },
     {
       value: "pa",

--- a/src/config/aggregations.tsx
+++ b/src/config/aggregations.tsx
@@ -9,16 +9,16 @@ export const searchAggregations = {
       label: "The New York Public Library for the Performing Arts",
     },
     {
+      value: "sc",
+      label: "Schomburg Center for Research in Black Culture",
+    },
+    {
       value: "rc",
       label: (
         <>
           Off-site - <i>Deliverable to NYPL research Libraries</i>
         </>
       ),
-    },
-    {
-      value: "sc",
-      label: "Schomburg Center for Research in Black Culture",
     },
   ],
   materialType: [

--- a/src/config/aggregations.tsx
+++ b/src/config/aggregations.tsx
@@ -16,7 +16,7 @@ export const searchAggregations = {
       value: "rc",
       label: (
         <>
-          Off-site - <i>Deliverable to NYPL all Research Libraries</i>
+          Off-site - <i>Deliverable to all NYPL Research Libraries</i>
         </>
       ),
     },

--- a/src/config/aggregations.tsx
+++ b/src/config/aggregations.tsx
@@ -18,7 +18,7 @@ export const searchAggregations = {
     },
     {
       value: "pa",
-      label: "Library for the Performing Arts",
+      label: "The New York Public Library for the Performing Arts",
     },
   ],
   materialType: [

--- a/src/models/SearchResultsFilters.ts
+++ b/src/models/SearchResultsFilters.ts
@@ -12,17 +12,22 @@ class SearchResultsFilters {
   constructor(aggregationsResults: Aggregation[], field: Option) {
     this.labelTransformations = {
       "Greek, Modern (1453- )": "Greek, Modern (1453-present)",
-      Offsite: searchAggregations.buildingLocation.find(
-        (loc) => loc.value === "rc"
-      ).label,
     }
+
     this.options = aggregationsResults
       .find((f) => f.id === field.value)
       ?.values.map((option) => ({
         ...option,
-        label: this.labelTransformations[option.label] || option.label,
+        label: this.getLabel(option, field),
       }))
     this.field = field.value
+  }
+  getLabel(option, field) {
+    if (field.value === "buildingLocation") {
+      return searchAggregations.buildingLocation.find(
+        (loc) => loc.value === option.value
+      ).label
+    } else return this.labelTransformations[option.label] || option.label
   }
 }
 

--- a/src/models/SearchResultsFilters.ts
+++ b/src/models/SearchResultsFilters.ts
@@ -3,7 +3,7 @@ import type {
   Aggregation,
   Option,
 } from "../types/filterTypes"
-import { searchAggregations } from "../config/aggregations"
+import { searchAggregations } from "../config/aggregations.tsx"
 
 class SearchResultsFilters {
   options: AggregationOption[]

--- a/src/models/SearchResultsFilters.ts
+++ b/src/models/SearchResultsFilters.ts
@@ -3,7 +3,7 @@ import type {
   Aggregation,
   Option,
 } from "../types/filterTypes"
-import { searchAggregations } from "../config/aggregations.tsx"
+import { searchAggregations } from "../config/aggregations"
 
 class SearchResultsFilters {
   options: AggregationOption[]

--- a/src/models/modelTests/SearchResultsFilters.test.ts
+++ b/src/models/modelTests/SearchResultsFilters.test.ts
@@ -1,0 +1,16 @@
+import { aggregationsResults } from "../../../__test__/fixtures/searchResultsManyBibs"
+import type { Aggregation } from "../../types/filterTypes"
+import SearchResultsFilters from "../SearchResultsFilters"
+
+describe("SearchResultsFilter model", () => {
+  it("adds proper label to building location options", () => {
+    const filters = new SearchResultsFilters(
+      aggregationsResults.itemListElement as Aggregation[],
+      {
+        value: "buildingLocation",
+        label: "Item location",
+      }
+    )
+    filters.options.map((f) => console.log(f.label))
+  })
+})

--- a/src/models/modelTests/SearchResultsFilters.test.ts
+++ b/src/models/modelTests/SearchResultsFilters.test.ts
@@ -11,6 +11,6 @@ describe("SearchResultsFilter model", () => {
         label: "Item location",
       }
     )
-    filters.options.map((f) => console.log(f.label))
+    // filters.options.map((f) => console.log(f.label))
   })
 })

--- a/src/types/filterTypes.ts
+++ b/src/types/filterTypes.ts
@@ -41,7 +41,7 @@ export interface Aggregation {
 
 export type Option = {
   value: string
-  label: string
+  label: string | JSX.Element
   count?: number
   field?: string
 }

--- a/src/types/searchTypes.ts
+++ b/src/types/searchTypes.ts
@@ -8,6 +8,7 @@ type ContributorLiteral = string
 type CreatorLiteral = string
 type Issuance = string
 type MaterialTypeFilter = string
+type BuildingLocationFilter = string
 
 export interface SearchFilters {
   materialType?: MaterialTypeFilter | MaterialTypeFilter[]
@@ -18,6 +19,7 @@ export interface SearchFilters {
   issuance?: Issuance | Issuance[]
   dateAfter?: string
   dateBefore?: string
+  buildingLocation?: BuildingLocationFilter | BuildingLocationFilter[]
 }
 
 export interface Identifiers {

--- a/src/utils/advancedSearchUtils.ts
+++ b/src/utils/advancedSearchUtils.ts
@@ -1,5 +1,5 @@
 import type { SearchParams, SearchFormInputField } from "../types/searchTypes"
-import { searchAggregations } from "../config/aggregations"
+import { searchAggregations } from "../config/aggregations.tsx"
 import { BASE_URL } from "../config/constants"
 
 export const textInputFields: SearchFormInputField[] = [

--- a/src/utils/advancedSearchUtils.ts
+++ b/src/utils/advancedSearchUtils.ts
@@ -1,5 +1,5 @@
 import type { SearchParams, SearchFormInputField } from "../types/searchTypes"
-import { searchAggregations } from "../config/aggregations.tsx"
+import { searchAggregations } from "../config/aggregations"
 import { BASE_URL } from "../config/constants"
 
 export const textInputFields: SearchFormInputField[] = [

--- a/src/utils/advancedSearchUtils.ts
+++ b/src/utils/advancedSearchUtils.ts
@@ -19,6 +19,7 @@ export const initialSearchFormState: SearchParams = {
     dateBefore: "",
     dateAfter: "",
     materialType: [],
+    buildingLocation: [],
   },
 }
 

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -49,13 +49,9 @@
   justify-content: space-between;
 }
 
-.refineCheckboxGroup {
-  display: flex;
-  flex-wrap: wrap;
-}
-
 .refineSearchContainer {
   background-color: var(--nypl-colors-ui-bg-default);
+  width: fit-content;
 }
 .refineSearchInner {
   @include maxWidth;

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -53,7 +53,9 @@
   background-color: var(--nypl-colors-ui-bg-default);
   width: fit-content;
 }
+
 .refineSearchInner {
-  @include maxWidth;
   padding-bottom: var(--nypl-space-l);
+  padding-left: 0;
+  padding-right: 0;
 }

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -35,15 +35,6 @@
   }
 }
 
-.refineSearchButton {
-  width: 100%;
-
-  @media screen and (min-width: 600px) {
-    width: auto;
-    margin-top: var(--nypl-space-xs);
-  }
-}
-
 .refineSearchContainer {
   background-color: var(--nypl-colors-ui-bg-default);
   width: fit-content;

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -1,13 +1,5 @@
 @import "../utils/mixins";
 
-.filterTags {
-  margin-bottom: var(--nypl-space-xs);
-
-  button[id^="ts-filter-clear-all"] {
-    color: var(--nypl-colors-ui-link-primary);
-    text-decoration: underline;
-  }
-}
 .searchContainer {
   background-color: var(--nypl-colors-ui-bg-default);
   padding: var(--nypl-space-s) 0;
@@ -30,16 +22,6 @@
   gap: var(--nypl-space-xxs);
   svg {
     margin-top: var(--nypl-space-xxxs);
-  }
-}
-
-.auxSearchContainer {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  margin-top: var(--nypl-space-xs);
-  @media screen and (min-width: 600px) {
-    flex-direction: row-reverse;
   }
 }
 

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -37,5 +37,4 @@
 
 .refineSearchContainer {
   background-color: var(--nypl-colors-ui-bg-default);
-  width: fit-content;
 }

--- a/styles/components/Search.module.scss
+++ b/styles/components/Search.module.scss
@@ -44,18 +44,7 @@
   }
 }
 
-.refineButtons {
-  display: flex;
-  justify-content: space-between;
-}
-
 .refineSearchContainer {
   background-color: var(--nypl-colors-ui-bg-default);
   width: fit-content;
-}
-
-.refineSearchInner {
-  padding-bottom: var(--nypl-space-l);
-  padding-left: 0;
-  padding-right: 0;
 }


### PR DESCRIPTION
- update location label names 
- display locations as single column
- all buttons in sentence case
- extract active filters tagset with header and use in search results and bib page
- move refine search panel buttons below advanced search button
- fix bug where clear filters was not removing location checkboxes
- misc spacing updates
- rm superfluous class names