### PR TITLE
SCC-4384: My Account 2.0 VQA/a11y round 1

### DIFF
--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -95,6 +95,7 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
         sx={{
           border: "none",
           h2: { border: "none", paddingTop: 0 },
+          marginBottom: "l",
         }}
       >
         {profileData}

--- a/src/components/MyAccount/ProfileTabs.tsx
+++ b/src/components/MyAccount/ProfileTabs.tsx
@@ -6,7 +6,7 @@ import RequestsTab from "./RequestsTab/RequestsTab"
 import FeesTab from "./FeesTab/FeesTab"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { useContext } from "react"
-import NewAccountSettingsTab from "./Settings/NewAccountSettingsTab"
+import AccountSettingsTab from "./Settings/AccountSettingsTab"
 
 interface ProfileTabsPropsType {
   activePath: string
@@ -49,7 +49,7 @@ const ProfileTabs = ({ activePath }: ProfileTabsPropsType) => {
       : []),
     {
       label: "Account settings",
-      content: <NewAccountSettingsTab />,
+      content: <AccountSettingsTab />,
       urlPath: "settings",
     },
   ]

--- a/src/components/MyAccount/Settings/AccountSettingsTab.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsTab.tsx
@@ -8,7 +8,7 @@ import { StatusBanner } from "./StatusBanner"
 
 type StatusType = "" | "failure" | "success"
 
-const NewAccountSettingsTab = () => {
+const AccountSettingsTab = () => {
   const {
     updatedAccountData: { patron, pickupLocations },
   } = useContext(PatronDataContext)
@@ -41,7 +41,7 @@ const NewAccountSettingsTab = () => {
           <StatusBanner status={status} statusMessage={statusMessage} />
         </div>
       )}
-      <Flex flexDir="column" sx={{ marginTop: "xl", gap: "s" }}>
+      <Flex flexDir="column" sx={{ marginTop: "m", gap: "s" }}>
         <SettingsInputForm
           patronData={patron}
           settingsState={settingsState}
@@ -73,4 +73,4 @@ const NewAccountSettingsTab = () => {
   )
 }
 
-export default NewAccountSettingsTab
+export default AccountSettingsTab

--- a/src/components/MyAccount/Settings/AddButton.tsx
+++ b/src/components/MyAccount/Settings/AddButton.tsx
@@ -16,7 +16,7 @@ const AddButton = ({ inputType, label, onClick }: AddButtonProps) => {
       sx={{
         justifyContent: "flex-start",
         width: { base: "100%", md: "300px" },
-        paddingLeft: { base: "m", md: "unset" },
+        paddingLeft: { base: "m", md: "xs" },
         paddingTop: "xs",
         paddingBottom: "xs",
         paddingRight: "xs",

--- a/src/components/MyAccount/Settings/AddButton.tsx
+++ b/src/components/MyAccount/Settings/AddButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@nypl/design-system-react-components"
+import { forwardRef } from "react"
 
 type AddButtonProps = {
   inputType?: string
@@ -6,25 +7,30 @@ type AddButtonProps = {
   onClick: () => void
 }
 
-const AddButton = ({ inputType, label, onClick }: AddButtonProps) => {
-  return (
-    <Button
-      id={inputType ? `add-${inputType}-button` : "add-button"}
-      buttonType="text"
-      onClick={onClick}
-      size="large"
-      sx={{
-        justifyContent: "flex-start",
-        width: { base: "100%", md: "300px" },
-        paddingLeft: { base: "m", md: "xs" },
-        paddingTop: "xs",
-        paddingBottom: "xs",
-        paddingRight: "xs",
-      }}
-    >
-      {label}
-    </Button>
-  )
-}
+const AddButton = forwardRef<HTMLButtonElement, AddButtonProps>(
+  ({ inputType, label, onClick }, ref) => {
+    return (
+      <Button
+        ref={ref}
+        id={inputType ? `add-${inputType}-button` : "add-button"}
+        buttonType="text"
+        onClick={onClick}
+        size="large"
+        sx={{
+          justifyContent: "flex-start",
+          width: { base: "100%", md: "300px" },
+          paddingLeft: { base: "m", md: "xs" },
+          paddingTop: "xs",
+          paddingBottom: "xs",
+          paddingRight: "xs",
+        }}
+      >
+        {label}
+      </Button>
+    )
+  }
+)
+
+AddButton.displayName = "AddButton"
 
 export default AddButton

--- a/src/components/MyAccount/Settings/AddButton.tsx
+++ b/src/components/MyAccount/Settings/AddButton.tsx
@@ -19,7 +19,7 @@ const AddButton = forwardRef<HTMLButtonElement, AddButtonProps>(
         sx={{
           justifyContent: "flex-start",
           width: { base: "100%", md: "300px" },
-          paddingLeft: { base: "m", md: "xs" },
+          paddingLeft: "xs",
           paddingTop: "xs",
           paddingBottom: "xs",
           paddingRight: "xs",

--- a/src/components/MyAccount/Settings/EditButton.tsx
+++ b/src/components/MyAccount/Settings/EditButton.tsx
@@ -1,4 +1,5 @@
 import { Button, Icon } from "@nypl/design-system-react-components"
+import { forwardRef } from "react"
 
 type EditButtonProps = {
   buttonId: string
@@ -6,24 +7,32 @@ type EditButtonProps = {
   onClick: () => void
 }
 
-const EditButton = ({ buttonId, buttonLabel, onClick }: EditButtonProps) => {
-  return (
-    <Button
-      id={buttonId}
-      aria-label={buttonLabel}
-      buttonType="text"
-      onClick={onClick}
-      sx={{
-        paddingTop: "0",
-        paddingBottom: "0",
-        paddingLeft: "xs",
-        paddingRight: "xs",
-      }}
-    >
-      <Icon name="editorMode" align="left" size="medium" />
-      Edit
-    </Button>
-  )
-}
+const EditButton = forwardRef<HTMLButtonElement, EditButtonProps>(
+  ({ buttonLabel, buttonId, onClick }, ref) => {
+    return (
+      <Button
+        ref={ref}
+        id={buttonId}
+        aria-label={buttonLabel}
+        buttonType="text"
+        onClick={onClick}
+        sx={{
+          _focus: {
+            outline: "2px green solid",
+          },
+          paddingTop: "0",
+          paddingBottom: "0",
+          paddingLeft: "xs",
+          paddingRight: "xs",
+        }}
+      >
+        <Icon name="editorMode" align="left" size="medium" />
+        Edit
+      </Button>
+    )
+  }
+)
+
+EditButton.displayName = "EditButton"
 
 export default EditButton

--- a/src/components/MyAccount/Settings/EditButton.tsx
+++ b/src/components/MyAccount/Settings/EditButton.tsx
@@ -2,19 +2,22 @@ import { Button, Icon } from "@nypl/design-system-react-components"
 
 type EditButtonProps = {
   buttonId: string
+  buttonLabel: string
   onClick: () => void
 }
 
-const EditButton = ({ buttonId, onClick }: EditButtonProps) => {
+const EditButton = ({ buttonId, buttonLabel, onClick }: EditButtonProps) => {
   return (
     <Button
       id={buttonId}
+      aria-label={buttonLabel}
       buttonType="text"
       onClick={onClick}
       sx={{
+        paddingTop: "0",
+        paddingBottom: "0",
         paddingLeft: "xs",
         paddingRight: "xs",
-        marginLeft: "xxl",
       }}
     >
       <Icon name="editorMode" align="left" size="medium" />

--- a/src/components/MyAccount/Settings/EditButton.tsx
+++ b/src/components/MyAccount/Settings/EditButton.tsx
@@ -17,9 +17,7 @@ const EditButton = forwardRef<HTMLButtonElement, EditButtonProps>(
         buttonType="text"
         onClick={onClick}
         sx={{
-          _focus: {
-            outline: "2px green solid",
-          },
+          marginTop: { base: "unset", lg: "-xs" },
           paddingTop: "0",
           paddingBottom: "0",
           paddingLeft: "xs",

--- a/src/components/MyAccount/Settings/EmailForm.test.tsx
+++ b/src/components/MyAccount/Settings/EmailForm.test.tsx
@@ -48,7 +48,9 @@ describe("email form", () => {
     render(component)
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    expect(screen.getAllByLabelText("Update emails")[0]).toBeInTheDocument()
+    expect(
+      screen.getByLabelText("Update primary email address")
+    ).toBeInTheDocument()
     expect(
       screen.getByDisplayValue("streganonna@gmail.com")
     ).toBeInTheDocument()
@@ -65,7 +67,7 @@ describe("email form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    const input = screen.getAllByLabelText("Update emails")[0]
+    const input = screen.getByLabelText("Update primary email address")
     fireEvent.change(input, { target: { value: "invalid-email" } })
 
     expect(
@@ -84,7 +86,7 @@ describe("email form", () => {
       screen.getByRole("button", { name: /\+ add an email address/i })
     )
 
-    expect(screen.getAllByLabelText("Update emails").length).toBe(
+    expect(screen.getAllByRole("textbox").length).toBe(
       processedPatron.emails.length + 1
     )
   })
@@ -106,7 +108,7 @@ describe("email form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    const input = screen.getAllByLabelText("Update emails")[0]
+    const input = screen.getByLabelText("Update primary email address")
     fireEvent.change(input, { target: { value: "newemail@example.com" } })
 
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
@@ -128,7 +130,7 @@ describe("email form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    const input = screen.getAllByLabelText("Update emails")[0]
+    const input = screen.getByLabelText("Update primary email address")
     fireEvent.change(input, { target: { value: "modified@example.com" } })
 
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }))

--- a/src/components/MyAccount/Settings/EmailForm.test.tsx
+++ b/src/components/MyAccount/Settings/EmailForm.test.tsx
@@ -62,6 +62,31 @@ describe("email form", () => {
     expect(screen.queryByText(/edit/)).not.toBeInTheDocument()
   })
 
+  it("manages focus", async () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Update email address 2")).toHaveFocus()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /edit/i })).toHaveFocus()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    fireEvent.click(screen.getByText("+ Add an email address"))
+
+    await waitFor(() => expect(screen.getAllByRole("textbox")[2]).toHaveFocus())
+
+    fireEvent.click(screen.getAllByLabelText("Remove email")[1])
+
+    await waitFor(() => expect(screen.getAllByRole("textbox")[1]).toHaveFocus())
+  })
+
   it("validates email input correctly", () => {
     render(component)
 

--- a/src/components/MyAccount/Settings/HomeLibraryForm.test.tsx
+++ b/src/components/MyAccount/Settings/HomeLibraryForm.test.tsx
@@ -48,6 +48,19 @@ describe("home library form", () => {
     expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument()
   })
 
+  it("manages focus", async () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveFocus())
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /edit/i })).toHaveFocus()
+    )
+  })
+
   it("allows editing when edit button is clicked", () => {
     render(component)
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))

--- a/src/components/MyAccount/Settings/NotificationForm.test.tsx
+++ b/src/components/MyAccount/Settings/NotificationForm.test.tsx
@@ -77,6 +77,19 @@ describe("notification preference form", () => {
     expect(screen.queryByText(/edit/)).not.toBeInTheDocument()
   })
 
+  it("manages focus", async () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveFocus())
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /edit/i })).toHaveFocus()
+    )
+  })
+
   it("calls submit with valid data", async () => {
     render(component)
 

--- a/src/components/MyAccount/Settings/PasswordForm.test.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, fireEvent, waitFor } from "../../../utils/testUtils"
+import { render, fireEvent, waitFor, screen } from "../../../utils/testUtils"
 import PasswordForm from "./PasswordForm"
 import {
   filteredPickupLocations,
@@ -38,6 +38,21 @@ beforeEach(() => {
 })
 
 describe("Pin/password form", () => {
+  it("manages focus", async () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Enter current pin/password")).toHaveFocus()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /edit/i })).toHaveFocus()
+    )
+  })
+
   it("disables submit button if any form field is empty", async () => {
     const { getByText, getByLabelText } = render(component)
     const button = getByText("Edit")

--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -1,5 +1,6 @@
-import { useContext, useState } from "react"
+import { forwardRef, useContext, useRef, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
+import type { TextInputRefType } from "@nypl/design-system-react-components"
 import {
   Banner,
   Flex,
@@ -30,37 +31,37 @@ export const passwordFormMessages = {
   INVALID: "Invalid new pin/password.",
 }
 
-const PasswordFormField = ({
-  label,
-  handler,
-  name,
-  isInvalid,
-}: PasswordFormFieldProps) => {
-  return (
-    <Flex
-      flexDir={{ base: "column", lg: "row" }}
-      alignItems="flex-start"
-      gap={{ base: "xs", lg: "unset" }}
-    >
-      <SettingsLabel icon="actionLockClosed" text={label} />
-      <TextInput
-        marginLeft={{ sm: "m", lg: 0 }}
-        width="320px"
-        id={name}
-        name={name}
-        type="password"
-        isRequired
-        showLabel={false}
-        isClearable
-        showRequiredLabel={false}
-        labelText={label}
-        onChange={handler}
-        invalidText="Pin/passwords do not match."
-        isInvalid={isInvalid}
-      />
-    </Flex>
-  )
-}
+const PasswordFormField = forwardRef<TextInputRefType, PasswordFormFieldProps>(
+  ({ label, handler, name, isInvalid }: PasswordFormFieldProps, ref) => {
+    return (
+      <Flex
+        flexDir={{ base: "column", lg: "row" }}
+        alignItems="flex-start"
+        gap={{ base: "xs", lg: "unset" }}
+      >
+        <SettingsLabel icon="actionLockClosed" text={label} />
+        <TextInput
+          ref={ref}
+          marginLeft={{ sm: "m", lg: 0 }}
+          width="320px"
+          id={name}
+          name={name}
+          type="password"
+          isRequired
+          showLabel={false}
+          isClearable
+          showRequiredLabel={false}
+          labelText={label}
+          onChange={handler}
+          invalidText="Pin/passwords do not match."
+          isInvalid={isInvalid}
+        />
+      </Flex>
+    )
+  }
+)
+
+PasswordFormField.displayName = "PasswordFormField"
 
 const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
   const { getMostUpdatedSierraAccountData } = useContext(PatronDataContext)
@@ -74,10 +75,15 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
   })
   const { setStatus, setStatusMessage, editingField, setEditingField } =
     settingsState
+  const editingRef = useRef<HTMLButtonElement | null>()
+  const inputRef = useRef<TextInputRefType | null>()
 
   const cancelEditing = () => {
     setIsEditing(false)
     setEditingField("")
+    setTimeout(() => {
+      editingRef.current?.focus()
+    }, 0)
   }
 
   const validateForm =
@@ -162,6 +168,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
               }}
             >
               <PasswordFormField
+                ref={inputRef}
                 label="Enter current pin/password"
                 name="currentPassword"
                 handler={handleInputChange}
@@ -235,11 +242,15 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
             </Text>
             {editingField === "" && (
               <EditButton
+                ref={editingRef}
                 buttonLabel="Edit password"
                 buttonId="edit-password-button"
                 onClick={() => {
                   setIsEditing(true)
                   setEditingField("password")
+                  setTimeout(() => {
+                    inputRef.current?.focus()
+                  }, 0)
                 }}
               />
             )}

--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -41,9 +41,11 @@ const PasswordFormField = forwardRef<TextInputRefType, PasswordFormFieldProps>(
       >
         <SettingsLabel icon="actionLockClosed" text={label} />
         <TextInput
+          sx={{
+            width: { base: "100%", md: "300px" },
+          }}
           ref={ref}
-          marginLeft={{ sm: "m", lg: 0 }}
-          width="320px"
+          marginLeft={{ base: "m", lg: 0 }}
           id={name}
           name={name}
           type="password"
@@ -75,14 +77,13 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
   })
   const { setStatus, setStatusMessage, editingField, setEditingField } =
     settingsState
-  const editingRef = useRef<HTMLButtonElement | null>()
-  const inputRef = useRef<TextInputRefType | null>()
+  const focusRef = useRef<HTMLButtonElement | TextInputRefType | null>()
 
   const cancelEditing = () => {
     setIsEditing(false)
     setEditingField("")
     setTimeout(() => {
-      editingRef.current?.focus()
+      focusRef.current?.focus()
     }, 0)
   }
 
@@ -152,12 +153,19 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
   return (
     <>
       {isLoading ? (
-        <SkeletonLoader
-          sx={{ "> div": { marginTop: "-xs" } }}
-          contentSize={2}
-          showImage={false}
-          headingSize={0}
-        />
+        <Flex
+          flexDir={{ base: "column", lg: "row" }}
+          alignItems="flex-start"
+          width="100%"
+        >
+          <SettingsLabel icon="actionLockClosed" text="Pin/password" />
+          <SkeletonLoader
+            sx={{ "> div": { marginTop: "-xs" } }}
+            contentSize={2}
+            showImage={false}
+            headingSize={0}
+          />
+        </Flex>
       ) : isEditing ? (
         <>
           <Flex alignItems="flex-start" flexDir={{ base: "column", lg: "row" }}>
@@ -168,7 +176,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
               }}
             >
               <PasswordFormField
-                ref={inputRef}
+                ref={focusRef as React.Ref<TextInputRefType>}
                 label="Enter current pin/password"
                 name="currentPassword"
                 handler={handleInputChange}
@@ -242,14 +250,14 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
             </Text>
             {editingField === "" && (
               <EditButton
-                ref={editingRef}
+                ref={focusRef as React.Ref<HTMLButtonElement>}
                 buttonLabel="Edit password"
                 buttonId="edit-password-button"
                 onClick={() => {
                   setIsEditing(true)
                   setEditingField("password")
                   setTimeout(() => {
-                    inputRef.current?.focus()
+                    focusRef.current?.focus()
                   }, 0)
                 }}
               />

--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -146,13 +146,17 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
   return (
     <>
       {isLoading ? (
-        <SkeletonLoader contentSize={2} showImage={false} headingSize={0} />
+        <SkeletonLoader
+          sx={{ "> div": { marginTop: "-xs" } }}
+          contentSize={2}
+          showImage={false}
+          headingSize={0}
+        />
       ) : isEditing ? (
         <>
-          <Flex flexDir={{ base: "column", lg: "row" }}>
+          <Flex alignItems="flex-start" flexDir={{ base: "column", lg: "row" }}>
             <Flex
               sx={{
-                marginTop: "xs",
                 flexDir: "column",
                 gap: "s",
               }}
@@ -221,9 +225,9 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
           <Flex>
             <Text
               sx={{
-                width: { base: "l", sm: "250px" },
+                width: { base: "200px", sm: "250px" },
                 marginTop: "xs",
-                marginLeft: { base: "l", lg: "unset" },
+                marginLeft: { base: "m", lg: "unset" },
                 marginBottom: 0,
               }}
             >
@@ -231,6 +235,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
             </Text>
             {editingField === "" && (
               <EditButton
+                buttonLabel="Edit password"
                 buttonId="edit-password-button"
                 onClick={() => {
                   setIsEditing(true)

--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -160,7 +160,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
         >
           <SettingsLabel icon="actionLockClosed" text="Pin/password" />
           <SkeletonLoader
-            sx={{ "> div": { marginTop: "-xs" } }}
+            sx={{ "> div": { marginTop: "-s" } }}
             contentSize={2}
             showImage={false}
             headingSize={0}

--- a/src/components/MyAccount/Settings/PhoneForm.test.tsx
+++ b/src/components/MyAccount/Settings/PhoneForm.test.tsx
@@ -64,6 +64,31 @@ describe("phone form", () => {
     expect(screen.queryByText(/edit/)).not.toBeInTheDocument()
   })
 
+  it("manages focus", async () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Update primary phone number")).toHaveFocus()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /edit/i })).toHaveFocus()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    fireEvent.click(screen.getByText("+ Add a phone number"))
+
+    await waitFor(() => expect(screen.getAllByRole("textbox")[1]).toHaveFocus())
+
+    fireEvent.click(screen.getByLabelText("Remove phone"))
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
+  })
+
   it("validates phone input correctly", () => {
     render(component)
 

--- a/src/components/MyAccount/Settings/PhoneForm.test.tsx
+++ b/src/components/MyAccount/Settings/PhoneForm.test.tsx
@@ -50,7 +50,9 @@ describe("phone form", () => {
     render(component)
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    expect(screen.getAllByLabelText("Update phones")[0]).toBeInTheDocument()
+    expect(
+      screen.getByLabelText("Update primary phone number")
+    ).toBeInTheDocument()
     expect(
       screen.getByDisplayValue(processedPatron.phones[0].number)
     ).toBeInTheDocument()
@@ -67,7 +69,7 @@ describe("phone form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    const input = screen.getAllByLabelText("Update phones")[0]
+    const input = screen.getByLabelText("Update primary phone number")
     fireEvent.change(input, { target: { value: "invalid-phone" } })
 
     expect(
@@ -86,7 +88,7 @@ describe("phone form", () => {
       screen.getByRole("button", { name: /\+ add a phone number/i })
     )
 
-    expect(screen.getAllByLabelText("Update phones").length).toBe(
+    expect(screen.getAllByRole("textbox").length).toBe(
       processedPatron.phones.length + 1
     )
   })
@@ -100,7 +102,7 @@ describe("phone form", () => {
       screen.getByRole("button", { name: /\+ add a phone number/i })
     )
 
-    const input = screen.getAllByLabelText("Update phones")[1]
+    const input = screen.getByLabelText("Update phone number 2")
 
     fireEvent.change(input, { target: { value: "5106974153" } })
 
@@ -109,8 +111,7 @@ describe("phone form", () => {
     )
 
     fireEvent.click(screen.getByLabelText("Remove phone"))
-
-    expect(screen.getAllByLabelText("Update phones").length).toBe(
+    expect(screen.getAllByRole("textbox").length).toBe(
       processedPatron.phones.length
     )
   })
@@ -120,7 +121,7 @@ describe("phone form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    const input = screen.getAllByLabelText("Update phones")[0]
+    const input = screen.getByLabelText("Update primary phone number")
     fireEvent.change(input, { target: { value: "1234" } })
 
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
@@ -142,7 +143,7 @@ describe("phone form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    const input = screen.getAllByLabelText("Update phones")[0]
+    const input = screen.getByLabelText("Update primary phone number")
     fireEvent.change(input, { target: { value: "4534" } })
 
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }))

--- a/src/components/MyAccount/Settings/SaveCancelButtons.tsx
+++ b/src/components/MyAccount/Settings/SaveCancelButtons.tsx
@@ -4,7 +4,7 @@ type SaveCancelButtonProps = {
   isDisabled?: boolean
   onCancel: () => void
   onSave: () => void
-  inputType?: "phones" | "emails"
+  inputType?: string
 }
 
 const SaveCancelButtons = ({

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -189,7 +189,7 @@ const SettingsInputForm = ({
         <SettingsLabel icon={formUtils.icon} text={formUtils.inputLabel} />
         {isLoading ? (
           <SkeletonLoader
-            sx={{ "> div": { marginTop: "-xs" } }}
+            sx={{ "> div": { marginTop: "-s" } }}
             contentSize={2}
             showImage={false}
             headingSize={0}
@@ -240,7 +240,7 @@ const SettingsInputForm = ({
                 </Flex>
               </Form>
             ))}
-            <Flex flexDir="row">
+            <Flex flexDir="row" width="fill">
               <AddButton
                 inputType={inputType}
                 label={formUtils.addButtonLabel}

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -44,6 +44,7 @@ const SettingsInputForm = ({
   const [tempInputs, setTempInputs] = useState([...inputs])
 
   const inputRefs = useRef<Array<TextInputRefType | null>>([])
+  const editingRef = useRef<HTMLButtonElement | null>()
 
   const focusLastInput = () => {
     const lastIndex = tempInputs.length - 1
@@ -59,6 +60,9 @@ const SettingsInputForm = ({
   const formUtils = {
     regex: isEmail ? /^[^@]+@[^@]+\.[^@]+$/ : /^\+?[1-9]\d{1,14}$/,
     labelText: isEmail ? "Update email address" : "Update phone number",
+    primaryLabelText: isEmail
+      ? "Update primary email address"
+      : "Update primary phone number",
     addButtonLabel: isEmail ? "+ Add an email address" : "+ Add a phone number",
     errorMessage: `Please enter a valid and unique ${
       isEmail ? "email address" : "phone number"
@@ -126,6 +130,9 @@ const SettingsInputForm = ({
     setIsEditing(false)
     setEditingField("")
     setError(false)
+    setTimeout(() => {
+      editingRef.current?.focus()
+    }, 0)
   }
 
   const submitInputs = async () => {
@@ -207,7 +214,7 @@ const SettingsInputForm = ({
                     id={`${inputType}-text-input-${index}`}
                     labelText={
                       index == 0
-                        ? `Update primary ${inputType}`
+                        ? formUtils.primaryLabelText
                         : `${formUtils.labelText} ${index}`
                     }
                     showLabel={false}
@@ -277,6 +284,7 @@ const SettingsInputForm = ({
             </Flex>
             {editingField === "" && tempInputs.length > 0 && (
               <EditButton
+                ref={editingRef}
                 buttonLabel={`Edit ${inputType}`}
                 buttonId={`edit-${inputType}-button`}
                 onClick={() => {

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -215,7 +215,7 @@ const SettingsInputForm = ({
                     labelText={
                       index == 0
                         ? formUtils.primaryLabelText
-                        : `${formUtils.labelText} ${index}`
+                        : `${formUtils.labelText} ${index + 1}`
                     }
                     showLabel={false}
                     isInvalid={error && !validateInput(input, tempInputs)}

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -55,7 +55,7 @@ const SettingsInputForm = ({
 
   useEffect(() => {
     focusLastInput()
-  }, [tempInputs])
+  }, [tempInputs.length])
 
   const formUtils = {
     regex: isEmail ? /^[^@]+@[^@]+\.[^@]+$/ : /^\+?[1-9]\d{1,14}$/,
@@ -99,6 +99,9 @@ const SettingsInputForm = ({
   const handleRemove = (index) => {
     const updatedInputs = tempInputs.filter((_, i) => i !== index)
     setTempInputs(updatedInputs)
+
+    // Remove its corresponding ref.
+    inputRefs.current = inputRefs.current.filter((_, i) => i !== index)
 
     // Immediately revalidate remaining inputs.
     const hasInvalidInput = updatedInputs.some(

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -166,12 +166,16 @@ const SettingsInputForm = ({
         width="100%"
       >
         <SettingsLabel icon={formUtils.icon} text={formUtils.inputLabel} />
-
         {isLoading ? (
-          <SkeletonLoader contentSize={2} showImage={false} headingSize={0} />
+          <SkeletonLoader
+            sx={{ "> div": { marginTop: "-xs" } }}
+            contentSize={2}
+            showImage={false}
+            headingSize={0}
+          />
         ) : isEditing ? (
           <Flex
-            marginLeft={{ base: "l", lg: "unset" }}
+            marginLeft={{ base: "m", lg: "unset" }}
             marginTop={{ base: "xs", lg: "unset" }}
             flexDir="column"
             width="-webkit-fill-available"
@@ -195,6 +199,7 @@ const SettingsInputForm = ({
                     isClearable
                     isClearableCallback={() => handleClearableCallback(index)}
                   />
+                  {index == 0 && <div style={{ width: "57px" }}> </div>}
                   {index !== 0 && (
                     <Button
                       aria-label={`Remove ${formUtils.inputLabel.toLowerCase()}`}
@@ -209,15 +214,18 @@ const SettingsInputForm = ({
                 </Flex>
               </Form>
             ))}
-            <AddButton
-              inputType={inputType}
-              label={formUtils.addButtonLabel}
-              onClick={handleAdd}
-            />
+            <Flex flexDir="row">
+              <AddButton
+                inputType={inputType}
+                label={formUtils.addButtonLabel}
+                onClick={handleAdd}
+              />
+              <div style={{ width: "72px" }}> </div>
+            </Flex>
           </Flex>
         ) : isEmail || tempInputs.length !== 0 ? (
           <Flex
-            marginLeft={{ base: "l", lg: "unset" }}
+            marginLeft={{ base: "m", lg: "unset" }}
             flexDir="row"
             alignItems="flex-start"
           >
@@ -226,9 +234,9 @@ const SettingsInputForm = ({
                 <Text
                   key={index}
                   sx={{
-                    width: { base: "l", sm: "250px" },
-                    paddingTop: "xs",
+                    width: { base: "200px", sm: "250px" },
                     marginBottom: "xs",
+                    marginTop: { base: "xs", lg: "unset" },
                   }}
                 >
                   {input}{" "}
@@ -250,6 +258,7 @@ const SettingsInputForm = ({
             </Flex>
             {editingField === "" && tempInputs.length > 0 && (
               <EditButton
+                buttonLabel={`Edit ${inputType}`}
                 buttonId={`edit-${inputType}-button`}
                 onClick={() => {
                   setIsEditing(true)

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -58,7 +58,7 @@ const SettingsInputForm = ({
 
   const formUtils = {
     regex: isEmail ? /^[^@]+@[^@]+\.[^@]+$/ : /^\+?[1-9]\d{1,14}$/,
-    labelText: `Update ${inputType}`,
+    labelText: isEmail ? "Update email address" : "Update phone number",
     addButtonLabel: isEmail ? "+ Add an email address" : "+ Add a phone number",
     errorMessage: `Please enter a valid and unique ${
       isEmail ? "email address" : "phone number"
@@ -200,17 +200,16 @@ const SettingsInputForm = ({
                   <TextInput
                     sx={{
                       width: { base: "87%", md: "300px" },
-                      " > div > input": {
-                        _focus: {
-                          outline: "2px green solid !important",
-                        },
-                      },
                     }}
                     ref={(el) => (inputRefs.current[index] = el)}
                     name={`input-${index}`}
                     value={input}
                     id={`${inputType}-text-input-${index}`}
-                    labelText={formUtils.labelText}
+                    labelText={
+                      index == 0
+                        ? `Update primary ${inputType}`
+                        : `${formUtils.labelText} ${index}`
+                    }
                     showLabel={false}
                     isInvalid={error && !validateInput(input, tempInputs)}
                     invalidText={formUtils.errorMessage}

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -8,7 +8,8 @@ import {
   Form,
   Box,
 } from "@nypl/design-system-react-components"
-import { useContext, useState } from "react"
+import type { TextInputRefType } from "@nypl/design-system-react-components"
+import { useContext, useEffect, useRef, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import SaveCancelButtons from "./SaveCancelButtons"
 import SettingsLabel from "./SettingsLabel"
@@ -41,6 +42,19 @@ const SettingsInputForm = ({
   const { setStatus, editingField, setEditingField } = settingsState
 
   const [tempInputs, setTempInputs] = useState([...inputs])
+
+  const inputRefs = useRef<Array<TextInputRefType | null>>([])
+
+  const focusLastInput = () => {
+    const lastIndex = tempInputs.length - 1
+    if (inputRefs.current[lastIndex]) {
+      inputRefs.current[lastIndex]?.focus()
+    }
+  }
+
+  useEffect(() => {
+    focusLastInput()
+  }, [tempInputs])
 
   const formUtils = {
     regex: isEmail ? /^[^@]+@[^@]+\.[^@]+$/ : /^\+?[1-9]\d{1,14}$/,
@@ -186,7 +200,13 @@ const SettingsInputForm = ({
                   <TextInput
                     sx={{
                       width: { base: "87%", md: "300px" },
+                      " > div > input": {
+                        _focus: {
+                          outline: "2px green solid !important",
+                        },
+                      },
                     }}
+                    ref={(el) => (inputRefs.current[index] = el)}
                     name={`input-${index}`}
                     value={input}
                     id={`${inputType}-text-input-${index}`}
@@ -263,6 +283,7 @@ const SettingsInputForm = ({
                 onClick={() => {
                   setIsEditing(true)
                   setEditingField(inputType)
+                  setTimeout(() => focusLastInput(), 0)
                 }}
               />
             )}

--- a/src/components/MyAccount/Settings/SettingsLabel.tsx
+++ b/src/components/MyAccount/Settings/SettingsLabel.tsx
@@ -4,15 +4,15 @@ const SettingsLabel = ({ icon, text }) => {
   return (
     <Flex
       gap="xs"
-      minHeight="48px"
       alignItems="flex-start"
       sx={{
-        minWidth: { base: "unset", lg: "256px" },
+        height: { base: "unset", lg: "48px" },
+        minWidth: { base: "unset", lg: "242px" },
         marginRight: "xs",
-        paddingTop: "xs",
+        marginTop: { base: "xs", lg: "unset" },
       }}
     >
-      <Icon marginTop="xxs" name={icon} size="medium" />
+      <Icon marginTop="xxs" name={icon} size="medium" paddingTop="0" />
       <Text
         size="body1"
         sx={{

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -144,15 +144,19 @@ const SettingsSelectForm = ({
       >
         <SettingsLabel icon={formUtils.icon} text={formUtils.label} />
         {isLoading ? (
-          <SkeletonLoader contentSize={2} showImage={false} headingSize={0} />
+          <SkeletonLoader
+            sx={{ "> div": { marginTop: "-xs" } }}
+            contentSize={2}
+            showImage={false}
+            headingSize={0}
+          />
         ) : isEditing ? (
           <Flex
-            sx={{
-              marginTop: "xs",
-              marginLeft: { base: "l", lg: "unset" },
-              paddingRight: { base: "l", md: "unset" },
-              width: "100%",
-            }}
+            marginLeft={{ base: "m", lg: "unset" }}
+            marginTop={{ base: "s", md: "unset" }}
+            flexDir="column"
+            alignItems="flex-start"
+            width="-webkit-fill-available"
           >
             <Select
               width={{ base: "100%", md: "max-content" }}
@@ -171,12 +175,11 @@ const SettingsSelectForm = ({
             </Select>
           </Flex>
         ) : (
-          <Flex>
+          <Flex marginLeft={{ base: "m", lg: "unset" }}>
             <Text
               sx={{
-                width: { base: "l", sm: "250px" },
-                marginTop: "xs",
-                marginLeft: { base: "l", lg: "unset" },
+                marginTop: { base: "xs", lg: "unset" },
+                width: { base: "200px", sm: "250px" },
                 marginBottom: 0,
               }}
             >
@@ -184,6 +187,7 @@ const SettingsSelectForm = ({
             </Text>
             {editingField === "" && (
               <EditButton
+                buttonLabel={`Edit ${type}`}
                 buttonId={`edit-${type}-button`}
                 onClick={() => {
                   setIsEditing(true)

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -30,8 +30,7 @@ const SettingsSelectForm = ({
   const [error, setError] = useState(false)
 
   const { setStatus, editingField, setEditingField } = settingsState
-  const editingRef = useRef<HTMLButtonElement | null>()
-  const inputRef = useRef<HTMLSelectElement | null>()
+  const focusRef = useRef<HTMLSelectElement | HTMLButtonElement | null>()
 
   const notificationPreferenceMap =
     patronData.notificationPreference === "-"
@@ -92,7 +91,7 @@ const SettingsSelectForm = ({
     setIsEditing(false)
     setEditingField("")
     setTimeout(() => {
-      editingRef.current?.focus()
+      focusRef.current?.focus()
     }, 0)
   }
 
@@ -150,7 +149,7 @@ const SettingsSelectForm = ({
         <SettingsLabel icon={formUtils.icon} text={formUtils.label} />
         {isLoading ? (
           <SkeletonLoader
-            sx={{ "> div": { marginTop: "-xs" } }}
+            sx={{ "> div": { marginTop: "-s" } }}
             contentSize={2}
             showImage={false}
             headingSize={0}
@@ -164,7 +163,7 @@ const SettingsSelectForm = ({
             width="-webkit-fill-available"
           >
             <Select
-              ref={inputRef}
+              ref={focusRef as React.Ref<HTMLSelectElement>}
               width={{ base: "100%", md: "max-content" }}
               name={`select-${type}`}
               id={formUtils.selectorId}
@@ -193,14 +192,14 @@ const SettingsSelectForm = ({
             </Text>
             {editingField === "" && (
               <EditButton
-                ref={editingRef}
+                ref={focusRef as React.Ref<HTMLButtonElement>}
                 buttonLabel={`Edit ${type}`}
                 buttonId={`edit-${type}-button`}
                 onClick={() => {
                   setIsEditing(true)
                   setEditingField(type)
                   setTimeout(() => {
-                    inputRef.current?.focus()
+                    focusRef.current?.focus()
                   }, 0)
                 }}
               />

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react"
+import { useContext, useRef, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import {
   Flex,
@@ -30,6 +30,8 @@ const SettingsSelectForm = ({
   const [error, setError] = useState(false)
 
   const { setStatus, editingField, setEditingField } = settingsState
+  const editingRef = useRef<HTMLButtonElement | null>()
+  const inputRef = useRef<HTMLSelectElement | null>()
 
   const notificationPreferenceMap =
     patronData.notificationPreference === "-"
@@ -89,6 +91,9 @@ const SettingsSelectForm = ({
   const cancelEditing = () => {
     setIsEditing(false)
     setEditingField("")
+    setTimeout(() => {
+      editingRef.current?.focus()
+    }, 0)
   }
 
   const submitSelection = async () => {
@@ -159,6 +164,7 @@ const SettingsSelectForm = ({
             width="-webkit-fill-available"
           >
             <Select
+              ref={inputRef}
               width={{ base: "100%", md: "max-content" }}
               name={`select-${type}`}
               id={formUtils.selectorId}
@@ -187,11 +193,15 @@ const SettingsSelectForm = ({
             </Text>
             {editingField === "" && (
               <EditButton
+                ref={editingRef}
                 buttonLabel={`Edit ${type}`}
                 buttonId={`edit-${type}-button`}
                 onClick={() => {
                   setIsEditing(true)
                   setEditingField(type)
+                  setTimeout(() => {
+                    inputRef.current?.focus()
+                  }, 0)
                 }}
               />
             )}

--- a/src/components/MyAccount/Settings/StatusBanner.tsx
+++ b/src/components/MyAccount/Settings/StatusBanner.tsx
@@ -7,21 +7,15 @@ type StatusBannerProps = {
   statusMessage: string
 }
 
-const successContent = (
-  <Text marginBottom={0} color="ui.black !important">
-    Your changes were saved.
-  </Text>
-)
+const successContent = <Text marginBottom={0}>Your changes were saved.</Text>
 
 const generalFailureContent = (
-  <Text marginBottom={0} color="ui.black !important">
-    Your changes were not saved.
-  </Text>
+  <Text marginBottom={0}>Your changes were not saved.</Text>
 )
 
 const specificFailureContent = (statusMessage: string) => {
   return (
-    <Text marginBottom={0} color={"ui.black !important"}>
+    <Text marginBottom={0}>
       {statusMessage} Please try again or{" "}
       <Link href="https://www.nypl.org/get-help/contact-us">contact us</Link>{" "}
       for assistance.

--- a/src/components/MyAccount/Settings/UsernameForm.test.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.test.tsx
@@ -64,6 +64,27 @@ describe("username form", () => {
     expect(screen.queryByRole("button", { name: /edit/i })).toBeNull()
   })
 
+  it("manages focus", async () => {
+    render(component)
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    await waitFor(() => expect(screen.getByLabelText("Username")).toHaveFocus())
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /edit/i })).toHaveFocus()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    fireEvent.click(screen.getByLabelText("Delete username from your account"))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /add /i })).toHaveFocus()
+    )
+  })
+
   it("allows editing when edit button is clicked", () => {
     render(component)
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))

--- a/src/components/MyAccount/Settings/UsernameForm.test.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.test.tsx
@@ -120,7 +120,7 @@ describe("username form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    fireEvent.click(screen.getByLabelText("Remove username"))
+    fireEvent.click(screen.getByLabelText("Delete username from your account"))
 
     expect(
       screen.queryByDisplayValue(processedPatron.username)

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -151,10 +151,14 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
     <Flex alignItems="center" marginTop={{ base: "unset", md: "-xs" }}>
       {usernameInSierra ? (
         <>
-          <Text size="body1" sx={{ marginBottom: 0 }}>
+          <Text
+            size="body1"
+            sx={{ marginBottom: 0, width: { base: "l", sm: "250px" } }}
+          >
             {usernameInSierra}
           </Text>
           <EditButton
+            buttonLabel="Edit username"
             buttonId="edit-username-button"
             onClick={() => setIsEditing(true)}
           />
@@ -199,7 +203,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
         contentSize={2}
         showImage={false}
         headingSize={0}
-        sx={{ marginTop: "-s" }}
+        sx={{ marginTop: "-xs" }}
       />
     )
   } else if (isEditing) {

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -246,6 +246,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
       {content}
       {isEditing && (
         <SaveCancelButtons
+          inputType="username"
           onCancel={cancelEditing}
           onSave={submitInput}
           isDisabled={error}

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -7,7 +7,8 @@ import {
   SkeletonLoader,
   Banner,
 } from "@nypl/design-system-react-components"
-import { useContext, useState } from "react"
+import type { TextInputRefType } from "@nypl/design-system-react-components"
+import { useContext, useRef, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import SaveCancelButtons from "./SaveCancelButtons"
 import type { Patron } from "../../../types/myAccountTypes"
@@ -45,6 +46,9 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
   const currentUsernameNotDeleted = tempUsername !== null
 
   const { setUsernameStatus, setUsernameStatusMessage } = usernameState
+  const inputRef = useRef<TextInputRefType | null>()
+  const editingRef = useRef<HTMLButtonElement | null>()
+  const addButtonRef = useRef<HTMLButtonElement | null>()
 
   const validateUsername = (username: string) => {
     const usernameRegex = /^[a-zA-Z0-9]{5,15}$/
@@ -55,6 +59,9 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
     setTempUsername(usernameInSierra)
     setIsEditing(false)
     setError(false)
+    setTimeout(() => {
+      editingRef.current?.focus()
+    }, 0)
   }
 
   const handleInputChange = (e) => {
@@ -114,6 +121,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
           sx={{
             width: { base: "87%", md: "300px" },
           }}
+          ref={inputRef}
           value={tempUsername}
           id="username-input"
           labelText="Username"
@@ -133,6 +141,9 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
           onClick={() => {
             setTempUsername(null)
             setError(false)
+            setTimeout(() => {
+              addButtonRef.current?.focus()
+            }, 0)
           }}
         >
           {" "}
@@ -158,9 +169,15 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
             {usernameInSierra}
           </Text>
           <EditButton
+            ref={editingRef}
             buttonLabel="Edit username"
             buttonId="edit-username-button"
-            onClick={() => setIsEditing(true)}
+            onClick={() => {
+              setIsEditing(true)
+              setTimeout(() => {
+                inputRef.current?.focus()
+              }, 0)
+            }}
           />
         </>
       ) : (
@@ -170,6 +187,9 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
             setIsEditing(true)
             setTempUsername("")
             setError(true)
+            setTimeout(() => {
+              inputRef.current?.focus()
+            }, 0)
           }}
         />
       )}
@@ -186,10 +206,14 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
         editUsernameField
       ) : (
         <AddButton
+          ref={addButtonRef}
           label="+ Add username"
           onClick={() => {
             setTempUsername("")
             setError(true)
+            setTimeout(() => {
+              inputRef.current?.focus()
+            }, 0)
           }}
         />
       )}

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -135,9 +135,10 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
           isClearableCallback={() => setError(true)}
         />
         <Button
-          aria-label="Remove username"
+          aria-label="Delete username from your account"
+          aria-describedby="delete-warning-message"
           buttonType="text"
-          id="remove-username-btn"
+          id="delete-username-btn"
           onClick={() => {
             setTempUsername(null)
             setError(false)
@@ -151,6 +152,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
         </Button>
       </Flex>
       <Banner
+        id="delete-warning-message"
         sx={{ marginTop: "xs", width: "fill" }}
         content="If you delete your username, you will have to use your barcode to log in to your account in the future."
         type="warning"

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -182,6 +182,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
         </>
       ) : (
         <AddButton
+          ref={focusRef as React.Ref<HTMLButtonElement>}
           label="+ Add username"
           onClick={() => {
             setIsEditing(true)

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -46,9 +46,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
   const currentUsernameNotDeleted = tempUsername !== null
 
   const { setUsernameStatus, setUsernameStatusMessage } = usernameState
-  const inputRef = useRef<TextInputRefType | null>()
-  const editingRef = useRef<HTMLButtonElement | null>()
-  const addButtonRef = useRef<HTMLButtonElement | null>()
+  const focusRef = useRef<HTMLButtonElement | TextInputRefType | null>()
 
   const validateUsername = (username: string) => {
     const usernameRegex = /^[a-zA-Z0-9]{5,15}$/
@@ -60,7 +58,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
     setIsEditing(false)
     setError(false)
     setTimeout(() => {
-      editingRef.current?.focus()
+      focusRef.current?.focus()
     }, 0)
   }
 
@@ -121,7 +119,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
           sx={{
             width: { base: "87%", md: "300px" },
           }}
-          ref={inputRef}
+          ref={focusRef as React.Ref<TextInputRefType>}
           value={tempUsername}
           id="username-input"
           labelText="Username"
@@ -143,7 +141,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
             setTempUsername(null)
             setError(false)
             setTimeout(() => {
-              addButtonRef.current?.focus()
+              focusRef.current?.focus()
             }, 0)
           }}
         >
@@ -171,13 +169,13 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
             {usernameInSierra}
           </Text>
           <EditButton
-            ref={editingRef}
+            ref={focusRef as React.Ref<HTMLButtonElement>}
             buttonLabel="Edit username"
             buttonId="edit-username-button"
             onClick={() => {
               setIsEditing(true)
               setTimeout(() => {
-                inputRef.current?.focus()
+                focusRef.current?.focus()
               }, 0)
             }}
           />
@@ -190,7 +188,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
             setTempUsername("")
             setError(true)
             setTimeout(() => {
-              inputRef.current?.focus()
+              focusRef.current?.focus()
             }, 0)
           }}
         />
@@ -208,13 +206,13 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
         editUsernameField
       ) : (
         <AddButton
-          ref={addButtonRef}
+          ref={focusRef as React.Ref<HTMLButtonElement>}
           label="+ Add username"
           onClick={() => {
             setTempUsername("")
             setError(true)
             setTimeout(() => {
-              inputRef.current?.focus()
+              focusRef.current?.focus()
             }, 0)
           }}
         />
@@ -229,7 +227,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
         contentSize={2}
         showImage={false}
         headingSize={0}
-        sx={{ marginTop: "-xs" }}
+        sx={{ marginTop: "-s" }}
       />
     )
   } else if (isEditing) {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4384](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4384)

## This PR does the following:

- Addresses comments in [My Account 2.0](https://docs.google.com/document/d/1Rwi0eSEVBEfAMK1ypQ0NkGNd3FtI0ngRAaD-ONPIEvo/edit?tab=t.0) VQA and accessibility review
    - Mainly spacing (VQA) and focus behavior (a11y)

### Question/request for help: 
On mobile when you click edit for Home library/ Notification preference/Password, the fields jump up slightly like they're losing padding/margin or height is just not the same between the two states. I would love a fresh pair of eyes on this since I'm having trouble tracking down why this is happening

## How has this been tested?


## Accessibility concerns or updates

- Adds focus management to all form fields

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4364]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCC-4384]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ