### PR TITLE
add advanced search param

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- add searched_from=advanced param to track advanced searches
+
 ## [1.4.1] Hotfix 2025-1-23
 
 - Fix (derived from DFE) for failing delivery location fetch for off-site items with legacy barcode identifier.

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -72,7 +72,7 @@ describe("Advanced Search Form", () => {
     submit()
 
     expect(mockRouter.asPath).toBe(
-      "/search?q=spaghetti&title=strega+nonna&contributor=il+amore+di+pasta&callnumber=12345&standard_number=67890&subject=italian+food"
+      "/search?q=spaghetti&title=strega+nonna&contributor=il+amore+di+pasta&callnumber=12345&standard_number=67890&subject=italian+food&searched_from=advanced"
     )
   })
   it("renders inputs for all text input fields", () => {
@@ -88,7 +88,7 @@ describe("Advanced Search Form", () => {
     submit()
     // expect the label for Azerbaijani ("lang:aze") to be in url
     expect(mockRouter.asPath).toBe(
-      "/search?q=&filters%5Blanguage%5D=lang%3Aaze"
+      "/search?q=&filters%5Blanguage%5D=lang%3Aaze&searched_from=advanced"
     )
   })
   it("can check material checkboxes", async () => {
@@ -98,7 +98,7 @@ describe("Advanced Search Form", () => {
     // expect the label for notated music and cartographic
     // ("resourcetypes:not", "resourcetypes:car") to be in url
     expect(mockRouter.asPath).toBe(
-      "/search?q=&filters%5BmaterialType%5D%5B0%5D=resourcetypes%3Anot&filters%5BmaterialType%5D%5B1%5D=resourcetypes%3Acar"
+      "/search?q=&filters%5BmaterialType%5D%5B0%5D=resourcetypes%3Anot&filters%5BmaterialType%5D%5B1%5D=resourcetypes%3Acar&searched_from=advanced"
     )
   })
   it("can check location checkboxes", async () => {
@@ -106,7 +106,7 @@ describe("Advanced Search Form", () => {
     await userEvent.click(screen.getByLabelText(location.label as string))
     submit()
     expect(mockRouter.asPath).toBe(
-      `/search?q=&filters%5BbuildingLocation%5D%5B0%5D=${location.value}`
+      `/search?q=&filters%5BbuildingLocation%5D%5B0%5D=${location.value}&searched_from=advanced`
     )
   })
 

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -123,9 +123,13 @@ export default function AdvancedSearch({
       // If the NEXT_PUBLIC_REVERSE_PROXY_ENABLED feature flag is present, use window.location.replace
       // instead of router.push to forward search results to DFE.
       if (appConfig.features.reverseProxyEnabled[appConfig.environment]) {
-        window.location.replace(`${BASE_URL}${PATHS.SEARCH}${queryString}`)
+        window.location.replace(
+          `${BASE_URL}${PATHS.SEARCH}${queryString}&searched_from=advanced`
+        )
       } else {
-        await router.push(`${PATHS.SEARCH}${queryString}`)
+        await router.push(
+          `${PATHS.SEARCH}${queryString}&searched_from=advanced`
+        )
       }
     }
   }

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -68,10 +68,13 @@ export default function Search({
   const drbResults = mapWorksToDRBResults(drbWorks)
 
   const isLoading = useLoading()
+  const searchedFromAdvanced = query.searched_from === "advanced"
 
   const handlePageChange = async (page: number) => {
     const newQuery = getSearchQuery({ ...searchParams, page })
-    await push(newQuery)
+    await push(
+      `${newQuery}${searchedFromAdvanced ? "&searched_from=advanced" : ""}`
+    )
   }
 
   const aggs = results?.aggregations?.itemListElement


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4345](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4345)

## This PR does the following:

- Add searched_from=advanced param to searches from advanced search
  - resets upon a new search from the search bar.
  - persists on pagination updates, as well on refine search updates

## How has this been tested?

Updating local tests to include the param, and manual testing on local.nypl.org

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- NA

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4345]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ