### PR TITLE
Hotfix for Duplicated "View All" Loading Text on the Bib Page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [1.3.11] Hotfix 2025-1-17
+
+- Fix duplicate View All loading text (SCC-4467).
+
 ### [1.3.11] Hotfix 2025-1-13
 
 - Fix nyplApiClient cache, so cache keys are updated with api version numbers.

--- a/__test__/pages/bib/bibPage.test.tsx
+++ b/__test__/pages/bib/bibPage.test.tsx
@@ -314,9 +314,7 @@ describe("Bib Page Item Table", () => {
     )
     await userEvent.click(screen.getByText("View all 26 items").closest("a"))
     expect(
-      screen.queryAllByText(
-        "Loading all 26 items. This may take a few moments..."
-      )[0]
+      screen.queryByText("Loading all 26 items. This may take a few moments...")
     ).toBeInTheDocument()
   })
 

--- a/src/components/ItemTable/ItemTableControls.tsx
+++ b/src/components/ItemTable/ItemTableControls.tsx
@@ -63,19 +63,15 @@ const ItemTableControls = ({
             indicatorType="circular"
             isIndeterminate
             marginLeft="auto"
+            labelPlacement="right"
             sx={{
-              "> div": {
-                display: "flex",
-                justifyContent: "flex-start",
-                alignItems: "center",
-                flexDirection: "row",
-                "> div": {
-                  marginRight: "var(--nypl-space-xs)",
-                },
-              },
+              "div[role=progressbar]": { marginRight: "xs" },
               label: {
-                fontWeight: "var(--nypl-fontWeights-medium)",
-                fontSize: "var(--nypl-fontSizes-desktop-body-body2)",
+                fontWeight: "medium",
+                fontSize: {
+                  base: "mobile.body.body2",
+                  md: "desktop.body.body2",
+                },
                 marginBottom: 0,
               },
             }}

--- a/src/components/ItemTable/ItemTableControls.tsx
+++ b/src/components/ItemTable/ItemTableControls.tsx
@@ -56,38 +56,30 @@ const ItemTableControls = ({
       ) : null}
       {bib.showViewAllItemsLink(filtersAreApplied) &&
         (itemsLoading && viewAllExpanded ? (
-          <Box
-            ml="auto"
-            display="flex"
-            justifyContent="flex-start"
-            alignItems="center"
-          >
-            <ProgressIndicator
-              id="bib-all-items-loading"
-              labelText={viewAllLoadingMessage}
-              size="small"
-              indicatorType="circular"
-              mr="xs"
-              isIndeterminate
-            />
-            <Label
-              id="bib-all-items-loading-label"
-              htmlFor="bib-all-items-loading"
-              ref={viewAllLoadingTextRef}
-              fontSize={{
-                base: "mobile.body.body1",
-                md: "desktop.body.body1",
-              }}
-              fontWeight="medium"
-              mb={0}
-              // Label component does not expect tabIndex prop, so we are ignoring the typescript error that pops up.
-              // Add any additional props above this for typescript validation.
-              // @ts-expect-error
-              tabIndex={-1}
-            >
-              {viewAllLoadingMessage}
-            </Label>
-          </Box>
+          <ProgressIndicator
+            id="bib-all-items-loading"
+            labelText={viewAllLoadingMessage}
+            size="small"
+            indicatorType="circular"
+            isIndeterminate
+            marginLeft="auto"
+            sx={{
+              "> div": {
+                display: "flex",
+                justifyContent: "flex-start",
+                alignItems: "center",
+                flexDirection: "row",
+                "> div": {
+                  marginRight: "var(--nypl-space-xs)",
+                },
+              },
+              label: {
+                fontWeight: "var(--nypl-fontWeights-medium)",
+                fontSize: "var(--nypl-fontSizes-desktop-body-body2)",
+                marginBottom: 0,
+              },
+            }}
+          />
         ) : !itemsLoading ? (
           <>
             <RCLink


### PR DESCRIPTION
This hotfix resolves an issue where the "View All" loading text is being rendered twice on the Bib page on production. The issue arose due to a recent change in the design system, which led to the label component being rendered twice.

Changes Made:

- Removed the duplicate label component that was being rendered, ensuring the "View All" loading text is only displayed once.
- Styled the ProgressIndicator component to match the previous design, ensuring visual consistency with the old styles.