### PR TITLE
[SCC-4610] format->recordType for MyAccount requests tab

### DIFF
--- a/src/models/MyAccount.ts
+++ b/src/models/MyAccount.ts
@@ -56,7 +56,7 @@ export default class MyAccount {
 
   async fetchHolds() {
     return await this.client.get(
-      `${this.baseQuery}/holds?expand=record&fields=canFreeze,status,pickupLocation,frozen,patron,pickupByDate,format,record`
+      `${this.baseQuery}/holds?expand=record&fields=canFreeze,status,pickupLocation,frozen,patron,pickupByDate,recordType,record`
     )
   }
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4610](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4610)

## This PR does the following:

- Changes `format` back to `recordType` in the `fetchHolds` call in MyAccount (was changed to `format` in a search-and-replace [here](https://github.com/NYPL/research-catalog/commit/49493e1234c1844c6c04fd2e008bc73898ecf4b2))

## How has this been tested?

* This is what the path used to be, and tests are passing.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [N/A] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [N/A] I have added relevant accessibility documentation for this pull request.
- [X] All new and existing tests passed.


[SCC-4610]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ