### PR TITLE
SCC-4462 - Add patron authentication to Hold API routes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added HoldContactButton component and update error copy per VQA requests (SCC-4427)
 - Added email address field prepopulation on EDD Request form (SCC-4407)
 - Added server validation and form state prepopulation (SCC-4405)
+- Added patron authentication to hold api routes (SCC-4462)
 
 ### Updated
 

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -297,7 +297,9 @@ describe("EDD Request page", () => {
           isAuthenticated={true}
         />
       )
+    })
 
+    it("shows an error when there is a 500 error response from the edd api", async () => {
       global.fetch = jest.fn().mockImplementationOnce(() =>
         Promise.resolve({
           status: 500,
@@ -306,9 +308,38 @@ describe("EDD Request page", () => {
       )
 
       await fillRequiredEDDFormFields()
+
+      fireEvent(screen.getByText("Submit request"), new MouseEvent("click"))
+      await waitFor(() => {
+        expect(screen.getByTestId("hold-request-error")).toBeInTheDocument()
+      })
+
+      expect(
+        screen.getByText("Request failed.", { exact: false })
+      ).toBeInTheDocument()
+
+      expect(
+        screen.queryByText(
+          "We were unable to process your request at this time. Please ",
+          { exact: false }
+        )
+      ).toBeInTheDocument()
+
+      expect(
+        screen.getByRole("button", { name: "contact us" })
+      ).toBeInTheDocument()
     })
 
-    it("shows an error when the request fails", async () => {
+    it("shows an error when there is a invalid patron response response from the edd api", async () => {
+      global.fetch = jest.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 403,
+          json: () => Promise.resolve({ success: true }),
+        })
+      )
+
+      await fillRequiredEDDFormFields()
+
       fireEvent(screen.getByText("Submit request"), new MouseEvent("click"))
       await waitFor(() => {
         expect(screen.getByTestId("hold-request-error")).toBeInTheDocument()
@@ -331,7 +362,17 @@ describe("EDD Request page", () => {
     })
 
     it("populates the feedback form with the call number and appropriate copy when the request fails", async () => {
+      global.fetch = jest.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 500,
+          json: () => Promise.resolve({ success: true }),
+        })
+      )
+
+      await fillRequiredEDDFormFields()
+
       fireEvent(screen.getByText("Submit request"), new MouseEvent("click"))
+
       await waitFor(() => {
         expect(screen.getByTestId("hold-request-error")).toBeInTheDocument()
       })

--- a/__test__/pages/hold/holdRequestPage.test.tsx
+++ b/__test__/pages/hold/holdRequestPage.test.tsx
@@ -221,7 +221,9 @@ describe("Hold Request page", () => {
           isAuthenticated={true}
         />
       )
+    })
 
+    it("shows an error when there is a 500 error response from the hold api", async () => {
       global.fetch = jest.fn().mockImplementationOnce(() =>
         Promise.resolve({
           status: 500,
@@ -233,9 +235,40 @@ describe("Hold Request page", () => {
         screen.getByText("Submit request"),
         new MouseEvent("click")
       )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("hold-request-error")).toBeInTheDocument()
+      })
+
+      expect(
+        screen.getByText("Request failed.", { exact: false })
+      ).toBeInTheDocument()
+
+      expect(
+        screen.queryByText(
+          "We were unable to process your request at this time. Please ",
+          { exact: false }
+        )
+      ).toBeInTheDocument()
+
+      expect(
+        screen.getByRole("button", { name: "contact us" })
+      ).toBeInTheDocument()
     })
 
-    it("shows an error when there is a bad response from the hold api", async () => {
+    it("shows an error when there is a invalid patron response response from the hold api", async () => {
+      global.fetch = jest.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 403,
+          json: () => Promise.resolve({ success: false }),
+        })
+      )
+
+      await fireEvent(
+        screen.getByText("Submit request"),
+        new MouseEvent("click")
+      )
+
       await waitFor(() => {
         expect(screen.getByTestId("hold-request-error")).toBeInTheDocument()
       })
@@ -257,6 +290,18 @@ describe("Hold Request page", () => {
     })
 
     it("populates the feedback form with the call number and appropriate copy when the request fails", async () => {
+      global.fetch = jest.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 500,
+          json: () => Promise.resolve({ success: false }),
+        })
+      )
+
+      await fireEvent(
+        screen.getByText("Submit request"),
+        new MouseEvent("click")
+      )
+
       await waitFor(() => {
         expect(screen.getByTestId("hold-request-error")).toBeInTheDocument()
       })

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -16,12 +16,6 @@ import { BASE_URL, PATHS } from "../../../../../src/config/constants"
  * Default API route handler for EDD requests
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
-  const cookiePatronId = patronTokenResponse.decodedPatron?.sub
-  if (!cookiePatronId) {
-    return res.status(403).json("EDD Request API - No authenticated patron")
-  }
-
   if (req.method !== "POST") {
     return res.status(500).json({
       error: "Please use a POST request for the EDD Request API endpoint",
@@ -31,6 +25,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const { patronId, jsEnabled, ...rest } =
       typeof req.body === "string" ? JSON.parse(req.body) : req.body
+
+    const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+    const cookiePatronId = patronTokenResponse.decodedPatron?.sub
+
+    // Return a 403 if patron cookie does not patch patron id in request
+    if (!cookiePatronId || cookiePatronId !== patronId) {
+      return res.status(403).json("EDD Request API - No authenticated patron")
+    }
+
     const formState = rest
     const holdId = req.query.id as string
 

--- a/pages/api/hold/request/[id]/edd.ts
+++ b/pages/api/hold/request/[id]/edd.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next"
+import initializePatronTokenAuth from "../../../../../src/server/auth"
 
 import {
   postEDDRequest,
@@ -15,6 +16,12 @@ import { BASE_URL, PATHS } from "../../../../../src/config/constants"
  * Default API route handler for EDD requests
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+  const cookiePatronId = patronTokenResponse.decodedPatron?.sub
+  if (!cookiePatronId) {
+    return res.status(403).json("EDD Request API - No authenticated patron")
+  }
+
   if (req.method !== "POST") {
     return res.status(500).json({
       error: "Please use a POST request for the EDD Request API endpoint",

--- a/pages/api/hold/request/[id]/index.ts
+++ b/pages/api/hold/request/[id]/index.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next"
+import initializePatronTokenAuth from "../../../../../src/server/auth"
 
 import {
   postHoldRequest,
@@ -10,6 +11,12 @@ import { BASE_URL, PATHS } from "../../../../../src/config/constants"
  * Default API route handler for Hold requests
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+  const cookiePatronId = patronTokenResponse.decodedPatron?.sub
+  if (!cookiePatronId) {
+    return res.status(403).json("Hold Request API - No authenticated patron")
+  }
+
   if (req.method !== "POST") {
     return res.status(500).json({
       error: "Please use a POST request for the Hold Request API endpoint",

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -136,6 +136,10 @@ export default function EDDRequestPage({
           setErrorStatus("patronIneligible")
           setPatronEligibilityStatus(responseJson?.patronEligibilityStatus)
           break
+        case 403:
+          setFormPosting(false)
+          setErrorStatus("failed")
+          break
         case 500:
           handleServerHoldPostError(responseJson.error)
           break

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -118,6 +118,10 @@ export default function HoldRequestPage({
           setErrorStatus("patronIneligible")
           setPatronEligibilityStatus(responseJson?.patronEligibilityStatus)
           break
+        case 403:
+          setFormPosting(false)
+          setErrorStatus("failed")
+          break
         case 500:
           handleServerHoldPostError(responseJson.error)
           break


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4462](https://newyorkpubliclibrary.atlassian.net/browse/SCC-SCC-4462)

## This PR does the following:

- Adds patron authentication to hold api routes (returning a 403 status)
- Handles the error on the client side by setting an invalid status if a 403 status is returned.

## How has this been tested?

- Added unit tests.

## Accessibility concerns or updates

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4462]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ