### PR TITLE
SCC-4389: My Account 2.0 QA round 1 and VQA/a11y round 2

### DIFF
--- a/src/components/MyAccount/Settings/AddButton.tsx
+++ b/src/components/MyAccount/Settings/AddButton.tsx
@@ -4,11 +4,12 @@ import { forwardRef } from "react"
 type AddButtonProps = {
   inputType?: string
   label: string
+  isDisabled?: boolean
   onClick: () => void
 }
 
 const AddButton = forwardRef<HTMLButtonElement, AddButtonProps>(
-  ({ inputType, label, onClick }, ref) => {
+  ({ inputType, label, isDisabled, onClick }, ref) => {
     return (
       <Button
         ref={ref}
@@ -16,6 +17,7 @@ const AddButton = forwardRef<HTMLButtonElement, AddButtonProps>(
         buttonType="text"
         onClick={onClick}
         size="large"
+        isDisabled={isDisabled}
         sx={{
           justifyContent: "flex-start",
           width: { base: "100%", md: "300px" },

--- a/src/components/MyAccount/Settings/EditButton.tsx
+++ b/src/components/MyAccount/Settings/EditButton.tsx
@@ -5,13 +5,15 @@ type EditButtonProps = {
   buttonId: string
   buttonLabel: string
   onClick: () => void
+  isDisabled?: boolean
 }
 
 const EditButton = forwardRef<HTMLButtonElement, EditButtonProps>(
-  ({ buttonLabel, buttonId, onClick }, ref) => {
+  ({ buttonLabel, buttonId, isDisabled, onClick }, ref) => {
     return (
       <Button
         ref={ref}
+        isDisabled={isDisabled}
         id={buttonId}
         aria-label={buttonLabel}
         buttonType="text"

--- a/src/components/MyAccount/Settings/EmailForm.test.tsx
+++ b/src/components/MyAccount/Settings/EmailForm.test.tsx
@@ -67,7 +67,9 @@ describe("email form", () => {
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
     await waitFor(() =>
-      expect(screen.getByLabelText("Update email address 2")).toHaveFocus()
+      expect(
+        screen.getByLabelText("Update primary email address")
+      ).toHaveFocus()
     )
 
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }))
@@ -82,7 +84,7 @@ describe("email form", () => {
 
     await waitFor(() => expect(screen.getAllByRole("textbox")[2]).toHaveFocus())
 
-    fireEvent.click(screen.getAllByLabelText("Remove email")[1])
+    fireEvent.click(screen.getByLabelText("Remove email 2"))
 
     await waitFor(() => expect(screen.getAllByRole("textbox")[1]).toHaveFocus())
   })
@@ -121,7 +123,7 @@ describe("email form", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /edit/i }))
 
-    fireEvent.click(screen.getByLabelText("Remove email"))
+    fireEvent.click(screen.getByLabelText("Remove email 2"))
 
     expect(
       screen.queryByDisplayValue("spaghettigrandma@gmail.com")

--- a/src/components/MyAccount/Settings/PhoneForm.test.tsx
+++ b/src/components/MyAccount/Settings/PhoneForm.test.tsx
@@ -84,7 +84,7 @@ describe("phone form", () => {
 
     await waitFor(() => expect(screen.getAllByRole("textbox")[1]).toHaveFocus())
 
-    fireEvent.click(screen.getByLabelText("Remove phone"))
+    fireEvent.click(screen.getByLabelText("Remove phone 2"))
 
     await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
   })
@@ -135,7 +135,7 @@ describe("phone form", () => {
       processedPatron.phones.length + 1
     )
 
-    fireEvent.click(screen.getByLabelText("Remove phone"))
+    fireEvent.click(screen.getByLabelText("Remove phone 2"))
     expect(screen.getAllByRole("textbox").length).toBe(
       processedPatron.phones.length
     )

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -251,7 +251,7 @@ const SettingsInputForm = ({
               <div style={{ width: "72px" }}> </div>
             </Flex>
           </Flex>
-        ) : isEmail || tempInputs.length !== 0 ? (
+        ) : tempInputs.length !== 0 ? (
           <Flex
             marginLeft={{ base: "m", lg: "unset" }}
             flexDir="row"
@@ -292,7 +292,6 @@ const SettingsInputForm = ({
                 onClick={() => {
                   setIsEditing(true)
                   setEditingField(inputType)
-                  console.log("hello")
                   setTimeout(() => focusFirstInput(), 0)
                 }}
               />
@@ -300,15 +299,17 @@ const SettingsInputForm = ({
           </Flex>
         ) : (
           // User has no phone or email.
-          <AddButton
-            inputType={inputType}
-            onClick={() => {
-              setIsEditing(true)
-              setEditingField(inputType)
-              handleAdd()
-            }}
-            label={formUtils.addButtonLabel}
-          />
+          <Box sx={{ marginTop: { base: "unset", lg: "-xs" } }}>
+            <AddButton
+              inputType={inputType}
+              onClick={() => {
+                setIsEditing(true)
+                setEditingField(inputType)
+                handleAdd()
+              }}
+              label={formUtils.addButtonLabel}
+            />
+          </Box>
         )}
 
         {isEditing && (

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -53,6 +53,12 @@ const SettingsInputForm = ({
     }
   }
 
+  const focusFirstInput = () => {
+    if (inputRefs.current[0]) {
+      inputRefs?.current[0]?.focus()
+    }
+  }
+
   useEffect(() => {
     focusLastInput()
   }, [tempInputs.length])
@@ -286,7 +292,8 @@ const SettingsInputForm = ({
                 onClick={() => {
                   setIsEditing(true)
                   setEditingField(inputType)
-                  setTimeout(() => focusLastInput(), 0)
+                  console.log("hello")
+                  setTimeout(() => focusFirstInput(), 0)
                 }}
               />
             )}

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -301,6 +301,7 @@ const SettingsInputForm = ({
           // User has no phone or email.
           <Box sx={{ marginTop: { base: "unset", lg: "-xs" } }}>
             <AddButton
+              isDisabled={editingField !== ""}
               inputType={inputType}
               onClick={() => {
                 setIsEditing(true)

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -222,7 +222,9 @@ const SettingsInputForm = ({
                   {index == 0 && <div style={{ width: "57px" }}> </div>}
                   {index !== 0 && (
                     <Button
-                      aria-label={`Remove ${formUtils.inputLabel.toLowerCase()}`}
+                      aria-label={`Remove ${formUtils.inputLabel.toLowerCase()} ${
+                        index + 1
+                      }`}
                       buttonType="text"
                       id="remove-input-btn"
                       onClick={() => handleRemove(index)}

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -1,6 +1,7 @@
 import { useContext, useRef, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import {
+  Banner,
   Flex,
   Select,
   SkeletonLoader,
@@ -33,17 +34,20 @@ const SettingsSelectForm = ({
   const selectRef = useRef<HTMLSelectElement | null>()
   const editingRef = useRef<HTMLButtonElement | null>()
 
-  const notificationPreferenceMap =
-    patronData.notificationPreference === "-"
-      ? [
-          { code: "z", name: "Email" },
-          { code: "p", name: "Phone" },
-          { code: "-", name: "None" },
-        ]
-      : [
-          { code: "z", name: "Email" },
-          { code: "p", name: "Phone" },
-        ]
+  const patronHasNonePref = patronData.notificationPreference === "-"
+  const patronHasPhone = patronData.phones.length > 0
+  const patronHasEmail = patronData.emails.length > 0
+
+  const notificationPreferenceMap = patronHasNonePref
+    ? [
+        { code: "z", name: "Email" },
+        { code: "p", name: "Phone" },
+        { code: "-", name: "None" },
+      ]
+    : [
+        { code: "z", name: "Email" },
+        { code: "p", name: "Phone" },
+      ]
 
   const sortedPickupLocations = [
     patronData.homeLibrary,
@@ -174,7 +178,14 @@ const SettingsSelectForm = ({
               value={tempSelection}
             >
               {formUtils.options.map((option, index) => (
-                <option key={`${type}-option-${index}`} value={option.name}>
+                <option
+                  key={`${type}-option-${index}`}
+                  value={option.name}
+                  disabled={
+                    (option.name === "Email" && !patronHasEmail) ||
+                    (option.name === "Phone" && !patronHasPhone)
+                  }
+                >
                   {option.name}
                 </option>
               ))}
@@ -182,17 +193,37 @@ const SettingsSelectForm = ({
           </Flex>
         ) : (
           <Flex marginLeft={{ base: "m", lg: "unset" }}>
-            <Text
-              sx={{
-                marginTop: { base: "xs", lg: "unset" },
-                width: { base: "200px", sm: "250px" },
-                marginBottom: 0,
-              }}
-            >
-              {selection}
-            </Text>
+            <Flex flexDir="column">
+              <Text
+                sx={{
+                  marginTop: { base: "xs", lg: "unset" },
+                  width: { base: "200px", sm: "250px" },
+                  marginBottom: 0,
+                }}
+              >
+                {selection}
+              </Text>
+              {type === "notification" &&
+                patronHasNonePref &&
+                !patronHasPhone &&
+                !patronHasEmail && (
+                  <Banner
+                    sx={{
+                      marginTop: "s",
+                      width: { base: "200px", sm: "250px" },
+                    }}
+                    content="Please set a phone number or email address to choose a notification preference."
+                  />
+                )}
+            </Flex>
             {editingField === "" && (
               <EditButton
+                isDisabled={
+                  type === "notification" &&
+                  patronHasNonePref &&
+                  !patronHasPhone &&
+                  !patronHasEmail
+                }
                 ref={editingRef}
                 buttonLabel={`Edit ${type}`}
                 buttonId={`edit-${type}-button`}

--- a/src/components/MyAccount/Settings/StatusBanner.test.tsx
+++ b/src/components/MyAccount/Settings/StatusBanner.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react"
+import { StatusBanner } from "./StatusBanner"
+
+describe("Status banner", () => {
+  it("displays specific failure message", () => {
+    render(<StatusBanner status="failure" statusMessage="Specific failure" />)
+    expect(
+      screen.getByText(/Specific failure Please try again/)
+    ).toBeInTheDocument()
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "https://www.nypl.org/get-help/contact-us"
+    )
+    expect(screen.getByRole("complementary")).toHaveAttribute(
+      "data-type",
+      "negative"
+    )
+  })
+
+  it("displays general failure message", () => {
+    render(<StatusBanner status="failure" statusMessage="" />)
+    expect(screen.getByText(/Your changes were not saved/)).toBeInTheDocument()
+    expect(screen.getByRole("complementary")).toHaveAttribute(
+      "data-type",
+      "negative"
+    )
+  })
+
+  it("displays success message", () => {
+    render(<StatusBanner status="success" statusMessage="" />)
+    expect(screen.getByText(/Your changes were saved/)).toBeInTheDocument()
+    expect(screen.getByRole("complementary")).toHaveAttribute(
+      "data-type",
+      "positive"
+    )
+  })
+})

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -17,10 +17,8 @@ import AddButton from "./AddButton"
 import { BASE_URL } from "../../../config/constants"
 
 export const usernameStatusMessages = {
-  USERNAME_FAILURE:
-    "This username already exists. Please try a different username or contact us for assistance.",
-  FAILURE:
-    "Your changes could not be saved. Please try again or contact us for assistance. ",
+  USERNAME_FAILURE: "This username already exists.",
+  FAILURE: "Your changes could not be saved.",
   SUCCESS: "Your changes were saved.",
 }
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4389](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4389)

## This PR does the following:

Resolves the following issues:

a11y: 
- When activating an Edit button, when there are multiple fields focus is moving to the last one when it seems more logical to move to the first
- Each phone/email label should be named uniquely - if one is primary, include that in the label, and then you could increment the labels for additional items. Do the same for trash labels.

QA:
- Add email button should display for accounts with no email
- Notification preference dropdown should disable phone or email as options if you don’t have them **
- Notification preference “Edit” button should be disabled if you don’t have phone or email to change it to, and display a banner with “Please set a phone number or email address to choose a notification preference.” **
- Status banner text should not repeat itself (currently, when you try an already taken username, it says “This username already exists. Please try a different username or contact us for assistance. Please try again or [contact us](https://www.nypl.org/get-help/contact-us) for assistance.”) 
- Add email/phone button should also be disabled while another field is being edited (like the Edit buttons disappearing)


** New product requirements, introduced 12/12

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Most of these updates can only be seen on an account that has no attached phone number or email, and has its notification preference set to None. Use this one: 25555001351471 / 1082 but DO NOT actually Save Changes on an email/phone or on the notification preference, so that you can both see what's going on :)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4389]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ