### PR TITLE
SCC-4627: Sierra wrapper POST correction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrects Sierra client POST bug [SCC-4627](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4627)
 - Updates Next.js to version 13.5.9 [SCC-4609](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4609)
 
 ## [1.4.5] 2025-02-24

--- a/src/server/sierraClient/index.ts
+++ b/src/server/sierraClient/index.ts
@@ -54,7 +54,7 @@ const sierraClient = async () => {
       logger.info(`GET ${base}/${path}`)
       return await get(path)
     }
-    const post = wrapper.get.bind(wrapper)
+    const post = wrapper.post.bind(wrapper)
     wrapper.post = async function (path, body) {
       logger.info(`POST ${base}${path}`)
       return await post(path, body)


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4627](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4627)

## This PR does the following:

- Sets `wrapper.post` instead of `wrapper.get` in the Sierra client wrapper so that the call to `patrons/validate` (needed to reset the password) works as expected
- ** Not urgent imo but want to note that we mock all of our requests (see `helpers.test.tsx`), so that the wrong request method wasn't, and would never be, caught. Wondering if we should revisit these tests although I know they gave us lots of grief the first time around

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4627]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ