### PR TITLE
Scc 4405/hold pages js disabled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added eligibility checks to EDD and on-site request hold pages and API routes (SCC-3762)
 - Added HoldContactButton component and update error copy per VQA requests (SCC-4427)
 - Added email address field prepopulation on EDD Request form (SCC-4407)
+- Added server validation and form state prepopulation (SCC-4405)
 
 ### Updated
 
@@ -23,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated username to be editable in My Account header (SCC-4236)
 - Format patron ineligibility reasons as list only when more than one (SCC-4427)
 - Disable Hold Request submit button when patron is ineligible (SCC-4427)
+
+### Fixed
+
+- Fixed broken query param/JSON parsing in hold api routes causing errors when JS is disabled (SCC-4405)
 
 ## [1.3.6] 2024-11-6
 

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -5,6 +5,7 @@ import {
   waitFor,
 } from "../../../src/utils/testUtils"
 import userEvent from "@testing-library/user-event"
+import mockRouter from "next-router-mock"
 
 import EDDRequestPage, {
   getServerSideProps,
@@ -18,6 +19,7 @@ import { bibWithItems, bibWithSingleAeonItem } from "../../fixtures/bibFixtures"
 import {
   EDD_FORM_FIELD_COPY,
   HOLD_PAGE_ERROR_HEADINGS,
+  PATHS,
 } from "../../../src/config/constants"
 import {
   fetchDeliveryLocations,
@@ -345,6 +347,34 @@ describe("EDD Request page", () => {
       expect(
         screen.getByText(
           "Some fields contain errors. Please correct and submit again."
+        )
+      ).toBeInTheDocument()
+    })
+    it("shows a field errors when invalid field state is passed as a query param", async () => {
+      mockRouter.push(
+        `${PATHS.HOLD_REQUEST}/123-456/edd?formInvalid=true&validatedFields=[{%22key%22:%22emailAddress%22,%22isInvalid%22:true},{%22key%22:%22startPage%22,%22isInvalid%22:true},{%22key%22:%22endPage%22,%22isInvalid%22:true},{%22key%22:%22chapterTitle%22,%22isInvalid%22:true}]`
+      )
+      render(
+        <EDDRequestPage
+          discoveryBibResult={bibWithItems.resource}
+          discoveryItemResult={bibWithItems.resource.items[0]}
+          patronId="123"
+          isAuthenticated={true}
+        />
+      )
+      expect(
+        screen.getByText(
+          "There was a problem. Enter a valid email address. Your request will be delivered to the email address you enter above."
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.getAllByText(
+          "There was a problem. Enter a page number. You may request a maximum of 50 pages."
+        )
+      ).toHaveLength(2)
+      expect(
+        screen.getByText(
+          "There was a problem. Indicate the title of the chapter or article you are requesting."
         )
       ).toBeInTheDocument()
     })

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -272,7 +272,7 @@ describe("EDD Request page", () => {
           discoveryBibResult={bibWithItems.resource}
           discoveryItemResult={bibWithItems.resource.items[2]}
           patronId="123"
-          patronEmail="test@test.com"
+          patronEmail="patron@test.com"
           isAuthenticated={true}
         />
       )

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -93,12 +93,14 @@ describe("EDD Request page", () => {
         params: { id },
         req: mockReq,
         res: mockRes,
+        query: {},
       })
       expect(responseWithZeroRedirects.redirect).toBeDefined()
       const responseWithTwoRedirects = await getServerSideProps({
         params: { id: "123-456" },
         req: { ...mockReq, cookies: { nyplAccountRedirects: 2 } },
         res: mockRes,
+        query: {},
       })
       expect(responseWithTwoRedirects.redirect).toBeDefined()
     })
@@ -115,6 +117,7 @@ describe("EDD Request page", () => {
         params: { id },
         req: mockReq,
         res: mockRes,
+        query: {},
       })
       expect(responseWithoutRedirect.redirect).not.toBeDefined()
     })
@@ -123,6 +126,7 @@ describe("EDD Request page", () => {
         params: { id },
         req: mockReq,
         res: mockRes,
+        query: {},
       })
       expect(response.redirect).toBeUndefined()
     })
@@ -138,6 +142,7 @@ describe("EDD Request page", () => {
         params: { id },
         res: mockRes,
         req: mockReq,
+        query: {},
       })
       expect(mockRes.setHeader.mock.calls[0]).toStrictEqual([
         "Set-Cookie",
@@ -163,6 +168,7 @@ describe("EDD Request page", () => {
         params: { id },
         res: mockRes,
         req: mockReq,
+        query: {},
       })
       expect(responseWithAeonRedirect.redirect).toStrictEqual({
         destination: bibWithSingleAeonItem.resource.items[0].aeonUrl[0],

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -250,7 +250,7 @@ describe("EDD Request page", () => {
     })
   })
   describe("EDD Request prepopulated form fields", () => {
-    beforeEach(() => {
+    it("prepopulates the email field with the patron's email address if present", () => {
       render(
         <EDDRequestPage
           discoveryBibResult={bibWithItems.resource}
@@ -260,15 +260,27 @@ describe("EDD Request page", () => {
           isAuthenticated={true}
         />
       )
-    })
-    it("prepopulates the email field with the patron's email address if present", () => {
+
       expect(screen.getByDisplayValue("test@test.com")).toBeInTheDocument()
     })
     it("prepopulates all form fields and overwrites patron email when form fields are present in url", () => {
       mockRouter.push(
-        `${PATHS.HOLD_REQUEST}/123-456/edd?formState={%22source%22:%22sierra-nypl%22,%22emailAddress%22:%22test@test.com%22,%22startPage%22:%221%22,%22endPage%22:%225%22,%22chapterTitle%22:%22on%20spaghetti%22,%22author%22:%22%22,%22date%22:%22%22,%22volume%22:%22%22,%22issue%22:%22%22,%22requestNotes%22:%22%22}`
+        `${PATHS.HOLD_REQUEST}/123-456/edd?formState={%22source%22:%22sierra-nypl%22,%22emailAddress%22:%22test@test.com%22,%22startPage%22:%22ch%201%22,%22endPage%22:%22ch%205%22,%22chapterTitle%22:%22on%20spaghetti%22,%22author%22:%22%22,%22date%22:%22%22,%22volume%22:%22%22,%22issue%22:%22%22,%22requestNotes%22:%22%22}`
       )
+      render(
+        <EDDRequestPage
+          discoveryBibResult={bibWithItems.resource}
+          discoveryItemResult={bibWithItems.resource.items[2]}
+          patronId="123"
+          patronEmail="test@test.com"
+          isAuthenticated={true}
+        />
+      )
+
       expect(screen.getByDisplayValue("test@test.com")).toBeInTheDocument()
+      expect(screen.getByDisplayValue("ch 1")).toBeInTheDocument()
+      expect(screen.getByDisplayValue("ch 5")).toBeInTheDocument()
+      expect(screen.getByDisplayValue("on spaghetti")).toBeInTheDocument()
 
       // Clear query params for next test
       // TODO: Investigate if there's a more optimal way to test router changes without requiring cleanup for the next test

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -264,6 +264,16 @@ describe("EDD Request page", () => {
     it("prepopulates the email field with the patron's email address if present", () => {
       expect(screen.getByDisplayValue("test@test.com")).toBeInTheDocument()
     })
+    it("prepopulates all form fields and overwrites patron email when form fields are present in url", () => {
+      mockRouter.push(
+        `${PATHS.HOLD_REQUEST}/123-456/edd?formState={%22source%22:%22sierra-nypl%22,%22emailAddress%22:%22test@test.com%22,%22startPage%22:%221%22,%22endPage%22:%225%22,%22chapterTitle%22:%22on%20spaghetti%22,%22author%22:%22%22,%22date%22:%22%22,%22volume%22:%22%22,%22issue%22:%22%22,%22requestNotes%22:%22%22}`
+      )
+      expect(screen.getByDisplayValue("test@test.com")).toBeInTheDocument()
+
+      // Clear query params for next test
+      // TODO: Investigate if there's a more optimal way to test router changes without requiring cleanup for the next test
+      mockRouter.push(`${PATHS.HOLD_REQUEST}/123-456/edd`)
+    })
   })
   describe("EDD Request form validation", () => {
     beforeEach(async () => {

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -5,7 +5,7 @@ import {
   fetchPatronEligibility,
 } from "../../../../../src/server/api/hold"
 import {
-  initialEDDInvalidFields,
+  defaultValidatedEDDFields,
   validateEDDForm,
   eddFormIsInvalid,
 } from "../../../../../src/utils/holdPageUtils"
@@ -28,7 +28,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const holdId = req.query.id as string
 
     // Server-side form validation
-    const validatedFields = validateEDDForm(formState, initialEDDInvalidFields)
+    const validatedFields = validateEDDForm(
+      formState,
+      defaultValidatedEDDFields
+    )
 
     const [, itemId] = holdId.split("-")
 

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -22,7 +22,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const { patronId, jsEnabled, ...rest } = req.body
+    const { patronId, jsEnabled, ...rest } =
+      typeof req.body === "string" ? JSON.parse(req.body) : req.body
     const formState = rest
     const holdId = req.query.id as string
 
@@ -55,7 +56,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const eddRequestResponse = await postEDDRequest({
       itemId,
       patronId,
-      ...rest,
+      ...formState,
     })
 
     const { requestId } = eddRequestResponse
@@ -78,7 +79,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       return res.redirect(
         `${BASE_URL}${
           PATHS.HOLD_REQUEST
-        }/${holdId}/edd?formInvalid=${formInvalid}&validatedFields=${JSON.stringify(
+        }/${holdId}/edd?formInvalid=${JSON.stringify(
+          formInvalid
+        )}&validatedFields=${JSON.stringify(
           validatedFields
         )}&formState=${JSON.stringify(formState)}`
       )

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -22,10 +22,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   try {
     const { patronId, jsEnabled, ...rest } = req.body
+    const formState = rest
     const holdId = req.query.id as string
 
     // Server-side form validation
-    const validatedEDDFields = validateEDDForm(rest, initialEDDInvalidFields)
+    const validatedFields = validateEDDForm(formState, initialEDDInvalidFields)
 
     const [, itemId] = holdId.split("-")
 
@@ -70,16 +71,16 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     // JS-Disabled functionality
-    const eddFormInvalid = !!validatedEDDFields.find(
+    const formInvalid = !!validatedFields.find(
       (validatedFieldKey) => validatedFieldKey.isInvalid
     )
-    if (eddFormInvalid) {
+    if (formInvalid) {
       return res.redirect(
         `${BASE_URL}${
           PATHS.HOLD_REQUEST
-        }/${holdId}/edd?validatedEDDFields=${JSON.stringify(
-          validatedEDDFields
-        )}`
+        }/${holdId}/edd?validatedFields=${JSON.stringify(
+          validatedFields
+        )}&formState=${JSON.stringify(formState)}`
       )
     }
 

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -75,22 +75,24 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
     }
 
-    // JS-Disabled functionality
+    // JS-Disabled error validation/redirect
     const formInvalid = eddFormIsInvalid(validatedFields)
 
     if (formInvalid) {
-      return res.redirect(
-        `${BASE_URL}${
-          PATHS.HOLD_REQUEST
-        }/${holdId}/edd?formInvalid=${JSON.stringify(
-          formInvalid
-        )}&validatedFields=${JSON.stringify(
-          validatedFields
-        )}&formState=${JSON.stringify(formState)}`
-      )
+      const formInvalidQuery = `formInvalid=${JSON.stringify(formInvalid)}`
+      const validatedFieldsQuery = `validatedFields=${JSON.stringify(
+        validatedFields
+      )}`
+      const formStateQuery = `formState=${JSON.stringify(formState)}`
+
+      const invalidFormRedirectUrl =
+        encodeURI(`${BASE_URL}${PATHS.HOLD_REQUEST}/${holdId}/edd?
+    )}&${formInvalidQuery}&${validatedFieldsQuery}&${formStateQuery}`)
+
+      return res.redirect(invalidFormRedirectUrl)
     }
 
-    // Redirect to confirmation page
+    // Redirect to confirmation page if there are no errors
     return res.redirect(
       `${BASE_URL}${PATHS.HOLD_CONFIRMATION}/${holdId}?pickupLocation=edd&requestId=${requestId}`
     )

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -85,9 +85,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       )}`
       const formStateQuery = `formState=${JSON.stringify(formState)}`
 
-      const invalidFormRedirectUrl =
-        encodeURI(`${BASE_URL}${PATHS.HOLD_REQUEST}/${holdId}/edd?
-    )}&${formInvalidQuery}&${validatedFieldsQuery}&${formStateQuery}`)
+      const invalidFormRedirectUrl = encodeURI(
+        `${BASE_URL}${PATHS.HOLD_REQUEST}/${holdId}/edd?${formInvalidQuery}&${validatedFieldsQuery}&${formStateQuery}`
+      )
 
       return res.redirect(invalidFormRedirectUrl)
     }

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -17,7 +17,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const { patronId, jsEnabled, ...rest } = JSON.parse(req.body)
+    const { patronId, jsEnabled, ...rest } = req.body
+
     const holdId = req.query.id as string
 
     const [, itemId] = holdId.split("-")
@@ -39,13 +40,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }
     }
 
-    const holdRequestResponse = await postEDDRequest({
+    const eddRequestResponse = await postEDDRequest({
       itemId,
       patronId,
       ...rest,
     })
 
-    const { requestId } = holdRequestResponse
+    const { requestId } = eddRequestResponse
 
     if (!requestId) {
       throw new Error("Malformed response from hold request API")
@@ -62,7 +63,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     // Redirect to confirmation page
     return res.redirect(
-      `${BASE_URL}${PATHS.HOLD_CONFIRMATION}/${holdId}?pickupLocation=edd?requestId=${requestId}`
+      `${BASE_URL}${PATHS.HOLD_CONFIRMATION}/${holdId}?pickupLocation=edd&requestId=${requestId}`
     )
   } catch (error) {
     const { statusText } = error as Response

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -7,6 +7,7 @@ import {
 import {
   initialEDDInvalidFields,
   validateEDDForm,
+  eddFormIsInvalid,
 } from "../../../../../src/utils/holdPageUtils"
 import { BASE_URL, PATHS } from "../../../../../src/config/constants"
 
@@ -71,14 +72,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     // JS-Disabled functionality
-    const formInvalid = !!validatedFields.find(
-      (validatedFieldKey) => validatedFieldKey.isInvalid
-    )
+    const formInvalid = eddFormIsInvalid(validatedFields)
+
     if (formInvalid) {
       return res.redirect(
         `${BASE_URL}${
           PATHS.HOLD_REQUEST
-        }/${holdId}/edd?validatedFields=${JSON.stringify(
+        }/${holdId}/edd?formInvalid=${formInvalid}&validatedFields=${JSON.stringify(
           validatedFields
         )}&formState=${JSON.stringify(formState)}`
       )

--- a/pages/api/hold/request/[id]/index.ts
+++ b/pages/api/hold/request/[id]/index.ts
@@ -17,7 +17,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const { patronId, source, pickupLocation, jsEnabled } = JSON.parse(req.body)
+    const { patronId, source, pickupLocation, jsEnabled } = req.body
 
     const holdId = req.query.id as string
     const [, itemId] = holdId.split("-")
@@ -64,7 +64,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     // Server side redirect in case user has JS disabled
     return res.redirect(
-      `${BASE_URL}${PATHS.HOLD_CONFIRMATION}/${holdId}?pickupLocation=${pickupLocationFromResponse}?requestId=${requestId}`
+      `${BASE_URL}${PATHS.HOLD_CONFIRMATION}/${holdId}?pickupLocation=${pickupLocationFromResponse}&requestId=${requestId}`
     )
   } catch (error) {
     const { statusText } = error as Response

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -83,8 +83,8 @@ export default function EDDRequestPage({
   const router = useRouter()
   const isLoading = useLoading()
 
-  // Populate form values from query string in case of js-disabled server-side redirect
-  const formStateFromQuery = router.query?.formState
+  // Derive form values from query string in case of js-disabled server-side redirect
+  const formStateFromServer = router.query?.formState
     ? JSON.parse(router.query.formState as string)
     : []
 
@@ -93,7 +93,8 @@ export default function EDDRequestPage({
     emailAddress: patronEmail,
     patronId,
     source: item.formattedSourceForHoldRequest,
-    ...formStateFromQuery,
+    // Override values with server form state in the case of a no-js request
+    ...formStateFromServer,
   })
 
   useEffect(() => {

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -84,7 +84,9 @@ export default function EDDRequestPage({
   const isLoading = useLoading()
 
   // Populate form values from query string in case of js-disabled server-side redirect
-  const formStateFromQuery = JSON.parse(router.query?.formState as string)
+  const formStateFromQuery = router.query?.formState
+    ? JSON.parse(router.query.formState as string)
+    : []
 
   const [eddFormState, setEddFormState] = useState<EDDRequestParams>({
     ...initialEDDFormState,

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -41,6 +41,7 @@ import type {
   EDDRequestParams,
   HoldErrorStatus,
   PatronEligibilityStatus,
+  EDDFormValidatedField,
 } from "../../../../src/types/holdPageTypes"
 
 interface EDDRequestPropsType {
@@ -51,6 +52,7 @@ interface EDDRequestPropsType {
   isAuthenticated?: boolean
   errorStatus?: HoldErrorStatus
   patronEligibilityStatus?: PatronEligibilityStatus
+  validatedEDDFields?: EDDFormValidatedField[]
 }
 
 /**
@@ -64,6 +66,7 @@ export default function EDDRequestPage({
   isAuthenticated,
   errorStatus: defaultErrorStatus,
   patronEligibilityStatus: defaultEligibilityStatus,
+  validatedEDDFields,
 }: EDDRequestPropsType) {
   const metadataTitle = `Electronic Delivery Request | ${SITE_NAME}`
   const bib = new Bib(discoveryBibResult)
@@ -180,6 +183,7 @@ export default function EDDRequestPage({
             handleSubmit={postEDDRequest}
             setErrorStatus={setErrorStatus}
             errorStatus={errorStatus}
+            validatedEDDFields={validatedEDDFields}
             holdId={holdId}
           />
         ) : null}
@@ -188,8 +192,9 @@ export default function EDDRequestPage({
   )
 }
 
-export async function getServerSideProps({ params, req, res }) {
+export async function getServerSideProps({ params, req, res, query }) {
   const { id } = params
+  const { validatedEDDFields } = query
 
   // authentication redirect
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
@@ -275,6 +280,7 @@ export async function getServerSideProps({ params, req, res }) {
         patronEmail,
         isAuthenticated,
         patronEligibilityStatus,
+        validatedEDDFields: JSON.parse(validatedEDDFields),
         errorStatus: locationOrEligibilityFetchFailed
           ? "failed"
           : patronEligibilityStatus.status === 401

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -51,8 +51,9 @@ interface EDDRequestPropsType {
   patronEmail?: string
   isAuthenticated?: boolean
   errorStatus?: HoldErrorStatus
+  initialFormState?: EDDRequestParams
   patronEligibilityStatus?: PatronEligibilityStatus
-  validatedEDDFields?: EDDFormValidatedField[]
+  validatedFields?: EDDFormValidatedField[]
 }
 
 /**
@@ -65,8 +66,9 @@ export default function EDDRequestPage({
   patronEmail,
   isAuthenticated,
   errorStatus: defaultErrorStatus,
+  initialFormState = initialEDDFormState,
   patronEligibilityStatus: defaultEligibilityStatus,
-  validatedEDDFields,
+  validatedFields,
 }: EDDRequestPropsType) {
   const metadataTitle = `Electronic Delivery Request | ${SITE_NAME}`
   const bib = new Bib(discoveryBibResult)
@@ -80,8 +82,8 @@ export default function EDDRequestPage({
   )
 
   const [eddFormState, setEddFormState] = useState<EDDRequestParams>({
-    ...initialEDDFormState,
-    emailAddress: patronEmail,
+    ...initialFormState,
+    emailAddress: initialFormState.emailAddress || patronEmail,
     patronId,
     source: item.formattedSourceForHoldRequest,
   })
@@ -183,7 +185,7 @@ export default function EDDRequestPage({
             handleSubmit={postEDDRequest}
             setErrorStatus={setErrorStatus}
             errorStatus={errorStatus}
-            validatedEDDFields={validatedEDDFields}
+            validatedEDDFields={validatedFields}
             holdId={holdId}
           />
         ) : null}
@@ -194,7 +196,7 @@ export default function EDDRequestPage({
 
 export async function getServerSideProps({ params, req, res, query }) {
   const { id } = params
-  const { validatedEDDFields } = query
+  const { validatedFields, formState } = query
 
   // authentication redirect
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
@@ -280,7 +282,8 @@ export async function getServerSideProps({ params, req, res, query }) {
         patronEmail,
         isAuthenticated,
         patronEligibilityStatus,
-        validatedEDDFields: JSON.parse(validatedEDDFields),
+        validatedFields: JSON.parse(validatedFields) || null,
+        initialFormState: JSON.parse(formState) || null,
         errorStatus: locationOrEligibilityFetchFailed
           ? "failed"
           : patronEligibilityStatus.status === 401

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -50,7 +50,6 @@ const EDDRequestForm = ({
   errorStatus,
   validatedEDDFields,
 }: EDDRequestFormProps) => {
-  console.log("validatedEDDFields", typeof validatedEDDFields)
   // Set the invalid fields as an array in state to keep track of the first invalid field for focus on submit
   const [invalidFields, setInvalidFields] = useState(
     validatedEDDFields || initialEDDInvalidFields

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -53,7 +53,7 @@ const EDDRequestForm = ({
 }: EDDRequestFormProps) => {
   const router = useRouter()
 
-  // Get form state from query in case of js-disabled server-side redirect
+  // Derive form validation state from query in case of js-disabled server-side redirect
   const { validatedFields } = router.query
   const serverValidatedFields = validatedFields
     ? JSON.parse(validatedFields as string)

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from "@nypl/design-system-react-components"
 import { useState, createRef, type SyntheticEvent } from "react"
+import { useRouter } from "next/router"
 
 import { BASE_URL, EDD_FORM_FIELD_COPY } from "../../config/constants"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
@@ -18,9 +19,10 @@ import { CopyrightRestrictionsBanner } from "./CopyrightRestrictionsBanner"
 import {
   getUpdatedInvalidFields,
   validateEDDForm,
-  initialEDDInvalidFields,
   isInvalidField,
   holdButtonDisabledStatuses,
+  initialEDDInvalidFields,
+  getFirstInvalidField,
 } from "../../utils/holdPageUtils"
 import type {
   EDDRequestParams,
@@ -48,11 +50,15 @@ const EDDRequestForm = ({
   setErrorStatus,
   holdId,
   errorStatus,
-  validatedEDDFields,
 }: EDDRequestFormProps) => {
+  const router = useRouter()
+
+  // Get form state from query in case of js-disabled server-side redirect
+  const { validatedFields: validatedFieldsFromQuery } = router.query
+
   // Set the invalid fields as an array in state to keep track of the first invalid field for focus on submit
-  const [invalidFields, setInvalidFields] = useState(
-    validatedEDDFields || initialEDDInvalidFields
+  const [invalidFields, setInvalidFields] = useState<EDDFormValidatedField[]>(
+    JSON.parse(validatedFieldsFromQuery as string) || initialEDDInvalidFields
   )
 
   // Create refs for fields that require validation to focus on the first invalid field on submit
@@ -90,9 +96,7 @@ const EDDRequestForm = ({
     setInvalidFields(newValidatedFields)
 
     // Find the first invalid field and focus on it
-    const firstInvalidField = newValidatedFields.find(
-      (validatedFieldKey) => validatedFieldKey.isInvalid
-    )
+    const firstInvalidField = getFirstInvalidField(newValidatedFields)
 
     // Prevent form submission and focus on first invalid field if there is one
     if (firstInvalidField) {

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -37,7 +37,6 @@ interface EDDRequestFormProps {
   setErrorStatus: (errorStatus: HoldErrorStatus) => void
   holdId: string
   errorStatus?: HoldErrorStatus
-  validatedEDDFields?: EDDFormValidatedField[]
 }
 
 /**

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -21,7 +21,7 @@ import {
   validateEDDForm,
   isInvalidField,
   holdButtonDisabledStatuses,
-  initialEDDInvalidFields,
+  defaultValidatedEDDFields,
   getFirstInvalidEDDField,
 } from "../../utils/holdPageUtils"
 import type {
@@ -61,7 +61,7 @@ const EDDRequestForm = ({
 
   // Set the invalid fields as an array in state to keep track of the first invalid field for focus on submit
   const [invalidFields, setInvalidFields] = useState<EDDFormValidatedField[]>(
-    serverValidatedFields || initialEDDInvalidFields
+    serverValidatedFields || defaultValidatedEDDFields
   )
 
   // Create refs for fields that require validation to focus on the first invalid field on submit

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -25,6 +25,7 @@ import {
 import type {
   EDDRequestParams,
   HoldErrorStatus,
+  EDDFormValidatedField,
 } from "../../types/holdPageTypes"
 
 interface EDDRequestFormProps {
@@ -34,6 +35,7 @@ interface EDDRequestFormProps {
   setErrorStatus: (errorStatus: HoldErrorStatus) => void
   holdId: string
   errorStatus?: HoldErrorStatus
+  validatedEDDFields?: EDDFormValidatedField[]
 }
 
 /**
@@ -46,9 +48,13 @@ const EDDRequestForm = ({
   setErrorStatus,
   holdId,
   errorStatus,
+  validatedEDDFields,
 }: EDDRequestFormProps) => {
+  console.log("validatedEDDFields", typeof validatedEDDFields)
   // Set the invalid fields as an array in state to keep track of the first invalid field for focus on submit
-  const [invalidFields, setInvalidFields] = useState(initialEDDInvalidFields)
+  const [invalidFields, setInvalidFields] = useState(
+    validatedEDDFields || initialEDDInvalidFields
+  )
 
   // Create refs for fields that require validation to focus on the first invalid field on submit
   const [validatedInputRefs] = useState(

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -22,7 +22,7 @@ import {
   isInvalidField,
   holdButtonDisabledStatuses,
   initialEDDInvalidFields,
-  getFirstInvalidField,
+  getFirstInvalidEDDField,
 } from "../../utils/holdPageUtils"
 import type {
   EDDRequestParams,
@@ -54,11 +54,14 @@ const EDDRequestForm = ({
   const router = useRouter()
 
   // Get form state from query in case of js-disabled server-side redirect
-  const { validatedFields: validatedFieldsFromQuery } = router.query
+  const { validatedFields } = router.query
+  const serverValidatedFields = validatedFields
+    ? JSON.parse(validatedFields as string)
+    : null
 
   // Set the invalid fields as an array in state to keep track of the first invalid field for focus on submit
   const [invalidFields, setInvalidFields] = useState<EDDFormValidatedField[]>(
-    JSON.parse(validatedFieldsFromQuery as string) || initialEDDInvalidFields
+    serverValidatedFields || initialEDDInvalidFields
   )
 
   // Create refs for fields that require validation to focus on the first invalid field on submit
@@ -96,7 +99,7 @@ const EDDRequestForm = ({
     setInvalidFields(newValidatedFields)
 
     // Find the first invalid field and focus on it
-    const firstInvalidField = getFirstInvalidField(newValidatedFields)
+    const firstInvalidField = getFirstInvalidEDDField(newValidatedFields)
 
     // Prevent form submission and focus on first invalid field if there is one
     if (firstInvalidField) {

--- a/src/server/api/hold.ts
+++ b/src/server/api/hold.ts
@@ -188,6 +188,7 @@ export async function fetchHoldDetails(
   try {
     const client = await nyplApiClient()
     const holdDetailsResult = await client.get(`/hold-requests/${requestId}`)
+
     const { id, pickupLocation, patron } = holdDetailsResult.data
 
     return {

--- a/src/utils/holdPageUtils.ts
+++ b/src/utils/holdPageUtils.ts
@@ -42,8 +42,6 @@ export const getUpdatedInvalidFields = (
   prevInvalidFields: EDDFormValidatedField[]
 ): EDDFormValidatedField[] => {
   return prevInvalidFields.map((field) => {
-    console.log("fieldName", fieldName)
-    console.log("field.key", field.key)
     if (field.key === fieldName) {
       switch (field.key) {
         // Validate email field

--- a/src/utils/holdPageUtils.ts
+++ b/src/utils/holdPageUtils.ts
@@ -42,6 +42,8 @@ export const getUpdatedInvalidFields = (
   prevInvalidFields: EDDFormValidatedField[]
 ): EDDFormValidatedField[] => {
   return prevInvalidFields.map((field) => {
+    console.log("fieldName", fieldName)
+    console.log("field.key", field.key)
     if (field.key === fieldName) {
       switch (field.key) {
         // Validate email field

--- a/src/utils/holdPageUtils.ts
+++ b/src/utils/holdPageUtils.ts
@@ -23,7 +23,7 @@ export const initialEDDFormState: EDDRequestParams = {
 }
 
 // Initial state for invalid fields in the EDD form to keep track of the first invalid field for focus on submit
-export const initialEDDInvalidFields: EDDFormValidatedField[] = [
+export const defaultValidatedEDDFields: EDDFormValidatedField[] = [
   { key: "emailAddress", isInvalid: false },
   { key: "startPage", isInvalid: false },
   { key: "endPage", isInvalid: false },

--- a/src/utils/holdPageUtils.ts
+++ b/src/utils/holdPageUtils.ts
@@ -72,5 +72,14 @@ export const validateEDDForm = (
 
 export const isInvalidField = (
   fieldName: string,
-  invalidFields: EDDFormValidatedField[]
-): boolean => invalidFields.find((field) => field.key === fieldName).isInvalid
+  validatedFields: EDDFormValidatedField[]
+): boolean => validatedFields.find((field) => field.key === fieldName).isInvalid
+
+export const getFirstInvalidEDDField = (
+  validatedFields: EDDFormValidatedField[]
+): EDDFormValidatedField =>
+  validatedFields.find((validatedFieldKey) => validatedFieldKey.isInvalid)
+
+export const eddFormIsInvalid = (
+  validatedFields: EDDFormValidatedField[]
+): boolean => !!getFirstInvalidEDDField(validatedFields)

--- a/src/utils/utilsTests/holdPageUtils.test.ts
+++ b/src/utils/utilsTests/holdPageUtils.test.ts
@@ -1,5 +1,5 @@
 import {
-  initialEDDInvalidFields,
+  defaultValidatedEDDFields,
   getUpdatedInvalidFields,
 } from "../holdPageUtils"
 
@@ -7,7 +7,11 @@ describe("holdPageUtils", () => {
   describe("getUpdatedInvalidFields", () => {
     it("returns correctly updated field validation statuses for different inputs", () => {
       expect(
-        getUpdatedInvalidFields("emailAddress", "test", initialEDDInvalidFields)
+        getUpdatedInvalidFields(
+          "emailAddress",
+          "test",
+          defaultValidatedEDDFields
+        )
       ).toStrictEqual([
         { isInvalid: true, key: "emailAddress" },
         { isInvalid: false, key: "startPage" },
@@ -18,7 +22,7 @@ describe("holdPageUtils", () => {
         getUpdatedInvalidFields(
           "emailAddress",
           "test@test.com",
-          initialEDDInvalidFields
+          defaultValidatedEDDFields
         )
       ).toStrictEqual([
         { isInvalid: false, key: "emailAddress" },
@@ -27,7 +31,7 @@ describe("holdPageUtils", () => {
         { isInvalid: false, key: "chapterTitle" },
       ])
       expect(
-        getUpdatedInvalidFields("emailAddress", "", initialEDDInvalidFields)
+        getUpdatedInvalidFields("emailAddress", "", defaultValidatedEDDFields)
       ).toStrictEqual([
         { isInvalid: true, key: "emailAddress" },
         { isInvalid: false, key: "startPage" },
@@ -35,7 +39,7 @@ describe("holdPageUtils", () => {
         { isInvalid: false, key: "chapterTitle" },
       ])
       expect(
-        getUpdatedInvalidFields("startPage", "", initialEDDInvalidFields)
+        getUpdatedInvalidFields("startPage", "", defaultValidatedEDDFields)
       ).toStrictEqual([
         { isInvalid: false, key: "emailAddress" },
         { isInvalid: true, key: "startPage" },
@@ -43,7 +47,7 @@ describe("holdPageUtils", () => {
         { isInvalid: false, key: "chapterTitle" },
       ])
       expect(
-        getUpdatedInvalidFields("endPage", "", initialEDDInvalidFields)
+        getUpdatedInvalidFields("endPage", "", defaultValidatedEDDFields)
       ).toStrictEqual([
         { isInvalid: false, key: "emailAddress" },
         { isInvalid: false, key: "startPage" },
@@ -51,7 +55,7 @@ describe("holdPageUtils", () => {
         { isInvalid: false, key: "chapterTitle" },
       ])
       expect(
-        getUpdatedInvalidFields("chapterTitle", "", initialEDDInvalidFields)
+        getUpdatedInvalidFields("chapterTitle", "", defaultValidatedEDDFields)
       ).toStrictEqual([
         { isInvalid: false, key: "emailAddress" },
         { isInvalid: false, key: "startPage" },


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4405](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4405)

## This PR does the following:

- Adds server-side validation on EDD hold requests
- Fixes bugs causing errors on No-js hold requests (related to JSON parsing/query string formatting)
- Adds formState and validatedFields query params to populate field values/validation state on refreshes/js-disabled redirects.
- Renames initialEDDInvalidFields to defaultValidatedEDDFields

## How has this been tested?

- Added unit tests

## Accessibility concerns or updates

- I thought about adding autofocus when js is disabled but it ended up adding a bunch of code, so not sure if it's worth it. Let me know if you think this is important (will check with Clare as well) and I'll add it back.

### Checklist:

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4405]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ