### PR TITLE
Fix Item id not getting passed at time of EDD hold post

### DIFF
--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -57,9 +57,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     const eddRequestResponse = await postEDDRequest({
+      ...formState,
       itemId,
       patronId,
-      ...formState,
     })
 
     const { requestId } = eddRequestResponse


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4460](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4460)

## This PR does the following:

- Fixes a bug where the item id was getting overridden by the edd params at the time of the post request.

## How has this been tested?

- No tests but I'll open a ticket to revisit adding test coverage to API routes as a follow-up.

## Accessibility concerns or updates

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4460]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ