### PR TITLE
SCC-4236: Username for My Account 2.0 

### DIFF
--- a/__test__/pages/account/account.test.tsx
+++ b/__test__/pages/account/account.test.tsx
@@ -231,22 +231,6 @@ describe("MyAccount page", () => {
     const result = await getServerSideProps({ req: req, res: mockRes })
     expect(result.props.tabsPath).toBe("overdues")
   })
-  it("can handle no username", () => {
-    render(
-      <MyAccount
-        isAuthenticated={true}
-        accountData={{
-          checkouts: processedCheckouts,
-          holds: processedHolds,
-          patron: { ...processedPatron, username: undefined },
-          fines: processedFines,
-          pickupLocations: filteredPickupLocations,
-        }}
-      />
-    )
-    const username = screen.queryByText("Username")
-    expect(username).toBeNull()
-  })
   it("renders notification banner if user has fines", () => {
     render(
       <MyAccount

--- a/pages/api/account/username/[id].ts
+++ b/pages/api/account/username/[id].ts
@@ -1,0 +1,40 @@
+import type { NextApiResponse, NextApiRequest } from "next"
+import initializePatronTokenAuth from "../../../../src/server/auth"
+import { updateUsername } from "../helpers"
+
+/**
+ * API route handler for /api/account/username/{patronId}
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  let responseMessage = "Request error"
+  let responseStatus = 400
+  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+  const cookiePatronId = patronTokenResponse.decodedPatron?.sub
+  if (!cookiePatronId) {
+    responseStatus = 403
+    responseMessage = "No authenticated patron"
+    return res.status(responseStatus).json(responseMessage)
+  }
+  if (req.method == "GET") {
+    responseMessage = "Please make a PUT request to this endpoint."
+  }
+  if (req.method == "PUT") {
+    /**  We get the patron id from the request: */
+    const patronId = req.query.id as string
+    const { username } = req.body
+    /**  We check that the patron cookie matches the patron id in the request,
+     * i.e.,the logged in user is updating their own PIN. */
+    if (patronId == cookiePatronId) {
+      const response = await updateUsername(patronId, username)
+      responseStatus = response.status
+      responseMessage = response.message
+    } else {
+      responseStatus = 403
+      responseMessage = "Authenticated patron does not match request"
+    }
+  }
+  res.status(responseStatus).json(responseMessage)
+}

--- a/src/components/MyAccount/IconListElement.tsx
+++ b/src/components/MyAccount/IconListElement.tsx
@@ -11,7 +11,7 @@ export interface IconListElementPropType {
 
 // This component is designed to centralize common styling patterns for a
 // description type List with icons
-const IconListElement = ({
+export const IconListElement = ({
   icon,
   term,
   description,

--- a/src/components/MyAccount/NewSettings/AddButton.tsx
+++ b/src/components/MyAccount/NewSettings/AddButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@nypl/design-system-react-components"
 
 type AddButtonProps = {
-  inputType: string
+  inputType?: string
   label: string
   onClick: () => void
 }
@@ -9,7 +9,7 @@ type AddButtonProps = {
 const AddButton = ({ inputType, label, onClick }: AddButtonProps) => {
   return (
     <Button
-      id={`add-${inputType}-button`}
+      id={inputType ? `add-${inputType}-button` : "add-button"}
       buttonType="text"
       onClick={onClick}
       size="large"

--- a/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
+++ b/src/components/MyAccount/NewSettings/NewAccountSettingsTab.tsx
@@ -1,9 +1,10 @@
-import { Flex, Banner, Link, Text } from "@nypl/design-system-react-components"
+import { Flex } from "@nypl/design-system-react-components"
 import { useContext, useEffect, useRef, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import SettingsInputForm from "./SettingsInputForm"
 import SettingsSelectForm from "./SettingsSelectForm"
 import PasswordForm from "./PasswordForm"
+import { StatusBanner } from "./StatusBanner"
 
 type StatusType = "" | "failure" | "success"
 
@@ -33,47 +34,11 @@ const NewAccountSettingsTab = () => {
     }
   }, [status])
 
-  const bannerContent = (
-    <div style={{ alignItems: "center" }}>
-      {status === "failure" ? (
-        statusMessage !== "" ? (
-          <Text marginBottom={0} color={"ui.black !important"}>
-            {statusMessage} Please try again or{" "}
-            <Link
-              sx={{
-                color: "ui.link.primary !important",
-                textDecorationColor: "ui.link.primary !important",
-                textDecoration: "underline",
-              }}
-              href="https://www.nypl.org/get-help/contact-us"
-            >
-              contact us
-            </Link>{" "}
-            for assistance.
-          </Text>
-        ) : (
-          <Text marginBottom={0} color={"ui.black !important"}>
-            Your changes were not saved.
-          </Text>
-        )
-      ) : (
-        <Text marginBottom={0} color={"ui.black !important"}>
-          Your changes were saved.
-        </Text>
-      )}
-    </div>
-  )
-
   return (
     <>
       {status !== "" && (
         <div ref={bannerRef} tabIndex={-1}>
-          <Banner
-            sx={{ marginTop: "m" }}
-            isDismissible
-            content={bannerContent}
-            type={status === "failure" ? "negative" : "positive"}
-          />
+          <StatusBanner status={status} statusMessage={statusMessage} />
         </div>
       )}
       <Flex flexDir="column" sx={{ marginTop: "xl", gap: "s" }}>

--- a/src/components/MyAccount/NewSettings/StatusBanner.tsx
+++ b/src/components/MyAccount/NewSettings/StatusBanner.tsx
@@ -1,0 +1,50 @@
+import { Banner, Text, Link } from "@nypl/design-system-react-components"
+
+export type StatusType = "" | "failure" | "usernameFailure" | "success"
+
+type StatusBannerProps = {
+  status: StatusType
+  statusMessage: string
+}
+
+export const StatusBanner = ({ status, statusMessage }: StatusBannerProps) => {
+  const bannerContent = (
+    <div style={{ alignItems: "center" }}>
+      {status === "failure" ? (
+        statusMessage !== "" ? (
+          <Text marginBottom={0} color={"ui.black !important"}>
+            {statusMessage} Please try again or{" "}
+            <Link
+              sx={{
+                color: "ui.link.primary !important",
+                textDecorationColor: "ui.link.primary !important",
+                textDecoration: "underline",
+              }}
+              href="https://www.nypl.org/get-help/contact-us"
+            >
+              contact us
+            </Link>{" "}
+            for assistance.
+          </Text>
+        ) : (
+          <Text marginBottom={0} color={"ui.black !important"}>
+            Your changes were not saved.
+          </Text>
+        )
+      ) : (
+        <Text marginBottom={0} color={"ui.black !important"}>
+          Your changes were saved.
+        </Text>
+      )}
+    </div>
+  )
+
+  return (
+    <Banner
+      sx={{ marginTop: "m" }}
+      isDismissible
+      content={bannerContent}
+      type={status === "failure" ? "negative" : "positive"}
+    />
+  )
+}

--- a/src/components/MyAccount/NewSettings/UsernameForm.test.tsx
+++ b/src/components/MyAccount/NewSettings/UsernameForm.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { PatronDataProvider } from "../../../context/PatronDataContext"
+import {
+  emptyPatron,
+  filteredPickupLocations,
+  processedPatron,
+} from "../../../../__test__/fixtures/processedMyAccountData"
+import UsernameForm from "./UsernameForm"
+
+describe("username form", () => {
+  const mockUsernameState = {
+    setUsernameStatus: jest.fn(),
+    setUsernameStatusMessage: jest.fn(),
+  }
+  const accountFetchSpy = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => {
+        console.log("Updated")
+      },
+      status: 200,
+    } as Response)
+  })
+
+  const component = (
+    <PatronDataProvider
+      testSpy={accountFetchSpy}
+      value={{
+        patron: processedPatron,
+        pickupLocations: filteredPickupLocations,
+      }}
+    >
+      <UsernameForm
+        patron={processedPatron}
+        usernameState={mockUsernameState}
+      />
+    </PatronDataProvider>
+  )
+
+  const noUsernameComponent = (
+    <PatronDataProvider
+      testSpy={accountFetchSpy}
+      value={{
+        patron: emptyPatron,
+        pickupLocations: filteredPickupLocations,
+      }}
+    >
+      <UsernameForm patron={emptyPatron} usernameState={mockUsernameState} />
+    </PatronDataProvider>
+  )
+
+  it("renders correctly with initial username", () => {
+    render(component)
+
+    expect(screen.getByText(processedPatron.username)).toBeInTheDocument()
+
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument()
+  })
+
+  it("renders correctly with when user has no username", () => {
+    render(noUsernameComponent)
+
+    expect(screen.getByText("+ Add username")).toBeInTheDocument()
+
+    expect(screen.queryByRole("button", { name: /edit/i })).toBeNull()
+  })
+
+  it("allows editing when edit button is clicked", () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    expect(
+      screen.getByLabelText(
+        "Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByDisplayValue(processedPatron.username)
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /save changes/i })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/edit/)).not.toBeInTheDocument()
+  })
+
+  it("validates username input correctly", () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    const input = screen.getByLabelText(
+      "Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
+    )
+    fireEvent.change(input, { target: { value: "!!!!!" } })
+
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled()
+  })
+
+  it("removes username when delete icon is clicked", () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    fireEvent.click(screen.getByLabelText("Remove username"))
+
+    expect(
+      screen.queryByDisplayValue(processedPatron.username)
+    ).not.toBeInTheDocument()
+  })
+
+  it("calls submitInput with valid data", async () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    const input = screen.getByLabelText(
+      "Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
+    )
+    fireEvent.change(input, { target: { value: "newUsername" } })
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+
+    expect(fetch).toHaveBeenCalledWith(
+      `/research/research-catalog/api/account/username/${processedPatron.id}`,
+      expect.objectContaining({
+        body: '{"username":"newUsername"}',
+        headers: { "Content-Type": "application/json" },
+        method: "PUT",
+      })
+    )
+  })
+
+  it("cancels editing and reverts state", () => {
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    const input = screen.getByLabelText(
+      "Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
+    )
+    fireEvent.change(input, { target: { value: "modification" } })
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    expect(screen.getByText(processedPatron.username)).toBeInTheDocument()
+    expect(screen.queryByDisplayValue("modification")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/MyAccount/NewSettings/UsernameForm.tsx
+++ b/src/components/MyAccount/NewSettings/UsernameForm.tsx
@@ -5,25 +5,45 @@ import {
   Flex,
   Button,
   SkeletonLoader,
-  Form,
-  Box,
   Banner,
 } from "@nypl/design-system-react-components"
 import { useContext, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import SaveCancelButtons from "./SaveCancelButtons"
-import SettingsLabel from "./SettingsLabel"
 import type { Patron } from "../../../types/myAccountTypes"
 import EditButton from "./EditButton"
 import AddButton from "./AddButton"
-import IconListElement from "../IconListElement"
+import { BASE_URL } from "../../../config/constants"
 
-const UsernameForm = ({ patron }: { patron: Patron }) => {
+export const usernameStatusMessages = {
+  USERNAME_FAILURE:
+    "This username already exists. Please try a different username or contact us for assistance.",
+  FAILURE:
+    "Your changes could not be saved. Please try again or contact us for assistance. ",
+  SUCCESS: "Your changes were saved.",
+}
+
+interface UsernameFormProps {
+  patron: Patron
+  usernameState
+}
+
+const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
+  const { getMostUpdatedSierraAccountData } = useContext(PatronDataContext)
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [error, setError] = useState(false)
-  const [input, setInput] = useState(patron.username)
+  const [input, setInput] = useState(patron.username || "")
   const [tempInput, setTempInput] = useState(input)
+
+  const { setUsernameStatus, setUsernameStatusMessage } = usernameState
+
+  const validateUsername = (username: string | null) => {
+    if (username === null) return false
+    if (username === "") return true
+    const usernameRegex = /^[a-zA-Z0-9]{5,15}$/
+    return usernameRegex.test(username)
+  }
 
   const cancelEditing = () => {
     setTempInput(input)
@@ -31,37 +51,82 @@ const UsernameForm = ({ patron }: { patron: Patron }) => {
     setError(false)
   }
 
+  const handleInputChange = (e) => {
+    const { value } = e.target
+    setTempInput(value)
+    if (!validateUsername(value)) {
+      setError(true)
+    } else {
+      setError(false)
+    }
+  }
+
   const submitInput = async () => {
     setIsLoading(true)
     setIsEditing(false)
+    setUsernameStatus("")
+    const submissionInput = tempInput === null ? "" : tempInput
+    console.log(JSON.stringify({ username: submissionInput }))
+    try {
+      const response = await fetch(
+        `${BASE_URL}/api/account/username/${patron.id}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ username: submissionInput }),
+        }
+      )
+      const responseMessage = await response.json()
+      if (responseMessage !== "Username taken" && response.status === 200) {
+        await getMostUpdatedSierraAccountData()
+        setUsernameStatus("success")
+        setInput(submissionInput)
+        setTempInput(submissionInput)
+      } else {
+        setUsernameStatus("failure")
+        setUsernameStatusMessage(
+          responseMessage === "Username taken"
+            ? usernameStatusMessages.USERNAME_FAILURE
+            : usernameStatusMessages.FAILURE
+        )
+        setTempInput(input)
+      }
+    } catch (error) {
+      setUsernameStatus("failure")
+      setUsernameStatusMessage(usernameStatusMessages.FAILURE)
+      console.error("Error submitting username:", error)
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (
-    <>
-      <Flex
-        flexDir={{ base: "column", lg: "row" }}
-        alignItems="flex-start"
-        width="100%"
-        sx={{
-          marginBottom: "xxl",
-        }}
-      >
-        <Flex gap="xs" marginRight="140px" alignItems="center">
-          <Icon name={"actionIdentity"} size="large" />
-          <Text
-            size="body1"
-            sx={{
-              fontWeight: "500",
-              marginBottom: 0,
-            }}
-          >
-            Username
-          </Text>
-        </Flex>
-        {isEditing ? (
-          <Flex flexDir="column">
-            {tempInput ? (
-              <Flex flexDir="column">
+    <Flex
+      flexDir={{ base: "column", lg: "row" }}
+      alignItems="flex-start"
+      width="100%"
+    >
+      <Flex gap="xs" marginRight="140px" paddingTop="xs" alignItems="center">
+        <Icon name="actionIdentity" size="large" />
+        <Text size="body1" sx={{ fontWeight: "500", marginBottom: 0 }}>
+          Username
+        </Text>
+      </Flex>
+
+      {isLoading ? (
+        <SkeletonLoader contentSize={2} showImage={false} headingSize={0} />
+      ) : isEditing ? (
+        <Flex
+          flexDir="column"
+          marginLeft={{ base: "l", lg: "unset" }}
+          marginTop={{ base: "xs", lg: "unset" }}
+          maxWidth={{ base: "600px", md: "320px" }}
+        >
+          {tempInput !== null ? (
+            <>
+              <Flex flexDir="row" alignItems="flex-start">
                 <TextInput
                   sx={{
                     width: { base: "87%", md: "300px" },
@@ -69,17 +134,18 @@ const UsernameForm = ({ patron }: { patron: Patron }) => {
                     flexDirection: "column-reverse",
                     label: {
                       fontWeight: "400",
+                      color: error ? "ui.error.primary" : "ui.black",
                     },
                   }}
-                  value={tempInput}
+                  value={tempInput || ""}
                   id="username-input"
                   labelText="Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
                   showLabel
-                  //isInvalid={error && !validateInput(input, tempInput)}
-                  invalidText="Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
-                  //onChange={(e) => handleInputChange(e)}
+                  isInvalid={error && !validateUsername(tempInput)}
+                  showHelperInvalidText={false}
+                  onChange={handleInputChange}
                   isClearable
-                  //isClearableCallback={() => handleClearableCallback}
+                  isClearableCallback={() => setError(true)}
                 />
                 <Button
                   aria-label="Remove username"
@@ -87,56 +153,60 @@ const UsernameForm = ({ patron }: { patron: Patron }) => {
                   id="remove-username-btn"
                   onClick={() => {
                     setTempInput(null)
+                    setError(false)
                   }}
                 >
                   {" "}
                   <Icon name="actionDelete" size="large" />
                 </Button>
-                <Banner
-                  sx={{ marginTop: "xs", width: "300px" }}
-                  content="If you delete your username, you will have to use your barcode to log in to your account in the future."
-                  type="warning"
-                />
               </Flex>
-            ) : (
-              <AddButton
-                label={"+ Add username"}
-                onClick={() => {
-                  setTempInput("")
-                }}
+              <Banner
+                sx={{ marginTop: "xs", width: "fill" }}
+                content="If you delete your username, you will have to use your barcode to log in to your account in the future."
+                type="warning"
               />
-            )}
-          </Flex>
-        ) : (
-          <Flex
-            alignItems="flex-start"
-            sx={{
-              button: {
-                paddingBottom: "m",
-              },
-            }}
-          >
-            <Text size="body1" sx={{ marginBottom: 0 }}>
-              {patron.username}
-            </Text>
-            <EditButton
-              buttonId="edit-username-button"
+            </>
+          ) : (
+            <AddButton
+              label="+ Add username"
               onClick={() => {
-                setIsEditing(true)
+                setTempInput("")
               }}
             />
-          </Flex>
-        )}
-        {isEditing && (
-          <SaveCancelButtons
-            onCancel={cancelEditing}
-            onSave={submitInput}
-            isDisabled={error}
-          />
-        )}
-      </Flex>
-    </>
+          )}
+        </Flex>
+      ) : (
+        <Flex alignItems="center">
+          {input !== "" ? (
+            <>
+              <Text size="body1" sx={{ marginBottom: 0 }}>
+                {input}
+              </Text>
+              <EditButton
+                buttonId="edit-username-button"
+                onClick={() => setIsEditing(true)}
+              />
+            </>
+          ) : (
+            <AddButton
+              label="+ Add username"
+              onClick={() => {
+                setIsEditing(true)
+                setTempInput("")
+              }}
+            />
+          )}
+        </Flex>
+      )}
+
+      {isEditing && (
+        <SaveCancelButtons
+          onCancel={cancelEditing}
+          onSave={submitInput}
+          isDisabled={error}
+        />
+      )}
+    </Flex>
   )
 }
-
 export default UsernameForm

--- a/src/components/MyAccount/NewSettings/UsernameForm.tsx
+++ b/src/components/MyAccount/NewSettings/UsernameForm.tsx
@@ -1,0 +1,142 @@
+import {
+  Icon,
+  TextInput,
+  Text,
+  Flex,
+  Button,
+  SkeletonLoader,
+  Form,
+  Box,
+  Banner,
+} from "@nypl/design-system-react-components"
+import { useContext, useState } from "react"
+import { PatronDataContext } from "../../../context/PatronDataContext"
+import SaveCancelButtons from "./SaveCancelButtons"
+import SettingsLabel from "./SettingsLabel"
+import type { Patron } from "../../../types/myAccountTypes"
+import EditButton from "./EditButton"
+import AddButton from "./AddButton"
+import IconListElement from "../IconListElement"
+
+const UsernameForm = ({ patron }: { patron: Patron }) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [error, setError] = useState(false)
+  const [input, setInput] = useState(patron.username)
+  const [tempInput, setTempInput] = useState(input)
+
+  const cancelEditing = () => {
+    setTempInput(input)
+    setIsEditing(false)
+    setError(false)
+  }
+
+  const submitInput = async () => {
+    setIsLoading(true)
+    setIsEditing(false)
+  }
+
+  return (
+    <>
+      <Flex
+        flexDir={{ base: "column", lg: "row" }}
+        alignItems="flex-start"
+        width="100%"
+        sx={{
+          marginBottom: "xxl",
+        }}
+      >
+        <Flex gap="xs" marginRight="140px" alignItems="center">
+          <Icon name={"actionIdentity"} size="large" />
+          <Text
+            size="body1"
+            sx={{
+              fontWeight: "500",
+              marginBottom: 0,
+            }}
+          >
+            Username
+          </Text>
+        </Flex>
+        {isEditing ? (
+          <Flex flexDir="column">
+            {tempInput ? (
+              <Flex flexDir="column">
+                <TextInput
+                  sx={{
+                    width: { base: "87%", md: "300px" },
+                    display: "flex",
+                    flexDirection: "column-reverse",
+                    label: {
+                      fontWeight: "400",
+                    },
+                  }}
+                  value={tempInput}
+                  id="username-input"
+                  labelText="Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
+                  showLabel
+                  //isInvalid={error && !validateInput(input, tempInput)}
+                  invalidText="Must be 5-15 characters and use only letters (a-z) and numbers (0-9)"
+                  //onChange={(e) => handleInputChange(e)}
+                  isClearable
+                  //isClearableCallback={() => handleClearableCallback}
+                />
+                <Button
+                  aria-label="Remove username"
+                  buttonType="text"
+                  id="remove-username-btn"
+                  onClick={() => {
+                    setTempInput(null)
+                  }}
+                >
+                  {" "}
+                  <Icon name="actionDelete" size="large" />
+                </Button>
+                <Banner
+                  sx={{ marginTop: "xs", width: "300px" }}
+                  content="If you delete your username, you will have to use your barcode to log in to your account in the future."
+                  type="warning"
+                />
+              </Flex>
+            ) : (
+              <AddButton
+                label={"+ Add username"}
+                onClick={() => {
+                  setTempInput("")
+                }}
+              />
+            )}
+          </Flex>
+        ) : (
+          <Flex
+            alignItems="flex-start"
+            sx={{
+              button: {
+                paddingBottom: "m",
+              },
+            }}
+          >
+            <Text size="body1" sx={{ marginBottom: 0 }}>
+              {patron.username}
+            </Text>
+            <EditButton
+              buttonId="edit-username-button"
+              onClick={() => {
+                setIsEditing(true)
+              }}
+            />
+          </Flex>
+        )}
+        {isEditing && (
+          <SaveCancelButtons
+            onCancel={cancelEditing}
+            onSave={submitInput}
+            isDisabled={error}
+          />
+        )}
+      </Flex>
+    </>
+  )
+}
+
+export default UsernameForm

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -1,4 +1,5 @@
 import {
+  Banner,
   Box,
   List,
   useNYPLBreakpoints,
@@ -11,9 +12,26 @@ import type { Patron } from "../../types/myAccountTypes"
 import type { IconListElementPropType } from "./IconListElement"
 import { buildListElementsWithIcons } from "./IconListElement"
 import UsernameForm from "./NewSettings/UsernameForm"
+import { useEffect, useRef, useState } from "react"
+import type { StatusType } from "./NewSettings/StatusBanner"
+import { StatusBanner } from "./NewSettings/StatusBanner"
 
 const ProfileHeader = ({ patron }: { patron: Patron }) => {
   const { isLargerThanMobile } = useNYPLBreakpoints()
+  const [usernameStatus, setUsernameStatus] = useState<StatusType>("")
+  const [usernameStatusMessage, setUsernameStatusMessage] = useState<string>("")
+  const usernameBannerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (usernameStatus !== "" && usernameBannerRef.current) {
+      usernameBannerRef.current.focus()
+    }
+  }, [usernameStatus])
+
+  const usernameState = {
+    setUsernameStatus,
+    setUsernameStatusMessage,
+  }
 
   const profileData = (
     [
@@ -50,6 +68,18 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
 
   return (
     <>
+      {usernameStatus !== "" && (
+        <div
+          ref={usernameBannerRef}
+          tabIndex={-1}
+          style={{ marginBottom: "32px" }}
+        >
+          <StatusBanner
+            status={usernameStatus}
+            statusMessage={usernameStatusMessage}
+          />
+        </div>
+      )}
       <List
         className={styles.myAccountList}
         id="my-account-profile-header"
@@ -58,12 +88,22 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
         sx={{
           border: "none",
           h2: { border: "none", paddingTop: 0 },
+        }}
+      >
+        {profileData[0]}
+      </List>
+      <UsernameForm patron={patron} usernameState={usernameState} />
+      <List
+        className={styles.myAccountList}
+        id="my-account-profile-header-2"
+        type="dl"
+        sx={{
+          border: "none",
           marginBottom: "xxl",
         }}
       >
-        {profileData}
+        {profileData.slice(1)}
       </List>
-      <UsernameForm patron={patron} />
     </>
   )
 }

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -10,6 +10,7 @@ import styles from "../../../styles/components/MyAccount.module.scss"
 import type { Patron } from "../../types/myAccountTypes"
 import type { IconListElementPropType } from "./IconListElement"
 import { buildListElementsWithIcons } from "./IconListElement"
+import UsernameForm from "./NewSettings/UsernameForm"
 
 const ProfileHeader = ({ patron }: { patron: Patron }) => {
   const { isLargerThanMobile } = useNYPLBreakpoints()
@@ -17,11 +18,6 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
   const profileData = (
     [
       { icon: "actionIdentityFilled", term: "Name", description: patron.name },
-      {
-        icon: "actionIdentity",
-        term: "Username",
-        description: patron.username,
-      },
       {
         icon: "actionPayment",
         term: "Card number",
@@ -53,19 +49,22 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
     .map(buildListElementsWithIcons)
 
   return (
-    <List
-      className={styles.myAccountList}
-      id="my-account-profile-header"
-      title="My Account"
-      type="dl"
-      sx={{
-        border: "none",
-        h2: { border: "none", paddingTop: 0 },
-        marginBottom: "xxl",
-      }}
-    >
-      {profileData}
-    </List>
+    <>
+      <List
+        className={styles.myAccountList}
+        id="my-account-profile-header"
+        title="My Account"
+        type="dl"
+        sx={{
+          border: "none",
+          h2: { border: "none", paddingTop: 0 },
+          marginBottom: "xxl",
+        }}
+      >
+        {profileData}
+      </List>
+      <UsernameForm patron={patron} />
+    </>
   )
 }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -6,17 +6,9 @@ export const appConfig: AppConfig = {
     (process.env.NEXT_PUBLIC_APP_ENV as Environment) || "development",
   apiEndpoints: {
     platform: {
-      development: "https://qa-platform.nypl.org/api/v0.1",
-      qa: "https://qa-platform.nypl.org/api/v0.1",
-      production: "https://platform.nypl.org/api/v0.1",
-    },
-    // The 'discovery' base URL should use DISCOVERY_API_BASE_URL if set,
-    // falling back on PLATFORM_API_BASE_URL if set,
-    // and finally falling back on a sensible default.
-    discovery: {
-      development: "https://qa-platform.nypl.org/api/v0.1",
-      qa: "https://qa-platform.nypl.org/api/v0.1",
-      production: "https://platform.nypl.org/api/v0.1",
+      development: "https://qa-platform.nypl.org/api",
+      qa: "https://qa-platform.nypl.org/api",
+      production: "https://platform.nypl.org/api",
     },
     domain: {
       development: "local.nypl.org:8080",

--- a/src/server/api/bib.ts
+++ b/src/server/api/bib.ts
@@ -7,7 +7,6 @@ import {
 } from "../../utils/bibUtils"
 import nyplApiClient from "../nyplApiClient"
 import {
-  DISCOVERY_API_NAME,
   DISCOVERY_API_SEARCH_ROUTE,
   ITEM_VIEW_ALL_BATCH_SIZE,
   SHEP_HTTP_TIMEOUT,
@@ -29,7 +28,7 @@ export async function fetchBib(
     }
   }
 
-  const client = await nyplApiClient({ apiName: DISCOVERY_API_NAME })
+  const client = await nyplApiClient()
   const [bibResponse, annotatedMarcResponse] = await Promise.allSettled([
     await client.get(
       `${DISCOVERY_API_SEARCH_ROUTE}/${standardizedId}${getBibQueryString(
@@ -148,7 +147,7 @@ async function fetchAllBibItemsWithQuery(
   batchSize: number
 ): Promise<DiscoveryItemResult[]> {
   const items: DiscoveryItemResult[] = []
-  const client = await nyplApiClient({ apiName: DISCOVERY_API_NAME })
+  const client = await nyplApiClient()
   const totalBatchNum = Math.ceil(numItems / batchSize)
 
   for (let batchNum = 1; batchNum <= totalBatchNum; batchNum++) {

--- a/src/server/api/locations.ts
+++ b/src/server/api/locations.ts
@@ -1,12 +1,11 @@
 import nyplApiClient from "../nyplApiClient"
-import { DISCOVERY_API_NAME } from "../../config/constants"
 import { encode as encodeQueryString } from "querystring"
 
 /**
  *  Fetch locations by query {object}
  */
 export async function fetchLocations(query) {
-  const client = await nyplApiClient({ apiName: DISCOVERY_API_NAME })
+  const client = await nyplApiClient()
   const path = `/locations?${encodeQueryString(query)}`
   return client.get(path)
 }

--- a/src/server/api/search.ts
+++ b/src/server/api/search.ts
@@ -5,7 +5,6 @@ import type {
 import { standardizeBibId } from "../../utils/bibUtils"
 import { getSearchQuery } from "../../utils/searchUtils"
 import {
-  DISCOVERY_API_NAME,
   DISCOVERY_API_SEARCH_ROUTE,
   DRB_API_NAME,
   RESULTS_PER_PAGE,
@@ -53,7 +52,7 @@ export async function fetchResults(
   //  - search results
   //  - aggregations
   //  - drb results
-  const client = await nyplApiClient({ apiName: DISCOVERY_API_NAME })
+  const client = await nyplApiClient()
   const drbClient = await nyplApiClient({ apiName: DRB_API_NAME })
 
   const [resultsResponse, aggregationsResponse, drbResultsResponse] =

--- a/src/server/nyplApiClient/index.ts
+++ b/src/server/nyplApiClient/index.ts
@@ -32,7 +32,6 @@ const nyplApiClient = async ({
 
   const baseUrl =
     appConfig.apiEndpoints[apiName][appEnvironment] + "/" + version
-  console.log(baseUrl)
 
   let decryptedId: string
   let decryptedSecret: string

--- a/src/server/nyplApiClient/index.ts
+++ b/src/server/nyplApiClient/index.ts
@@ -22,13 +22,17 @@ export class NyplApiClientError extends Error {
   }
 }
 
-const nyplApiClient = async (options = { apiName: "platform" }) => {
-  const { apiName } = options
+const nyplApiClient = async ({
+  apiName = "platform",
+  version = "v0.1",
+} = {}) => {
   if (CACHE.clients[apiName]) {
     return CACHE.clients[apiName]
   }
 
-  const baseUrl = appConfig.apiEndpoints[apiName][appEnvironment]
+  const baseUrl =
+    appConfig.apiEndpoints[apiName][appEnvironment] + "/" + version
+  console.log(baseUrl)
 
   let decryptedId: string
   let decryptedSecret: string

--- a/src/server/tests/helpers.test.ts
+++ b/src/server/tests/helpers.test.ts
@@ -1,13 +1,17 @@
 import sierraClient from "../../../src/server/sierraClient"
+import nyplApiClient from "../nyplApiClient"
 import {
   updatePin,
   updatePatronSettings,
   updateHold,
   renewCheckout,
   cancelHold,
+  updateUsername,
 } from "../../../pages/api/account/helpers"
 
 jest.mock("../../../src/server/sierraClient")
+jest.mock("../../../src/server/nyplApiClient")
+
 const mockCheckoutResponse = {
   id: "1234567",
   callNumber: "123 TEST",
@@ -269,6 +273,80 @@ describe("updatePin", () => {
     })
     expect(response.status).toBe(500)
     expect(response.message).toBe("Server error")
+  })
+})
+
+describe("updateUsername", () => {
+  it("should return a success message if username is updated", async () => {
+    const newUsername = "newUsername"
+    const patronId = "678910"
+
+    const platformMethodMock = jest.fn().mockResolvedValueOnce({
+      status: 200,
+      type: "available-username",
+    })
+    ;(nyplApiClient as jest.Mock).mockResolvedValueOnce({
+      post: platformMethodMock,
+    })
+
+    const sierraMethodMock = jest.fn().mockResolvedValueOnce({
+      status: 200,
+      message: `Username updated to ${newUsername}`,
+    })
+    ;(sierraClient as jest.Mock).mockResolvedValueOnce({
+      put: sierraMethodMock,
+    })
+
+    const response = await updateUsername(patronId, newUsername)
+
+    expect(nyplApiClient).toHaveBeenCalled
+    expect(platformMethodMock).toHaveBeenNthCalledWith(
+      1,
+      "/validations/username",
+      {
+        username: newUsername,
+      }
+    )
+
+    expect(sierraClient).toHaveBeenCalled
+    expect(sierraMethodMock).toHaveBeenNthCalledWith(1, `patrons/${patronId}`, {
+      varFields: [{ fieldTag: "u", content: newUsername }],
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.message).toBe(`Username updated to ${newUsername}`)
+  })
+
+  it("should return a message if username is already taken or invalid", async () => {
+    const alreadyTakenUsername = "alreadyTakenUsername"
+    const patronId = "678910"
+
+    const platformMethodMock = jest.fn().mockResolvedValueOnce({
+      status: 400,
+      type: "unavailable-username",
+      title: "Bad Username",
+      detail:
+        "Usernames should be 5-25 characters, letters or numbers only. Please revise your username.",
+    })
+    ;(nyplApiClient as jest.Mock).mockResolvedValueOnce({
+      post: platformMethodMock,
+    })
+
+    const response = await updateUsername(patronId, alreadyTakenUsername)
+
+    expect(nyplApiClient).toHaveBeenCalled
+    expect(platformMethodMock).toHaveBeenNthCalledWith(
+      1,
+      "/validations/username",
+      {
+        username: alreadyTakenUsername,
+      }
+    )
+
+    expect(sierraClient).not.toHaveBeenCalled
+
+    expect(response.status).toBe(200)
+    expect(response.message).toBe("Username taken")
   })
 })
 


### PR DESCRIPTION
## Ticket:

Resolves JIRA ticket [SCC-4236](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4236).

## This PR does the following:

- Adds `UsernameForm` to profile header
- Adds `api/account/username` route to validate new patron usernames
- Removes "discovery" from `src/config` (it's a duplicate of "platform")
- Updates `nyplApiClient` to take an api version (defaults to `v0.1`)
- Pulls out the settings status banner into a reusable `StatusBanner`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
