### PR TITLE
Hotfix finding aid

### DIFF
--- a/src/components/RefineSearch/RefineSearch.tsx
+++ b/src/components/RefineSearch/RefineSearch.tsx
@@ -159,7 +159,7 @@ const RefineSearch = ({
           buttonType="secondary"
           backgroundColor="ui.white"
         >
-          <Icon />
+          <Icon size="large" align="left" name="contentFilterList" />
           Filter results
         </Button>
       ) : (

--- a/src/models/Bib.ts
+++ b/src/models/Bib.ts
@@ -47,7 +47,7 @@ export default class Bib {
     this.subjectHeadings = result.subjectHeadings || null
     this.findingAid =
       result.supplementaryContent?.find(
-        (el) => el.label.toLocaleLowerCase() === "finding aid"
+        (el) => el.label?.toLocaleLowerCase() === "finding aid"
       )?.url || null
     this.items = this.getItemsFromResult(result)
   }

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -5,7 +5,6 @@ import type {
   FieldMapping,
   AnnotatedMarcField,
   BibDetailURL,
-  SubjectHeadingDetail,
   AnnotatedMarc,
   AnyBibDetail,
 } from "../types/bibDetailsTypes"

--- a/src/models/modelTests/Bib.test.ts
+++ b/src/models/modelTests/Bib.test.ts
@@ -24,6 +24,18 @@ describe("Bib model", () => {
           },
         ],
       })
+      it("can handle supp content with no label", () => {
+        const bib = new Bib({
+          ...bibWithItems.resource,
+          supplementaryContent: [
+            {
+              "@type": "nypl:SupplementaryContent",
+              url: "http://archives.nypl.org/scm/29990",
+            },
+          ],
+        })
+        expect(bib.findingAid).toBe(null)
+      })
       it("initializes the finding aid when present", () => {
         expect(findingAidBib.findingAid).toBe(
           "http://archives.nypl.org/scm/29990"

--- a/src/types/bibTypes.ts
+++ b/src/types/bibTypes.ts
@@ -65,7 +65,7 @@ export interface Note {
 
 interface SupplementaryContent {
   "@type": string
-  label: string
+  label?: string
   url: string
 }
 


### PR DESCRIPTION
- Back merge hotfix to supplementary content bug
  -  update types and tests for missing label supplementary content fields
- add missing icon to filter results button (the please give a name to this icon warning is totally gumming up our logs).
  - It looks fine to me, but I can also just remove it if we don't want to do this update so ad hoc. I honestly think no one will even notice. It's pretty innocuous and shares styles with all the other icon buttons.