### PR TITLE
HOTFIX: Resolve delivery location fetch issue for off-site items with legacy barcode identifiers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] Hotfix 2025-1-23
+
+- Fix (derived from DFE) for failing delivery location fetch for off-site items with legacy barcode identifier.
+
 ## [1.4.0] 2025-01-22
 
 ## Release Notes

--- a/pages/hold/confirmation/[id].tsx
+++ b/pages/hold/confirmation/[id].tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../src/config/constants"
 
 import Bib from "../../../src/models/Bib"
+import Item from "../../../src/models/Item"
 
 import RCLink from "../../../src/components/Links/RCLink/RCLink"
 import ExternalLink from "../../../src/components/Links/RCLink/RCLink"
@@ -163,14 +164,15 @@ export async function getServerSideProps({ params, req, res, query }) {
       throw new Error("No item id in url")
     }
     const { discoveryBibResult } = await fetchBib(bibId, {}, itemId)
+    const discoveryItemResult = discoveryBibResult?.items?.[0]
 
     // Get the item barcode's directly from discoveryBibResult to avoid initializing the entire Item model.
-    const itemBarcode = discoveryBibResult?.items?.[0]?.["idBarcode"]?.[0]
+    const bib = new Bib(discoveryBibResult)
+    const item = new Item(discoveryItemResult, bib)
+    const itemBarcode = item?.barcode
 
     if (!itemBarcode) {
-      throw new Error(
-        "Hold Confirmation Page - Item barcode not found in discoveryBibResult"
-      )
+      throw new Error("Hold Confirmation Page - Item barcode not found")
     }
 
     const { deliveryLocations } = await fetchDeliveryLocations(

--- a/pages/hold/confirmation/[id].tsx
+++ b/pages/hold/confirmation/[id].tsx
@@ -166,7 +166,6 @@ export async function getServerSideProps({ params, req, res, query }) {
     const { discoveryBibResult } = await fetchBib(bibId, {}, itemId)
     const discoveryItemResult = discoveryBibResult?.items?.[0]
 
-    // Get the item barcode's directly from discoveryBibResult to avoid initializing the entire Item model.
     const bib = new Bib(discoveryBibResult)
     const item = new Item(discoveryItemResult, bib)
     const itemBarcode = item?.barcode

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -238,6 +238,7 @@ export async function getServerSideProps({ params, req, res }) {
     if (!discoveryItemResult) {
       throw new Error("Hold Page - Item not found")
     }
+    console.log("discoveryItemResult", discoveryItemResult)
 
     const bib = new Bib(discoveryBibResult)
     const item = new Item(discoveryItemResult, bib)

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -238,7 +238,6 @@ export async function getServerSideProps({ params, req, res }) {
     if (!discoveryItemResult) {
       throw new Error("Hold Page - Item not found")
     }
-    console.log("discoveryItemResult", discoveryItemResult)
 
     const bib = new Bib(discoveryBibResult)
     const item = new Item(discoveryItemResult, bib)

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -158,7 +158,6 @@ export const AVAILABILITY_KEYS = {
   ONSITE_NO_FINDING_AID_NO_AEON: "noFindingAidNoAeonOnsite",
   RECAP_NO_FINDING_AID_NO_AEON: "noFindingAidNoAeonRecap",
 }
-
 export const HOLD_PAGE_HEADING = "Request for on-site use"
 export const EDD_PAGE_HEADING = "Request scan"
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -158,6 +158,7 @@ export const AVAILABILITY_KEYS = {
   ONSITE_NO_FINDING_AID_NO_AEON: "noFindingAidNoAeonOnsite",
   RECAP_NO_FINDING_AID_NO_AEON: "noFindingAidNoAeonRecap",
 }
+
 export const HOLD_PAGE_HEADING = "Request for on-site use"
 export const EDD_PAGE_HEADING = "Request scan"
 

--- a/src/models/Item.ts
+++ b/src/models/Item.ts
@@ -10,6 +10,8 @@ import {
   defaultNYPLLocation,
   partnerDefaultLocation,
   locationEndpointsMap,
+  getIdentifiers,
+  identifiersArray,
 } from "../utils/itemUtils"
 import { appConfig } from "../config/config"
 import ItemAvailability from "./ItemAvailability"
@@ -53,7 +55,7 @@ export default class Item {
     this.format = item.formatLiteral?.length
       ? item.formatLiteral[0]
       : bib.materialType
-    this.barcode = item.idBarcode?.length ? item.idBarcode[0] : null
+    this.barcode = this.getBarcodeFromItem(item)
     this.location = this.getLocationFromItem(item)
     this.aeonUrl = item.aeonUrl?.length ? item.aeonUrl[0] : null
     this.dueDate = item.dueDate?.length ? item.dueDate[0] : null
@@ -114,6 +116,21 @@ export default class Item {
       location.endpoint = locationEndpointsMap[locationKey] || null
     }
     return location
+  }
+
+  // This logic was adapted from DFE as part of a hotfix (delivery locations not loading for some off-site partner items)
+  // TODO: Refactor this as a follow-up if necessary
+  getBarcodeFromItem(item: DiscoveryItemResult): string {
+    if (item.idBarcode?.length) {
+      return item.idBarcode[0]
+    }
+
+    const identifiers = getIdentifiers(item?.identifier, identifiersArray)
+
+    if (identifiers?.barcode) {
+      return identifiers.barcode
+    }
+    return null
   }
 
   // Determine if item is Non-NYPL ReCAP by existence of "Recap" string in item source attribute

--- a/src/utils/itemUtils.ts
+++ b/src/utils/itemUtils.ts
@@ -62,7 +62,7 @@ const itemIdentifierTypeMappings = {
 
 // Copied from DFE as part of a hotfix (delivery locations not loading for some off-site partner items)
 // TODO: Refactor this as a follow-up if necessary
-export const identifiersArray = [{ name: "barcode", value: "" }]
+export const identifiersArray = [{ name: "barcode", value: "bf:Barcode" }]
 
 /**
  * Given an identifier value, returns same identifier transformed to entity representation.

--- a/src/utils/itemUtils.ts
+++ b/src/utils/itemUtils.ts
@@ -26,3 +26,107 @@ export const locationEndpointsMap: Record<ItemLocationKey, string> = {
 export function locationLabelToKey(label: string): ItemLocationKey {
   return label.replace(/SASB/, "Schwarzman").split(" ")[0] as ItemLocationKey
 }
+
+// Copied from DFE as part of a hotfix (delivery locations not loading for some off-site partner items)
+// TODO: Refactor this as a follow-up if necessary
+const itemIdentifierTypeMappings = {
+  barcode: {
+    type: "bf:Barcode",
+    legacyUrnPrefix: "urn:barcode:",
+  },
+  bnum: {
+    type: "nypl:Bnumber",
+    legacyUrnPrefix: "urn:bnum:",
+  },
+  callnumber: {
+    type: "bf:ShelfMark",
+    legacyUrnPrefix: "urn:callnumber:",
+  },
+  isbn: {
+    type: "bf:Isbn",
+    legacyUrnPrefix: "urn:isbn:",
+  },
+  issn: {
+    type: "bf:Issn",
+    legacyUrnPrefix: "urn:issn:",
+  },
+  lccn: {
+    type: "bf:Lccn",
+    legacyUrnPrefix: "urn:lccn:",
+  },
+  oclc: {
+    type: "nypl:Oclc",
+    legacyUrnPrefix: "urn:oclc:",
+  },
+}
+
+// Copied from DFE as part of a hotfix (delivery locations not loading for some off-site partner items)
+// TODO: Refactor this as a follow-up if necessary
+export const identifiersArray = [{ name: "barcode", value: "" }]
+
+/**
+ * Given an identifier value, returns same identifier transformed to entity representation.
+ *
+ * Copied from DFE as part of a hotfix (delivery locations not loading for some off-site partner items)
+ * TODO: Refactor this as a follow-up if necessary
+ */
+export const ensureLegacyIdentifierIsEntity = (identifier) => {
+  // If API has given us urn: prefixed identifiers..
+  if (typeof identifier === "string") {
+    // Convert them to entitys:
+    return Object.keys(itemIdentifierTypeMappings)
+      .filter(
+        (name) =>
+          identifier.indexOf(
+            itemIdentifierTypeMappings[name].legacyUrnPrefix
+          ) === 0
+      )
+      .map((name) => ({
+        "@type": itemIdentifierTypeMappings[name].type,
+        "@value": identifier.replace(
+          itemIdentifierTypeMappings[name].legacyUrnPrefix,
+          ""
+        ),
+      }))
+      .pop()
+  }
+
+  // Otherwise we assume it's already an entity:
+  return identifier
+}
+
+/**
+ * Given an array of identifier entries (either serialized as entities or
+ * string literals), returns the identifers (as entities) that match the
+ * given rdf:type
+ *
+ * Copied from DFE as part of a hotfix (delivery locations not loading for some off-site partner items)
+ * TODO: Refactor this as a follow-up if necessary
+ */
+const getIdentifierEntitiesByType = (identifiersArray, type) => {
+  return identifiersArray
+    .map(ensureLegacyIdentifierIsEntity)
+    .filter((identifier) => identifier && identifier["@type"] === type)
+}
+
+/**
+ * Gets into the array of the identifiers of an item. And then targets the identifiers we need
+ * by the prefixes in neededTagsArray. At last, extracts the identifiers and returns them.
+ *
+ * Copied from DFE as part of a hotfix (delivery locations not loading for some off-site partner items)
+ * TODO: Refactor this as a follow-up if necessary
+ */
+export const getIdentifiers = (identifiersArray, neededTagsArray) => {
+  if (!Array.isArray(identifiersArray)) return {}
+  return neededTagsArray.reduce((identifierMap, neededTag) => {
+    const matches = getIdentifierEntitiesByType(
+      identifiersArray,
+      neededTag.value
+    )
+    if (matches && matches.length > 0)
+      return Object.assign(identifierMap, {
+        [neededTag.name]: matches[0]["@value"],
+      })
+    return identifierMap
+  }, {})
+}


### PR DESCRIPTION
This PR addresses an issue that was identified after the launch of the Hold pages, where certain off-site partner records were showing an error on the hold request page.

The issue occurred because the delivery location fetch was failing. This was due to missing functionality in DFE, where barcodes are extracted from the identifier field for bibs with legacy formatting.

This PR adds the necessary functionality to resolve the issue. I've also opened a [follow-up ticket](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4474) to refactor the solution and add unit tests.