### PR TITLE
HOTFIX - On-site hold bug fix

### DIFF
--- a/pages/api/hold/request/[id]/index.ts
+++ b/pages/api/hold/request/[id]/index.ts
@@ -17,7 +17,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const { patronId, source, pickupLocation, jsEnabled } = req.body
+    const { patronId, source, pickupLocation, jsEnabled } =
+      typeof req.body === "string" ? JSON.parse(req.body) : req.body
 
     const holdId = req.query.id as string
     const [, itemId] = holdId.split("-")


### PR DESCRIPTION
This is a small bug fix for an issue I introduced in the no-js work that leads to a server error on on-site hold requests.

This PR adds a ternary (present in the edd route) that checks if the request body is stringified, which it isn't in the case of no-js.