### PR TITLE
HOTFIX - Fix analytics page tracking events

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.3.7] Hotfix 2024-11-21
+
+- Fix analytics bug where routes without a query string emit do not emit the correct virutal page view event (due to a ternary on a truthy -1 returned from indexOf) (SCC-4314)
+
 ## [1.3.6] 2024-11-6
 
 ## Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [1.3.7] Hotfix 2024-11-21
 
-- Fix analytics bug where routes without a query string emit do not emit the correct virutal page view event (due to a ternary on a truthy -1 returned from indexOf) (SCC-4314)
+- Fix analytics bug where routes without a query string emit do not emit the correct virutal page view event (SCC-4314)
 
 ## [1.3.6] 2024-11-6
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [1.3.7] Hotfix 2024-11-21
 
-- Fix analytics bug where routes without a query string emit do not emit the correct virutal page view event (SCC-4314)
+- Fix analytics bug where routes without a query string do not emit the correct virtual page view event (SCC-4314)
 
 ## [1.3.6] 2024-11-6
 

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -93,7 +93,7 @@ export const trackVirtualPageView = (pathname = "") => {
   const adobeDataLayer = window["adobeDataLayer"] || []
   const route = pathname.toLowerCase().replace(BASE_URL, "")
   const queryIndex = route.indexOf("?")
-  const path = route.substring(0, queryIndex)
+  const path = queryIndex >= 0 ? route.substring(0, queryIndex) : route
   const queryParams = route.slice(queryIndex)
 
   adobeDataLayer.push({


### PR DESCRIPTION
Hotfix for analytics bug where page routes without a query string were emitting a homepage view event. This was caused by the use of a -1 ending index in a substring function, which returns an empty string.

This was missed in QA for the bib release page, and I assume we didn't notice it when we released the search results because most routes have a query string.

There are no unit tests for trackVirtualPageView since it has a void return type, but I'll separate this logic out to add unit tests as a fast-follow.