### PR TITLE
optional chaining on supp content

### DIFF
--- a/src/models/Bib.ts
+++ b/src/models/Bib.ts
@@ -47,7 +47,7 @@ export default class Bib {
     this.subjectHeadings = result.subjectHeadings || null
     this.findingAid =
       result.supplementaryContent?.find(
-        (el) => el.label.toLocaleLowerCase() === "finding aid"
+        (el) => el.label?.toLocaleLowerCase() === "finding aid"
       )?.url || null
     this.items = this.getItemsFromResult(result)
   }


### PR DESCRIPTION
we expected supplementary content to have labels and they don't always. heres a hotfix.