### PR TITLE
SCC-4601: Keyword dropdown icon z index

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updates Next.js to version 13.5.9 [SCC-4609](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4609)
+- Fixes keyword dropdown icon to not disappear on click [SCC-4601](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4601)
 
 ## [1.4.5] 2025-02-24
 

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -111,9 +111,6 @@ const SearchForm = ({ aggregations }: { aggregations?: Aggregation[] }) => {
             labelText: searchTip,
             placeholder,
           }}
-          sx={{
-            ".chakra-select__icon-wrapper": { "z-index": "999 !important" },
-          }}
         />
         <Flex direction="column" justifyContent="space-between" mt="xs">
           <RCLink


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4601](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4601)

## This PR does the following:

- Removes the `zIndex` styling that was causing keyword dropdown arrow icon to disappear on click

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4601]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ