### PR TITLE
SCC-4428 - Pass item source in kebab case to hold forms

### DIFF
--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -74,7 +74,7 @@ export default function EDDRequestPage({
   const [eddFormState, setEddFormState] = useState({
     ...initialEDDFormState,
     patronId,
-    source: item.source,
+    source: item.holdRequestSource,
   })
   const [formPosting, setFormPosting] = useState(false)
 

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -74,7 +74,7 @@ export default function EDDRequestPage({
   const [eddFormState, setEddFormState] = useState({
     ...initialEDDFormState,
     patronId,
-    source: item.holdRequestSource,
+    source: item.formattedSourceForHoldRequest,
   })
   const [formPosting, setFormPosting] = useState(false)
 

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -180,7 +180,7 @@ export default function HoldRequestPage({
               handleSubmit={handleSubmit}
               holdId={holdId}
               patronId={patronId}
-              source={item.source}
+              source={item.holdRequestSource}
             />
           </>
         ) : null}

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -180,7 +180,7 @@ export default function HoldRequestPage({
               handleSubmit={handleSubmit}
               holdId={holdId}
               patronId={patronId}
-              source={item.holdRequestSource}
+              source={item.formattedSourceForHoldRequest}
             />
           </>
         ) : null}

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -82,7 +82,7 @@ export default class Item {
       .includes("all")
   }
 
-  get holdRequestSource(): string {
+  get formattedSourceForHoldRequest(): string {
     return convertCamelToShishKabobCase(this.source)
   }
 

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -12,6 +12,7 @@ import {
   locationEndpointsMap,
 } from "../utils/itemUtils"
 import { appConfig } from "../config/config"
+import { convertCamelToShishKabobCase } from "../utils/appUtils"
 
 /**
  * The Item class contains the data and getter functions
@@ -79,6 +80,10 @@ export default class Item {
     return closedLocations
       .concat(this.isReCAP ? recapClosedLocations : nonRecapClosedLocations)
       .includes("all")
+  }
+
+  get holdRequestSource(): string {
+    return convertCamelToShishKabobCase(this.source)
   }
 
   // Pre-processing logic for setting Item holding location

--- a/src/models/modelTests/Item.test.ts
+++ b/src/models/modelTests/Item.test.ts
@@ -106,7 +106,7 @@ describe("Item model", () => {
     })
 
     it("returns the source in kebabcase for use in hold requests", () => {
-      expect(item.holdRequestSource).toBe("sierra-nypl")
+      expect(item.formattedSourceForHoldRequest).toBe("sierra-nypl")
     })
   })
 

--- a/src/models/modelTests/Item.test.ts
+++ b/src/models/modelTests/Item.test.ts
@@ -104,6 +104,10 @@ describe("Item model", () => {
         "A history of spaghetti eating and cooking for: spaghetti dinner."
       )
     })
+
+    it("returns the source in kebabcase for use in hold requests", () => {
+      expect(item.holdRequestSource).toBe("sierra-nypl")
+    })
   })
 
   describe("ReCAP checks", () => {

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -140,3 +140,19 @@ export const convertToSentenceCase = (str: string) =>
   str.split(" ").length > 1
     ? str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
     : str
+
+/**
+ * Converts camel case string to shish kabob case
+ *
+ * e.g. camelToShishKabobCase("RecapPul")
+ *        => "recap-pul"
+ *      camelToShishKabobCase("firstCharCanBeLowerCase")
+ *        => "first-char-can-be-lower-case"
+ */
+export const convertCamelToShishKabobCase = (str: string) =>
+  str
+    // Change capital letters into "-{lowercase letter}"
+    .replace(/([A-Z])/g, (c, p1, i) => {
+      // If capital letter is not first character, precede with '-':
+      return (i > 0 ? "-" : "") + c.toLowerCase()
+    })

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -152,7 +152,7 @@ export const convertToSentenceCase = (str: string) =>
 export const convertCamelToShishKabobCase = (str: string) =>
   str
     // Change capital letters into "-{lowercase letter}"
-    .replace(/([A-Z])/g, (c, p1, i) => {
+    .replace(/([A-Z])/g, (capitalLetter, placeholderVar, index) => {
       // If capital letter is not first character, precede with '-':
-      return (i > 0 ? "-" : "") + c.toLowerCase()
+      return (index > 0 ? "-" : "") + capitalLetter.toLowerCase()
     })


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4428 ](url)

## This PR does the following:

- We had missed a small bit of functionality on DFE that converts the source to kebab case before being sent in hold request params.

## How has this been tested?

- Added a unit test

## Accessibility concerns or updates

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
