### PR TITLE
SCC-4409: My Account 2.0 QA #3

### DIFF
--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -81,12 +81,21 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
 
   const cancelEditing = () => {
     setIsEditing(false)
+    clearForm()
     setEditingField("")
     setTimeout(() => {
       editingRef.current?.focus()
     }, 0)
   }
 
+  const clearForm = () => {
+    setFormData({
+      currentPassword: "",
+      newPassword: "",
+      confirmPassword: "",
+      passwordsMatch: true,
+    })
+  }
   const validateForm =
     formData.currentPassword !== "" &&
     formData.newPassword !== "" &&
@@ -146,6 +155,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
       console.error("Error submitting", error)
     } finally {
       setIsLoading(false)
+      clearForm()
       setEditingField("")
     }
   }

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -190,50 +190,52 @@ const SettingsSelectForm = ({
             </Select>
           </Flex>
         ) : (
-          <Flex marginLeft={{ base: "m", lg: "unset" }}>
-            <Flex flexDir="column">
-              <Text
-                sx={{
-                  marginTop: { base: "xs", lg: "unset" },
-                  width: { base: "200px", sm: "250px" },
-                  marginBottom: 0,
-                }}
-              >
-                {selection}
-              </Text>
-              {isNotification &&
-                patronHasNonePref &&
-                !patronHasPhone &&
-                !patronHasEmail && (
-                  <Banner
-                    sx={{
-                      marginTop: "s",
-                      width: { base: "200px", sm: "250px" },
-                    }}
-                    content="Please set a phone number or email address to choose a notification preference."
-                  />
-                )}
+          <Flex flexDir="column">
+            <Flex marginLeft={{ base: "m", lg: "unset" }}>
+              <Flex flexDir="column">
+                <Text
+                  sx={{
+                    marginTop: { base: "xs", lg: "unset" },
+                    width: { base: "200px", sm: "250px" },
+                    marginBottom: 0,
+                  }}
+                >
+                  {selection}
+                </Text>
+              </Flex>
+              {editingField === "" && (
+                <EditButton
+                  isDisabled={
+                    isNotification &&
+                    patronHasNonePref &&
+                    !patronHasPhone &&
+                    !patronHasEmail
+                  }
+                  ref={editingRef}
+                  buttonLabel={`Edit ${type}`}
+                  buttonId={`edit-${type}-button`}
+                  onClick={() => {
+                    setIsEditing(true)
+                    setEditingField(type)
+                    setTimeout(() => {
+                      selectRef.current?.focus()
+                    }, 0)
+                  }}
+                />
+              )}
             </Flex>
-            {editingField === "" && (
-              <EditButton
-                isDisabled={
-                  isNotification &&
-                  patronHasNonePref &&
-                  !patronHasPhone &&
-                  !patronHasEmail
-                }
-                ref={editingRef}
-                buttonLabel={`Edit ${type}`}
-                buttonId={`edit-${type}-button`}
-                onClick={() => {
-                  setIsEditing(true)
-                  setEditingField(type)
-                  setTimeout(() => {
-                    selectRef.current?.focus()
-                  }, 0)
-                }}
-              />
-            )}
+            {isNotification &&
+              patronHasNonePref &&
+              !patronHasPhone &&
+              !patronHasEmail && (
+                <Banner
+                  sx={{
+                    width: { base: "80%", sm: "320px" },
+                    marginLeft: { base: "m", lg: "unset" },
+                  }}
+                  content="Please set a phone number or email address to choose a notification preference."
+                />
+              )}
           </Flex>
         )}
         {isEditing && (


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4409](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4409)

## This PR does the following:

QA:
- When you click “Edit” after canceling a filled out password form, it allows the “Save Changes” button to be active even though the form is not currently valid. Resolve

VQA:
- Info banner for None state needs to match width of the banner for username

## How has this been tested?

The banner width update can only be seen on an account that has no attached phone number or email, and has its notification preference set to None. Use this one: 25555001351471 / 1082 but DO NOT actually Save Changes on an email/phone or on the notification preference :)

To test the password form, submit an incorrect password OR fill out the whole form correctly then click Cancel. When you reopen the form, the Save Changes button should be disabled.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4409]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ