### PR TITLE
Filter out null locations in delivery location fetch result

### DIFF
--- a/src/server/api/hold.ts
+++ b/src/server/api/hold.ts
@@ -44,10 +44,11 @@ export async function fetchDeliveryLocations(
     }
 
     const deliveryLocations =
-      discoveryLocationsItem?.deliveryLocation?.map(
-        (locationElement: DiscoveryLocationElement) =>
+      discoveryLocationsItem?.deliveryLocation
+        ?.map((locationElement: DiscoveryLocationElement) =>
           mapLocationElementToDeliveryLocation(locationElement)
-      ) || []
+        )
+        .filter((deliveryLocation) => deliveryLocation) || []
     const eddRequestable = discoveryLocationsItem?.eddRequestable || false
 
     // Filter out closed locations

--- a/src/server/api/tests/hold.test.ts
+++ b/src/server/api/tests/hold.test.ts
@@ -21,7 +21,17 @@ jest.mock("../../nyplApiClient", () => {
           get: jest.fn().mockReturnValueOnce({
             itemListElement: [
               {
-                deliveryLocation: [{}, {}],
+                deliveryLocation: [
+                  {
+                    "@id": "loc:mal17",
+                    prefLabel: "Schwarzman Building - Scholar Room 217",
+                  },
+                  {
+                    "@id": "loc:mab",
+                    prefLabel:
+                      "Schwarzman Building - Art & Architecture Room 300",
+                  },
+                ],
               },
             ],
           }),
@@ -34,7 +44,17 @@ jest.mock("../../nyplApiClient", () => {
           get: jest.fn().mockReturnValueOnce({
             itemListElement: [
               {
-                deliveryLocation: [{}, {}],
+                deliveryLocation: [
+                  {
+                    "@id": "loc:mal17",
+                    prefLabel: "Schwarzman Building - Scholar Room 217",
+                  },
+                  {
+                    "@id": "loc:mab",
+                    prefLabel:
+                      "Schwarzman Building - Art & Architecture Room 300",
+                  },
+                ],
                 eddRequestable: true,
               },
             ],

--- a/src/server/api/tests/hold.test.ts
+++ b/src/server/api/tests/hold.test.ts
@@ -203,6 +203,10 @@ describe("fetchDeliveryLocations", () => {
     // expect(deliveryLocationResults.deliveryLocations.length).toEqual(0)
     expect(deliveryLocationResults.status).toEqual(500)
   })
+
+  it.todo(
+    "Add tests for filtering out locations that are not listed in NYPL_LOCATIONS constant (staff-only)"
+  )
 })
 
 describe("postHoldRequest", () => {


### PR DESCRIPTION
Fixes another location bug visible in on this [item request page](https://www.nypl.org/research/research-catalog/hold/request/pb994935823506421-pi23660840550006421)

This is happening because Discovery API is returning some staff-only locations, which should be filtered out.