### PR TITLE
SCC-3762 - Hold Confirmation Server Functions

### DIFF
--- a/.github/workflows/deploy_train.yml
+++ b/.github/workflows/deploy_train.yml
@@ -7,6 +7,7 @@ on:
       - train
       - set-up-train-env
       - hold-pages
+      - SCC-3762/hold-confirmation-server-functions
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy_train.yml
+++ b/.github/workflows/deploy_train.yml
@@ -7,7 +7,6 @@ on:
       - train
       - set-up-train-env
       - hold-pages
-      - SCC-3762/hold-confirmation-server-functions
 
 permissions:
   id-token: write

--- a/pages/hold/confirmation/[id].tsx
+++ b/pages/hold/confirmation/[id].tsx
@@ -11,6 +11,8 @@ import {
 import HoldConfirmationFAQ from "../../../src/components/HoldPages/HoldConfirmationFAQ"
 // import HoldItemDetails from "../../../src/components/HoldPages/HoldItemDetails"
 
+import { fetchHoldRequestDetails } from "../../../src/server/api/hold"
+
 interface HoldConfirmationPageProps {
   isEDD?: boolean
 }
@@ -55,4 +57,14 @@ export default function HoldConfirmationPage({
       </Layout>
     </>
   )
+}
+
+export async function getServerSideProps({ query }) {
+  const { pickupLocation, requestId } = query
+  fetchHoldRequestDetails({ requestId, patronId: "" })
+  return {
+    props: {
+      isEDD: pickupLocation === "edd",
+    },
+  }
 }

--- a/pages/hold/confirmation/[id].tsx
+++ b/pages/hold/confirmation/[id].tsx
@@ -66,6 +66,7 @@ export default function HoldConfirmationPage({
 }
 
 export async function getServerSideProps({ req, res, query }) {
+  const { pickupLocation, requestId } = query
   // authentication redirect
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
   const isAuthenticated = patronTokenResponse.isTokenValid
@@ -82,7 +83,10 @@ export async function getServerSideProps({ req, res, query }) {
         redirectCount + 1
       }; Max-Age=10; path=/; domain=.nypl.org;`
     )
-    const redirect = getLoginRedirect(req, `${PATHS.HOLD_REQUEST}/${id}/edd`)
+    const redirect = getLoginRedirect(
+      req,
+      `${PATHS.HOLD_CONFIRMATION}?pickupLocation=${pickupLocation}&requestId=${requestId}`
+    )
 
     return {
       redirect: {
@@ -93,7 +97,6 @@ export async function getServerSideProps({ req, res, query }) {
   }
 
   const patronId = patronTokenResponse?.decodedPatron?.sub
-  const { pickupLocation, requestId } = query
 
   try {
     const { patronId: patronIdFromResponse } = await fetchHoldDetails(requestId)

--- a/pages/hold/confirmation/[id].tsx
+++ b/pages/hold/confirmation/[id].tsx
@@ -6,7 +6,6 @@ import {
   SITE_NAME,
   HOLD_PAGE_HEADING,
   EDD_PAGE_HEADING,
-  BASE_URL,
   PATHS,
 } from "../../../src/config/constants"
 
@@ -19,15 +18,6 @@ import initializePatronTokenAuth, {
   doRedirectBasedOnNyplAccountRedirects,
   getLoginRedirect,
 } from "../../../src/server/auth"
-
-import Bib from "../../../src/models/Bib"
-import Item from "../../../src/models/Item"
-
-import type { DiscoveryBibResult } from "../../../src/types/bibTypes"
-import type { DiscoveryItemResult } from "../../../src/types/itemTypes"
-
-import { fetchBib } from "../../../src/server/api/bib"
-import { fetchDeliveryLocations } from "../../../src/server/api/hold"
 
 interface HoldConfirmationPageProps {
   isEDD?: boolean

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -17,7 +17,10 @@ import { SITE_NAME, BASE_URL, PATHS } from "../../../../src/config/constants"
 import useLoading from "../../../../src/hooks/useLoading"
 
 import { fetchBib } from "../../../../src/server/api/bib"
-import { fetchDeliveryLocations } from "../../../../src/server/api/hold"
+import {
+  fetchDeliveryLocations,
+  fetchHoldRequestEligibility,
+} from "../../../../src/server/api/hold"
 
 import initializePatronTokenAuth, {
   doRedirectBasedOnNyplAccountRedirects,
@@ -209,6 +212,9 @@ export async function getServerSideProps({ params, req, res }) {
 
   try {
     const patronId = patronTokenResponse?.decodedPatron?.sub
+
+    const holdRequestElligibility = await fetchHoldRequestEligibility(patronId)
+    console.log("holdRequestElligibility", holdRequestElligibility)
 
     // fetch bib and item
     const [bibId, itemId] = id.split("-")

--- a/src/server/api/hold.ts
+++ b/src/server/api/hold.ts
@@ -2,7 +2,7 @@ import nyplApiClient from "../nyplApiClient"
 
 import type {
   HoldPostResult,
-  HoldRequestDetailsParams,
+  HoldDetailsResult,
 } from "../../types/holdPageTypes"
 import type {
   DeliveryLocation,
@@ -126,27 +126,28 @@ export async function postHoldRequest(
 /**
  * Getter function for hold request details.
  */
-export async function fetchHoldRequestDetails(
-  holdRequestDetailsParams: HoldRequestDetailsParams
-): Promise<void> {
-  const { requestId, patronId } = holdRequestDetailsParams
-
+// TODO: Add return type
+export async function fetchHoldDetails(
+  requestId: string
+): Promise<HoldDetailsResult> {
   try {
     const client = await nyplApiClient()
     const holdDetailsResult = await client.get(`/hold-requests/${requestId}`)
-    if (patronId !== holdDetailsResult.data.patron) {
-      console.log("TODO: Redirect to 404 page")
-    }
+    const { id, pickupLocation, patron } = holdDetailsResult.data
 
-    console.log("holdDetailsResult", holdDetailsResult)
-    return
+    return {
+      requestId: id,
+      patronId: patron,
+      pickupLocation,
+      status: 200,
+    }
   } catch (error) {
     console.error(
       `Error fetching hold request details in fetchHoldRequestDetails server function, requestId: ${requestId}`,
       error.message
     )
 
-    return
+    return { status: 400 }
   }
 }
 

--- a/src/types/holdPageTypes.ts
+++ b/src/types/holdPageTypes.ts
@@ -21,10 +21,26 @@ export interface EDDRequestParams extends HoldRequestParams {
   requestNotes?: string
 }
 
+export interface HoldRequestDetailsParams {
+  requestId: string
+  patronId: string
+}
+
+export interface PatronEligibilityStatus {
+  eligibility: boolean
+  expired?: boolean
+  blocked?: boolean
+  moneyOwed?: boolean
+  ptypeDisallowsHolds?: boolean
+  reachedHoldLimit?: boolean
+  hasIssues?: boolean
+}
+
 export interface HoldPostResult {
   status: HTTPStatusCode
   pickupLocation?: NYPLocationKey | "edd"
   requestId?: string
+  errorMessage?: string
 }
 
 export interface DiscoveryHoldPostParams {

--- a/src/types/holdPageTypes.ts
+++ b/src/types/holdPageTypes.ts
@@ -21,9 +21,19 @@ export interface EDDRequestParams extends HoldRequestParams {
   requestNotes?: string
 }
 
-export interface HoldRequestDetailsParams {
-  requestId: string
-  patronId: string
+export interface HoldPostResult {
+  status: HTTPStatusCode
+  pickupLocation?: NYPLocationKey | "edd"
+  formInvalid?: boolean
+  requestId?: string
+}
+
+export interface HoldDetailsResult {
+  status: HTTPStatusCode
+  pickupLocation?: NYPLocationKey | "edd"
+  patronId?: string
+  requestId?: string
+  errorMessage?: string
 }
 
 export interface PatronEligibilityStatus {
@@ -36,13 +46,6 @@ export interface PatronEligibilityStatus {
   hasIssues?: boolean
 }
 
-export interface HoldPostResult {
-  status: HTTPStatusCode
-  pickupLocation?: NYPLocationKey | "edd"
-  requestId?: string
-  errorMessage?: string
-}
-
 export interface DiscoveryHoldPostParams {
   patron: string
   record: string
@@ -52,7 +55,7 @@ export interface DiscoveryHoldPostParams {
   pickupLocation?: NYPLocationKey | "edd"
   numberOfCopies?: number
   // TODO: make this EDD form content object
-  docDeliveryData?: string
+  docDeliveryData?: EDDRequestParams
 }
 
 export type EDDPageStatus = null | "failed" | "unavailable" | "invalid"

--- a/src/types/holdPageTypes.ts
+++ b/src/types/holdPageTypes.ts
@@ -26,6 +26,7 @@ export interface HoldPostResult {
   pickupLocation?: NYPLocationKey | "edd"
   formInvalid?: boolean
   requestId?: string
+  errorMessage?: string
 }
 
 export interface HoldDetailsResult {


### PR DESCRIPTION
Draft PR for server-side Hold Confirmation functions. The getter functions are mostly done but they need to be integrated and tested.

TODO:
- Render ineligibility messages and set new status on Hold form pages
- Fetch item in confirmation page and show details