### PR TITLE
SCC-4427 - VQA Round 2 Fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,11 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added fetchPatronEligibility server function that requests a patron's hold request eligibility status from Discovery API (SCC-3762)
 - Added patron ineligibility error messaging to HoldRequestErrorBanner component (SCC-3762)
 - Added eligibility checks to EDD and on-site request hold pages and API routes (SCC-3762)
+- Added HoldContactButton component and update error copy per VQA requests (SCC-4427)
 
 ### Updated
 
 - Updated phone, email, notification preference and home library to be individually editable in Account Settings (SCC-4337, SCC-4254, SCC-4253)
 - Updated username to be editable in My Account header (SCC-4236)
+- Format patron ineligibility reasons as list only when more than one (SCC-4427)
+- Disable Hold Request submit button when patron is ineligible (SCC-4427)
 
 ## [1.3.6] 2024-11-6
 

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -16,8 +16,6 @@ import initializePatronTokenAuth, {
 import { fetchBib } from "../../../src/server/api/bib"
 import { bibWithItems, bibWithSingleAeonItem } from "../../fixtures/bibFixtures"
 import {
-  BASE_URL,
-  PATHS,
   EDD_FORM_FIELD_COPY,
   HOLD_PAGE_ERROR_HEADINGS,
 } from "../../../src/config/constants"
@@ -238,7 +236,7 @@ describe("EDD Request page", () => {
 
       expect(
         screen.queryByText(
-          "We were unable to process your request at this time. Please try again, ",
+          "We were unable to process your request at this time. Please ",
           { exact: false }
         )
       ).toBeInTheDocument()
@@ -246,10 +244,6 @@ describe("EDD Request page", () => {
       expect(
         screen.getByRole("button", { name: "contact us" })
       ).toBeInTheDocument()
-
-      expect(
-        screen.getByText("start a new search", { exact: false })
-      ).toHaveAttribute("href", `${BASE_URL}${PATHS.SEARCH}`)
     })
 
     it("populates the feedback form with the call number and appropriate copy when the request fails", async () => {

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -389,12 +389,6 @@ describe("EDD Request page", () => {
       ).toBeInTheDocument()
 
       expect(
-        screen.getByText("This is because:", {
-          exact: false,
-        })
-      ).toBeInTheDocument()
-
-      expect(
         screen.getByText("Your account has expired", {
           exact: false,
         })
@@ -420,6 +414,8 @@ describe("EDD Request page", () => {
           exact: false,
         })
       ).toBeInTheDocument()
+
+      expect(screen.getByText("Submit request")).toBeDisabled()
     })
   })
 })

--- a/__test__/pages/hold/holdRequestPage.test.tsx
+++ b/__test__/pages/hold/holdRequestPage.test.tsx
@@ -15,8 +15,6 @@ import initializePatronTokenAuth, {
 import { fetchBib } from "../../../src/server/api/bib"
 import { bibWithItems, bibWithSingleAeonItem } from "../../fixtures/bibFixtures"
 import {
-  BASE_URL,
-  PATHS,
   NYPL_LOCATIONS,
   HOLD_PAGE_ERROR_HEADINGS,
 } from "../../../src/config/constants"
@@ -248,7 +246,7 @@ describe("Hold Request page", () => {
 
       expect(
         screen.queryByText(
-          "We were unable to process your request at this time. Please try again, ",
+          "We were unable to process your request at this time. Please ",
           { exact: false }
         )
       ).toBeInTheDocument()
@@ -256,10 +254,6 @@ describe("Hold Request page", () => {
       expect(
         screen.getByRole("button", { name: "contact us" })
       ).toBeInTheDocument()
-
-      expect(
-        screen.getByText("start a new search", { exact: false })
-      ).toHaveAttribute("href", `${BASE_URL}${PATHS.SEARCH}`)
     })
 
     it("populates the feedback form with the call number and appropriate copy when the request fails", async () => {

--- a/__test__/pages/hold/holdRequestPage.test.tsx
+++ b/__test__/pages/hold/holdRequestPage.test.tsx
@@ -340,12 +340,6 @@ describe("Hold Request page", () => {
       ).toBeInTheDocument()
 
       expect(
-        screen.getByText("This is because:", {
-          exact: false,
-        })
-      ).toBeInTheDocument()
-
-      expect(
         screen.getByText("Your account has expired", {
           exact: false,
         })
@@ -371,6 +365,8 @@ describe("Hold Request page", () => {
           exact: false,
         })
       ).toBeInTheDocument()
+
+      expect(screen.getByText("Submit request")).toBeDisabled()
     })
   })
 })

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -173,6 +173,7 @@ export default function EDDRequestPage({
             setEddFormState={setEddFormState}
             handleSubmit={postEDDRequest}
             setErrorStatus={setErrorStatus}
+            errorStatus={errorStatus}
             holdId={holdId}
           />
         ) : null}

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -69,10 +69,14 @@ export default function HoldRequestPage({
 
   const holdId = `${item.bibId}-${item.id}`
 
-  const [errorStatus, setErrorStatus] = useState(defaultErrorStatus)
-  const [patronEligibilityStatus, setPatronEligibilityStatus] = useState(
-    defaultEligibilityStatus
-  )
+  const [errorStatus, setErrorStatus] = useState("patronIneligible")
+  const [patronEligibilityStatus, setPatronEligibilityStatus] = useState({
+    expired: true,
+    moneyOwed: true,
+    ptypeDisallowsHolds: true,
+    reachedHoldLimit: true,
+    status: 401,
+  })
   const [formPosting, setFormPosting] = useState(false)
   const bannerContainerRef = useRef<HTMLDivElement>()
 

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -181,6 +181,7 @@ export default function HoldRequestPage({
               holdId={holdId}
               patronId={patronId}
               source={item.source}
+              errorStatus={errorStatus}
             />
           </>
         ) : null}

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -69,14 +69,10 @@ export default function HoldRequestPage({
 
   const holdId = `${item.bibId}-${item.id}`
 
-  const [errorStatus, setErrorStatus] = useState("patronIneligible")
-  const [patronEligibilityStatus, setPatronEligibilityStatus] = useState({
-    expired: true,
-    moneyOwed: true,
-    ptypeDisallowsHolds: true,
-    reachedHoldLimit: true,
-    status: 401,
-  })
+  const [errorStatus, setErrorStatus] = useState(defaultErrorStatus)
+  const [patronEligibilityStatus, setPatronEligibilityStatus] = useState(
+    defaultEligibilityStatus
+  )
   const [formPosting, setFormPosting] = useState(false)
   const bannerContainerRef = useRef<HTMLDivElement>()
 

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -79,15 +79,14 @@ const EDDRequestForm = ({
 
   const validateAndSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+    const newValidatedFields = validateEDDForm(eddFormState, invalidFields)
 
     // Validate the form on submission in case the user hasn't typed in all the required fields
-    setInvalidFields((prevInvalidFields) =>
-      validateEDDForm(eddFormState, prevInvalidFields)
-    )
+    setInvalidFields(newValidatedFields)
 
     // Find the first invalid field and focus on it
-    const firstInvalidField = invalidFields.find(
-      (firstInvalidFieldKey) => firstInvalidFieldKey.isInvalid
+    const firstInvalidField = newValidatedFields.find(
+      (validatedFieldKey) => validatedFieldKey.isInvalid
     )
 
     // Prevent form submission and focus on first invalid field if there is one

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -121,7 +121,7 @@ const EDDRequestForm = ({
         value={eddFormState.source}
       />
       <Box>
-        <Heading level="h3" size="heading4" mb="m">
+        <Heading level="h3" size="heading4" mb="xs">
           Required information
         </Heading>
         <Text noSpace>
@@ -181,7 +181,7 @@ const EDDRequestForm = ({
           />
         </FormField>
       </FormRow>
-      <FormField>
+      <FormField mb="xs">
         <TextInput
           id="chapterTitle"
           name="chapterTitle"
@@ -247,7 +247,7 @@ const EDDRequestForm = ({
           />
         </FormField>
       </FormRow>
-      <FormField>
+      <FormField mb="xs">
         <TextInput
           id="requestNotes"
           name="requestNotes"

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -138,7 +138,6 @@ const EDDRequestForm = ({
           name="emailAddress"
           value={eddFormState.emailAddress}
           labelText={EDD_FORM_FIELD_COPY.emailAddress.label}
-          isRequired
           placeholder={EDD_FORM_FIELD_COPY.emailAddress.placeholder}
           helperText={EDD_FORM_FIELD_COPY.emailAddress.helperText}
           invalidText={EDD_FORM_FIELD_COPY.emailAddress.invalidText}
@@ -157,7 +156,6 @@ const EDDRequestForm = ({
             name="startPage"
             value={eddFormState.startPage}
             labelText={EDD_FORM_FIELD_COPY.startPage.label}
-            isRequired
             placeholder={EDD_FORM_FIELD_COPY.startPage.placeholder}
             helperText={EDD_FORM_FIELD_COPY.startPage.helperText}
             invalidText={EDD_FORM_FIELD_COPY.startPage.invalidText}
@@ -173,7 +171,6 @@ const EDDRequestForm = ({
             name="endPage"
             value={eddFormState.endPage}
             labelText={EDD_FORM_FIELD_COPY.endPage.label}
-            isRequired
             placeholder={EDD_FORM_FIELD_COPY.endPage.placeholder}
             helperText={EDD_FORM_FIELD_COPY.endPage.helperText}
             invalidText={EDD_FORM_FIELD_COPY.endPage.invalidText}
@@ -190,7 +187,6 @@ const EDDRequestForm = ({
           name="chapterTitle"
           value={eddFormState.chapterTitle}
           labelText={EDD_FORM_FIELD_COPY.chapterTitle.label}
-          isRequired
           placeholder={EDD_FORM_FIELD_COPY.chapterTitle.placeholder}
           helperText={EDD_FORM_FIELD_COPY.chapterTitle.helperText}
           invalidText={EDD_FORM_FIELD_COPY.chapterTitle.invalidText}

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -20,6 +20,7 @@ import {
   validateEDDForm,
   initialEDDInvalidFields,
   isInvalidField,
+  holdButtonDisabledStatuses,
 } from "../../utils/holdPageUtils"
 import type {
   EDDRequestParams,
@@ -32,6 +33,7 @@ interface EDDRequestFormProps {
   handleSubmit: (eddParams: EDDRequestParams) => void
   setErrorStatus: (errorStatus: HoldErrorStatus) => void
   holdId: string
+  errorStatus?: HoldErrorStatus
 }
 
 /**
@@ -43,9 +45,15 @@ const EDDRequestForm = ({
   handleSubmit,
   setErrorStatus,
   holdId,
+  errorStatus,
 }: EDDRequestFormProps) => {
   // Set the invalid fields as an array in state to keep track of the first invalid field for focus on submit
   const [invalidFields, setInvalidFields] = useState(initialEDDInvalidFields)
+
+  // Disable the submit button for certain error statuses
+  const formDisabled = (["patronIneligible"] as HoldErrorStatus[]).includes(
+    errorStatus
+  )
 
   // Create refs for fields that require validation to focus on the first invalid field on submit
   const [validatedInputRefs] = useState(
@@ -261,7 +269,11 @@ const EDDRequestForm = ({
       </FormField>
       <CopyrightRestrictionsBanner />
       <ButtonGroup>
-        <Button id="edd-request-submit" type="submit">
+        <Button
+          id="edd-request-submit"
+          type="submit"
+          isDisabled={holdButtonDisabledStatuses.includes(errorStatus)}
+        >
           Submit request
         </Button>
       </ButtonGroup>

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -50,11 +50,6 @@ const EDDRequestForm = ({
   // Set the invalid fields as an array in state to keep track of the first invalid field for focus on submit
   const [invalidFields, setInvalidFields] = useState(initialEDDInvalidFields)
 
-  // Disable the submit button for certain error statuses
-  const formDisabled = (["patronIneligible"] as HoldErrorStatus[]).includes(
-    errorStatus
-  )
-
   // Create refs for fields that require validation to focus on the first invalid field on submit
   const [validatedInputRefs] = useState(
     invalidFields.reduce((acc, field) => {

--- a/src/components/HoldPages/HoldContactButton.tsx
+++ b/src/components/HoldPages/HoldContactButton.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@nypl/design-system-react-components"
+import { useContext, type ReactNode } from "react"
+
+import type Item from "../../models/Item"
+import type { ItemMetadata } from "../../types/itemTypes"
+import { FeedbackContext } from "../../context/FeedbackContext"
+
+interface HoldContactButtonProps {
+  item: Item
+  children: ReactNode
+}
+
+export const HoldContactButton = ({
+  item,
+  children,
+}: HoldContactButtonProps) => {
+  const { onOpen, setItemMetadata } = useContext(FeedbackContext)
+
+  const onContact = (metadata: ItemMetadata) => {
+    setItemMetadata(metadata)
+    onOpen()
+  }
+
+  return (
+    <Button
+      id="hold-contact"
+      onClick={() =>
+        onContact({
+          id: item.id,
+          barcode: item.barcode,
+          callNumber: item.callNumber,
+          bibId: item.bibId,
+          notificationText: `Request failed for call number ${item.callNumber}`,
+        })
+      }
+      buttonType="link"
+      // TODO: Ask DS team to make button link variant match the default link styles
+      sx={{
+        display: "inline",
+        fontWeight: "inherit",
+        fontSize: "inherit",
+        p: 0,
+        height: "auto",
+        textAlign: "left",
+        minHeight: "auto",
+        textDecorationStyle: "dotted",
+        textDecorationThickness: "1px",
+        textUnderlineOffset: "2px",
+      }}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/components/HoldPages/HoldRequestErrorBanner.tsx
+++ b/src/components/HoldPages/HoldRequestErrorBanner.tsx
@@ -11,7 +11,6 @@ import type Item from "../../models/Item"
 import RCLink from "../Links/RCLink/RCLink"
 import PatronIneligibilityErrors from "./PatronIneligibilityErrors"
 import {
-  PATHS,
   HOLD_PAGE_ERROR_HEADINGS,
   HOLD_PAGE_CONTACT_PREFIXES,
 } from "../../config/constants"
@@ -28,7 +27,7 @@ interface HoldRequestErrorBannerProps {
  */
 const HoldRequestErrorBanner = ({
   item,
-  errorStatus = "failed",
+  errorStatus = "patronIneligible",
   patronEligibilityStatus,
 }: HoldRequestErrorBannerProps) => {
   const { onOpen, setItemMetadata } = useContext(FeedbackContext)
@@ -54,9 +53,9 @@ const HoldRequestErrorBanner = ({
       content={
         <Box>
           {HOLD_PAGE_CONTACT_PREFIXES?.[errorStatus] && (
-            <Text>
+            <Text noSpace mt="xs">
               {HOLD_PAGE_CONTACT_PREFIXES?.[errorStatus]}
-              {" Please try again, "}
+              {" Please "}
               <Button
                 id="hold-contact"
                 onClick={() =>
@@ -85,8 +84,7 @@ const HoldRequestErrorBanner = ({
               >
                 contact us
               </Button>{" "}
-              for assistance, or{" "}
-              <RCLink href="/search">start a new search.</RCLink>
+              for assistance.
             </Text>
           )}
           {(() => {

--- a/src/components/HoldPages/HoldRequestErrorBanner.tsx
+++ b/src/components/HoldPages/HoldRequestErrorBanner.tsx
@@ -1,4 +1,3 @@
-import { useContext } from "react"
 import { Text, Box, Banner } from "@nypl/design-system-react-components"
 
 import type {
@@ -6,7 +5,6 @@ import type {
   PatronEligibilityStatus,
 } from "../../types/holdPageTypes"
 
-import type { ItemMetadata } from "../../types/itemTypes"
 import type Item from "../../models/Item"
 
 import PatronIneligibilityErrors from "./PatronIneligibilityErrors"

--- a/src/components/HoldPages/HoldRequestErrorBanner.tsx
+++ b/src/components/HoldPages/HoldRequestErrorBanner.tsx
@@ -1,15 +1,16 @@
 import { useContext } from "react"
-import { Text, Box, Banner, Button } from "@nypl/design-system-react-components"
+import { Text, Box, Banner } from "@nypl/design-system-react-components"
 
 import type {
   HoldErrorStatus,
   PatronEligibilityStatus,
 } from "../../types/holdPageTypes"
-import { FeedbackContext } from "../../context/FeedbackContext"
+
 import type { ItemMetadata } from "../../types/itemTypes"
 import type Item from "../../models/Item"
-import RCLink from "../Links/RCLink/RCLink"
+
 import PatronIneligibilityErrors from "./PatronIneligibilityErrors"
+import { HoldContactButton } from "./HoldContactButton"
 import {
   HOLD_PAGE_ERROR_HEADINGS,
   HOLD_PAGE_CONTACT_PREFIXES,
@@ -30,13 +31,6 @@ const HoldRequestErrorBanner = ({
   errorStatus = "patronIneligible",
   patronEligibilityStatus,
 }: HoldRequestErrorBannerProps) => {
-  const { onOpen, setItemMetadata } = useContext(FeedbackContext)
-
-  const onContact = (metadata: ItemMetadata) => {
-    setItemMetadata(metadata)
-    onOpen()
-  }
-
   return (
     <Banner
       type="negative"
@@ -56,35 +50,8 @@ const HoldRequestErrorBanner = ({
             <Text noSpace mt="xs">
               {HOLD_PAGE_CONTACT_PREFIXES?.[errorStatus]}
               {" Please "}
-              <Button
-                id="hold-contact"
-                onClick={() =>
-                  onContact({
-                    id: item.id,
-                    barcode: item.barcode,
-                    callNumber: item.callNumber,
-                    bibId: item.bibId,
-                    notificationText: `Request failed for call number ${item.callNumber}`,
-                  })
-                }
-                buttonType="link"
-                // TODO: Ask DS team to make button link variant match the default link styles
-                sx={{
-                  display: "inline",
-                  fontWeight: "inherit",
-                  fontSize: "inherit",
-                  p: 0,
-                  height: "auto",
-                  textAlign: "left",
-                  minHeight: "auto",
-                  textDecorationStyle: "dotted",
-                  textDecorationThickness: "1px",
-                  textUnderlineOffset: "2px",
-                }}
-              >
-                contact us
-              </Button>{" "}
-              for assistance.
+              <HoldContactButton item={item}>contact us</HoldContactButton> for
+              assistance.
             </Text>
           )}
           {(() => {
@@ -95,6 +62,7 @@ const HoldRequestErrorBanner = ({
                 return patronEligibilityStatus ? (
                   <PatronIneligibilityErrors
                     patronEligibilityStatus={patronEligibilityStatus}
+                    item={item}
                   />
                 ) : null
               default:

--- a/src/components/HoldPages/HoldRequestForm.tsx
+++ b/src/components/HoldPages/HoldRequestForm.tsx
@@ -8,6 +8,8 @@ import {
 } from "@nypl/design-system-react-components"
 
 import type { DeliveryLocation } from "../../../src/types/locationTypes"
+import type { HoldErrorStatus } from "../../../src/types/holdPageTypes"
+import { holdButtonDisabledStatuses } from "../../../src/utils/holdPageUtils"
 
 import { BASE_URL } from "../../config/constants"
 
@@ -17,6 +19,7 @@ interface HoldRequestFormProps {
   holdId: string
   patronId: string
   source: string
+  errorStatus?: HoldErrorStatus
 }
 
 /**
@@ -28,6 +31,7 @@ const HoldRequestForm = ({
   holdId,
   patronId,
   source,
+  errorStatus,
 }: HoldRequestFormProps) => {
   return (
     <Form
@@ -68,7 +72,11 @@ const HoldRequestForm = ({
         </RadioGroup>
       </FormField>
       <ButtonGroup>
-        <Button id="holdRequestSubmit" type="submit">
+        <Button
+          id="holdRequestSubmit"
+          type="submit"
+          isDisabled={holdButtonDisabledStatuses.includes(errorStatus)}
+        >
           Submit request
         </Button>
       </ButtonGroup>

--- a/src/components/HoldPages/PatronIneligibilityErrors.tsx
+++ b/src/components/HoldPages/PatronIneligibilityErrors.tsx
@@ -1,13 +1,18 @@
-import { Text, Box, List } from "@nypl/design-system-react-components"
+import { Box, List, Text } from "@nypl/design-system-react-components"
 
 import type { PatronEligibilityStatus } from "../../types/holdPageTypes"
+import type Item from "../../models/Item"
+
 import RCLink from "../Links/RCLink/RCLink"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
+import { HoldContactButton } from "./HoldContactButton"
+
 import { PATHS } from "../../config/constants"
 import { appConfig } from "../../config/config"
 
 interface PatronIneligibilityErrorsProps {
   patronEligibilityStatus: PatronEligibilityStatus
+  item: Item
 }
 
 /**
@@ -16,51 +21,61 @@ interface PatronIneligibilityErrorsProps {
  */
 const PatronIneligibilityErrors = ({
   patronEligibilityStatus,
+  item,
 }: PatronIneligibilityErrorsProps) => {
   const { expired, moneyOwed, ptypeDisallowsHolds, reachedHoldLimit } =
     patronEligibilityStatus
 
-  const hasSpecificReason =
-    expired || moneyOwed || ptypeDisallowsHolds || reachedHoldLimit
-
-  // Generic patron error displayed in heading, don't show reasons list if there isn't one
-  if (!hasSpecificReason) return null
-
-  return (
-    <Box mt="xs">
-      <List type="ul" margin={0}>
-        {expired ? (
-          <li>
+  const ineligibilityReasons = [
+    ...(expired
+      ? [
+          <>
             Your account has expired -- Please see{" "}
             <ExternalLink href={appConfig.urls.renewCard}>
               Library Terms and Conditions -- Renewing or Validating Your
               Library Card
             </ExternalLink>{" "}
             about renewing your card.
-          </li>
-        ) : (
-          <></>
-        )}
-        {moneyOwed ? (
-          <li>
+          </>,
+        ]
+      : []),
+    ...(moneyOwed
+      ? [
+          <>
             Your fines have exceeded the limit — you can pay your fines in a
             branch or online from the links under{" "}
             <RCLink href={PATHS.MY_ACCOUNT}>My Account</RCLink>.
-          </li>
-        ) : (
-          <></>
-        )}
-        {ptypeDisallowsHolds ? (
-          <li>Your card does not permit placing holds on ReCAP materials.</li>
-        ) : (
-          <></>
-        )}
-        {reachedHoldLimit ? (
-          <li>You have reached the allowed number of holds.</li>
-        ) : (
-          <></>
-        )}
-      </List>
+          </>,
+        ]
+      : []),
+    ...(ptypeDisallowsHolds
+      ? [<>Your card does not permit placing holds on ReCAP materials.</>]
+      : []),
+    ...(reachedHoldLimit
+      ? [<>You have reached the allowed number of holds.</>]
+      : []),
+  ]
+
+  // Generic patron error displayed in heading, don't show reasons list if there isn't one
+  if (!ineligibilityReasons.length) return null
+
+  return (
+    <Box mt="xs">
+      {ineligibilityReasons.length > 1 ? (
+        <>
+          <List type="ul" margin={0} listItems={ineligibilityReasons} />
+          <Text noSpace mt="xs">
+            Please <HoldContactButton item={item}>contact us</HoldContactButton>{" "}
+            for assistance if required.
+          </Text>
+        </>
+      ) : (
+        <>
+          {ineligibilityReasons.map((reason) => reason)} Please{" "}
+          <HoldContactButton item={item}>contact us</HoldContactButton> for
+          assistance if required.
+        </>
+      )}
     </Box>
   )
 }

--- a/src/components/HoldPages/PatronIneligibilityErrors.tsx
+++ b/src/components/HoldPages/PatronIneligibilityErrors.tsx
@@ -28,36 +28,35 @@ const PatronIneligibilityErrors = ({
 
   return (
     <Box mt="xs">
-      <Text mb="xs">This is because:</Text>
       <List type="ul" margin={0}>
         {expired ? (
-          <>
+          <li>
             Your account has expired -- Please see{" "}
             <ExternalLink href={appConfig.urls.renewCard}>
               Library Terms and Conditions -- Renewing or Validating Your
               Library Card
             </ExternalLink>{" "}
             about renewing your card.
-          </>
+          </li>
         ) : (
           <></>
         )}
         {moneyOwed ? (
-          <>
+          <li>
             Your fines have exceeded the limit — you can pay your fines in a
             branch or online from the links under{" "}
             <RCLink href={PATHS.MY_ACCOUNT}>My Account</RCLink>.
-          </>
+          </li>
         ) : (
           <></>
         )}
         {ptypeDisallowsHolds ? (
-          "Your card does not permit placing holds on ReCAP materials."
+          <li>Your card does not permit placing holds on ReCAP materials.</li>
         ) : (
           <></>
         )}
         {reachedHoldLimit ? (
-          "You have reached the allowed number of holds."
+          <li>You have reached the allowed number of holds.</li>
         ) : (
           <></>
         )}

--- a/src/components/HoldPages/PatronIneligibilityErrors.tsx
+++ b/src/components/HoldPages/PatronIneligibilityErrors.tsx
@@ -73,7 +73,7 @@ const PatronIneligibilityErrors = ({
         <>
           {ineligibilityReasons.map((reason) => reason)} Please{" "}
           <HoldContactButton item={item}>contact us</HoldContactButton> for
-          assistance if required.
+          assistance.
         </>
       )}
     </Box>

--- a/src/utils/holdPageUtils.ts
+++ b/src/utils/holdPageUtils.ts
@@ -1,6 +1,7 @@
 import type {
   EDDRequestParams,
   EDDFormValidatedField,
+  HoldErrorStatus,
 } from "../types/holdPageTypes"
 
 import { EMAIL_REGEX } from "../config/constants"
@@ -27,6 +28,11 @@ export const initialEDDInvalidFields: EDDFormValidatedField[] = [
   { key: "startPage", isInvalid: false },
   { key: "endPage", isInvalid: false },
   { key: "chapterTitle", isInvalid: false },
+]
+
+// Disable the submit button on both hold request forms for the following statuses
+export const holdButtonDisabledStatuses: HoldErrorStatus[] = [
+  "patronIneligible",
 ]
 
 // Gets updated invalidFields to set them in state based on the inputted field name and value


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4427](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4427)

## This PR does the following:

- Updates error banner copy, styles, and adds HoldContactButton component for ease of re-use.
- Only renders ineligibility reasons as a List when more than one (Apoorva request not in the VQA doc)
- Disables the Submit button when the patron is ineligible to place holds.
- Misc styling changes on hold request forms
- Remove isRequired from EDD form fields to prevent chrome's native handling of focus on errors.

## How has this been tested?

 - Updated unit tests

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4427]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ