### PR TITLE
HOTFIX - No results in DRB sidebar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+### [1.3.10] Hotfix 2025-1-8
+
+- Hotfix for bug on production where no results are appearing in DRB sidebar. Caused by implicit adding of version number to endpoint url.
 
 ## [1.3.9] 2025-01-07
 

--- a/src/components/Links/ExternalLink/ExternalLink.tsx
+++ b/src/components/Links/ExternalLink/ExternalLink.tsx
@@ -41,6 +41,8 @@ const ExternalLink = ({
       role="link"
       aria-disabled={disabled}
       tabIndex={disabled ? -1 : 0}
+      // TODO: Temporary fix for a DS issue where link text spills outside the parent container
+      whiteSpace="unset"
     >
       {children}
     </DSLink>

--- a/src/server/api/search.ts
+++ b/src/server/api/search.ts
@@ -52,7 +52,7 @@ export async function fetchResults(
   //  - aggregations
   //  - drb results
   const client = await nyplApiClient()
-  const drbClient = await nyplApiClient({ apiName: DRB_API_NAME })
+  const drbClient = await nyplApiClient({ apiName: DRB_API_NAME, version: "" })
   const [resultsResponse, aggregationsResponse, drbResultsResponse] =
     await Promise.allSettled([
       client.get(`${DISCOVERY_API_SEARCH_ROUTE}${resultsQuery}`),

--- a/src/server/nyplApiClient/index.ts
+++ b/src/server/nyplApiClient/index.ts
@@ -29,9 +29,11 @@ const nyplApiClient = async ({
   if (CACHE.clients[`${apiName}${version}`]) {
     return CACHE.clients[`${apiName}${version}`]
   }
-
-  const baseUrl =
-    appConfig.apiEndpoints[apiName][appEnvironment] + "/" + version
+  // Hotfix to avoid adding v0.1 to DRB endpoint url.
+  // TODO: Investigate the configuring of alternate versions of same endpoint without implicit appending of version number to url
+  const baseUrl = `${appConfig.apiEndpoints[apiName][appEnvironment]}${
+    version.length ? `/${version}` : ""
+  }`
 
   let decryptedId: string
   let decryptedSecret: string


### PR DESCRIPTION
Hotfix for a bug on production where no results are appearing in the DRB sidebar.

This was introduced in the latest My Account release with the implicit setting of the "v0.1" suffix to all urls passed to the api client. My fix addresses this by allowing the passing of an empty version as a temporary solution.

I added a TODO to revisit this later.