### PR TITLE
SCC-4105: Finding aid links

### DIFF
--- a/__test__/fixtures/bibFixtures.ts
+++ b/__test__/fixtures/bibFixtures.ts
@@ -3342,6 +3342,839 @@ export const bibWithSupplementaryContent = {
         label: "Image",
         url: "http://images.contentreserve.com/ImageType-100/0293-1/{C87D2BB9-0E13-4851-A9E2-547643F41A0E}Img100.jpg",
       },
+      {
+        "@type": "nypl:SupplementaryContent",
+        label: "Finding Aid",
+        url: "http://archives.nypl.org/scm/20601",
+      },
+    ],
+    title: ["Stick Dog slurps spaghetti"],
+    titleDisplay: [
+      "Stick Dog slurps spaghetti / by Tom Watson ; [illustrations by Ethan Long based on original sketches by Tom Watson].",
+    ],
+    type: ["nypl:Item"],
+    updatedAt: 1681297059060,
+    uri: "b21255464",
+    suppressed: false,
+    hasItemVolumes: false,
+    hasItemDates: false,
+  },
+  annotatedMarc: {
+    id: "21255464",
+    nyplSource: "sierra-nypl",
+    fields: [
+      {
+        label: "Author",
+        values: [
+          {
+            content: "Watson, Tom, 1965- author.",
+            source: {
+              fieldTag: "a",
+              marcTag: "100",
+              ind1: "1",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Watson, Tom,",
+                },
+                {
+                  tag: "d",
+                  content: "1965-",
+                },
+                {
+                  tag: "e",
+                  content: "author.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Title",
+        values: [
+          {
+            content:
+              "Stick Dog slurps spaghetti / by Tom Watson ; [illustrations by Ethan Long based on original sketches by Tom Watson].",
+            source: {
+              fieldTag: "t",
+              marcTag: "245",
+              ind1: "1",
+              ind2: "0",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Stick Dog slurps spaghetti /",
+                },
+                {
+                  tag: "c",
+                  content:
+                    "by Tom Watson ; [illustrations by Ethan Long based on original sketches by Tom Watson].",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Publisher",
+        values: [
+          {
+            content:
+              "New York, NY : Harper, An Imprint of HarperCollinsPublishers, [2016]",
+            source: {
+              fieldTag: "p",
+              marcTag: "264",
+              ind1: " ",
+              ind2: "1",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "New York, NY :",
+                },
+                {
+                  tag: "b",
+                  content: "Harper, An Imprint of HarperCollinsPublishers,",
+                },
+                {
+                  tag: "c",
+                  content: "[2016]",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Edition",
+        values: [
+          {
+            content: "First edition.",
+            source: {
+              fieldTag: "e",
+              marcTag: "250",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "First edition.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Description",
+        values: [
+          {
+            content: "1 online resource (238 pages) : illustrations.",
+            source: {
+              fieldTag: "r",
+              marcTag: "300",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "1 online resource (238 pages) :",
+                },
+                {
+                  tag: "b",
+                  content: "illustrations.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Type of Content",
+        values: [
+          {
+            content: "text",
+            source: {
+              fieldTag: "r",
+              marcTag: "336",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "text",
+                },
+                {
+                  tag: "b",
+                  content: "[redacted]",
+                },
+                {
+                  tag: "2",
+                  content: "[redacted]",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Type of Medium",
+        values: [
+          {
+            content: "computer",
+            source: {
+              fieldTag: "r",
+              marcTag: "337",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "computer",
+                },
+                {
+                  tag: "b",
+                  content: "[redacted]",
+                },
+                {
+                  tag: "2",
+                  content: "[redacted]",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Type of Carrier",
+        values: [
+          {
+            content: "online resource",
+            source: {
+              fieldTag: "r",
+              marcTag: "338",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "online resource",
+                },
+                {
+                  tag: "b",
+                  content: "[redacted]",
+                },
+                {
+                  tag: "2",
+                  content: "[redacted]",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Summary",
+        values: [
+          {
+            content:
+              "When they come across spaghetti in their search for a tug-of-war rope, Stick Dog and his hungry friends go on a quest for more pasta that sees them scale their suburb's tallest mountain and sneak into a restaurant filled with humans.",
+            source: {
+              fieldTag: "n",
+              marcTag: "520",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content:
+                    "When they come across spaghetti in their search for a tug-of-war rope, Stick Dog and his hungry friends go on a quest for more pasta that sees them scale their suburb's tallest mountain and sneak into a restaurant filled with humans.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Source of description",
+        values: [
+          {
+            content: "Print version record.",
+            source: {
+              fieldTag: "n",
+              marcTag: "588",
+              ind1: "0",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Print version record.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Connect to:",
+        values: [
+          {
+            label: "Access eNYPL",
+            content: "http://link.overdrive.com/?websiteID=37&titleID=2559851",
+            source: {
+              fieldTag: "y",
+              marcTag: "856",
+              ind1: "4",
+              ind2: "0",
+              content: null,
+              subfields: [
+                {
+                  tag: "u",
+                  content:
+                    "http://link.overdrive.com/?websiteID=37&titleID=2559851",
+                },
+                {
+                  tag: "y",
+                  content: "[redacted]",
+                },
+              ],
+            },
+          },
+          {
+            label: "Image",
+            content:
+              "http://images.contentreserve.com/ImageType-100/0293-1/{C87D2BB9-0E13-4851-A9E2-547643F41A0E}Img100.jpg",
+            source: {
+              fieldTag: "y",
+              marcTag: "856",
+              ind1: "4",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "3",
+                  content: "[redacted]",
+                },
+                {
+                  tag: "u",
+                  content:
+                    "http://images.contentreserve.com/ImageType-100/0293-1/{C87D2BB9-0E13-4851-A9E2-547643F41A0E}Img100.jpg",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Subject",
+        values: [
+          {
+            content: "Dogs -- Fiction.",
+            source: {
+              fieldTag: "d",
+              marcTag: "650",
+              ind1: " ",
+              ind2: "1",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Dogs",
+                },
+                {
+                  tag: "v",
+                  content: "Fiction.",
+                },
+              ],
+            },
+          },
+          {
+            content: "Pasta products -- Fiction.",
+            source: {
+              fieldTag: "d",
+              marcTag: "650",
+              ind1: " ",
+              ind2: "1",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Pasta products",
+                },
+                {
+                  tag: "v",
+                  content: "Fiction.",
+                },
+              ],
+            },
+          },
+          {
+            content: "Friendship -- Fiction.",
+            source: {
+              fieldTag: "d",
+              marcTag: "650",
+              ind1: " ",
+              ind2: "1",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Friendship",
+                },
+                {
+                  tag: "v",
+                  content: "Fiction.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Genre/Form",
+        values: [
+          {
+            content: "Humorous fiction.",
+            source: {
+              fieldTag: "d",
+              marcTag: "655",
+              ind1: " ",
+              ind2: "7",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Humorous fiction.",
+                },
+                {
+                  tag: "2",
+                  content: "[redacted]",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Subject",
+        values: [
+          {
+            content: "Illustrated children's books.",
+            source: {
+              fieldTag: "d",
+              marcTag: "650",
+              ind1: " ",
+              ind2: "0",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Illustrated children's books.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Genre/Form",
+        values: [
+          {
+            content: "Humorous fiction.",
+            source: {
+              fieldTag: "d",
+              marcTag: "655",
+              ind1: " ",
+              ind2: "7",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Humorous fiction.",
+                },
+                {
+                  tag: "2",
+                  content: "[redacted]",
+                },
+                {
+                  tag: "0",
+                  content: "[redacted]",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Subject",
+        values: [
+          {
+            content: "Illustrated children's books.",
+            source: {
+              fieldTag: "d",
+              marcTag: "650",
+              ind1: " ",
+              ind2: "7",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Illustrated children's books.",
+                },
+                {
+                  tag: "2",
+                  content: "[redacted]",
+                },
+                {
+                  tag: "0",
+                  content: "[redacted]",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Genre/Form",
+        values: [
+          {
+            content: "Electronic books.",
+            source: {
+              fieldTag: "d",
+              marcTag: "655",
+              ind1: " ",
+              ind2: "0",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Electronic books.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Added Author",
+        values: [
+          {
+            content: "Long, Ethan, illustrator.",
+            source: {
+              fieldTag: "b",
+              marcTag: "700",
+              ind1: "1",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "Long, Ethan,",
+                },
+                {
+                  tag: "e",
+                  content: "illustrator.",
+                },
+              ],
+            },
+          },
+          {
+            content: "OverDrive, Inc.",
+            source: {
+              fieldTag: "b",
+              marcTag: "710",
+              ind1: "2",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "OverDrive, Inc.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Other Form:",
+        values: [
+          {
+            content:
+              "Print version: Watson, Tom, 1965- Stick Dog slurps spaghetti. First edition. New York, NY : Harper, An Imprint of HarperCollinsPublishers, [2016] 006234322X (DLC)  2016932092 (OCoLC)935985696",
+            source: {
+              fieldTag: "w",
+              marcTag: "776",
+              ind1: "0",
+              ind2: "8",
+              content: null,
+              subfields: [
+                {
+                  tag: "i",
+                  content: "Print version:",
+                },
+                {
+                  tag: "a",
+                  content: "Watson, Tom, 1965-",
+                },
+                {
+                  tag: "t",
+                  content: "Stick Dog slurps spaghetti.",
+                },
+                {
+                  tag: "b",
+                  content: "First edition.",
+                },
+                {
+                  tag: "d",
+                  content:
+                    "New York, NY : Harper, An Imprint of HarperCollinsPublishers, [2016]",
+                },
+                {
+                  tag: "z",
+                  content: "006234322X",
+                },
+                {
+                  tag: "w",
+                  content: "(DLC)  2016932092",
+                },
+                {
+                  tag: "w",
+                  content: "(OCoLC)935985696",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "ISBN",
+        values: [
+          {
+            content: "9780062343239 (electronic bk.)",
+            source: {
+              fieldTag: "i",
+              marcTag: "020",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "9780062343239",
+                },
+                {
+                  tag: "q",
+                  content: "(electronic bk.)",
+                },
+              ],
+            },
+          },
+          {
+            content: "0062343238 (electronic bk.)",
+            source: {
+              fieldTag: "i",
+              marcTag: "020",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "0062343238",
+                },
+                {
+                  tag: "q",
+                  content: "(electronic bk.)",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        label: "Branch Call Number",
+        values: [
+          {
+            content: "eNYPL Book",
+            source: {
+              fieldTag: "c",
+              marcTag: "091",
+              ind1: " ",
+              ind2: " ",
+              content: null,
+              subfields: [
+                {
+                  tag: "a",
+                  content: "eNYPL Book",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+
+export const bibWithFindingAidAndTOC = {
+  resource: {
+    "@context":
+      "http://discovery-api-production.us-east-1.elasticbeanstalk.com/api/v0.1/discovery/context_all.jsonld",
+    "@type": ["nypl:Item", "nypl:Resource"],
+    "@id": "res:b21255464",
+    carrierType: [
+      {
+        "@id": "carriertypes:nc",
+        prefLabel: "volume",
+      },
+    ],
+    contributorLiteral: ["Long, Ethan", "OverDrive, Inc."],
+    createdString: ["2016"],
+    createdYear: 2016,
+    creatorLiteral: ["Watson, Tom, 1965-"],
+    dateStartYear: 2016,
+    dateString: ["2016"],
+    description: [
+      "When they come across spaghetti in their search for a tug-of-war rope, Stick Dog and his hungry friends go on a quest for more pasta that sees them scale their suburb's tallest mountain and sneak into a restaurant filled with humans.",
+    ],
+    electronicResources: [
+      {
+        url: "http://link.overdrive.com/?websiteID=37&titleID=2559851",
+        prefLabel: "Access eNYPL",
+      },
+      {
+        url: "http://link.overdrive.com/?websiteID=37&titleID=2559851",
+        prefLabel: "Table of contents only",
+      },
+    ],
+    extent: ["1 online resource (238 pages) : illustrations."],
+    genreForm: ["Humorous fiction."],
+    idIsbn: ["9780062343239", "0062343238"],
+    idOclc: ["959966725"],
+    identifier: [
+      {
+        "@type": "nypl:Bnumber",
+        "@value": "21255464",
+      },
+      {
+        "@type": "bf:Isbn",
+        "@value": "9780062343239",
+      },
+      {
+        "@type": "bf:Isbn",
+        "@value": "0062343238",
+      },
+      {
+        "@type": "nypl:Oclc",
+        "@value": "959966725",
+      },
+      {
+        "@type": "nypl:Oclc",
+        "@value": "959966725",
+      },
+      {
+        "@type": "bf:Identifier",
+        "@value": "(OCoLC)959966725",
+      },
+    ],
+    issuance: [
+      {
+        "@id": "urn:biblevel:m",
+        prefLabel: "monograph/item",
+      },
+    ],
+    itemAggregations: [
+      {
+        "@type": "nypl:Aggregation",
+        "@id": "res:location",
+        id: "location",
+        field: "location",
+        values: [],
+      },
+      {
+        "@type": "nypl:Aggregation",
+        "@id": "res:format",
+        id: "format",
+        field: "format",
+        values: [
+          {
+            value: "Text",
+            count: 1,
+            label: "Text",
+          },
+        ],
+      },
+      {
+        "@type": "nypl:Aggregation",
+        "@id": "res:status",
+        id: "status",
+        field: "status",
+        values: [],
+      },
+    ],
+    items: [],
+    language: [
+      {
+        "@id": "lang:eng",
+        prefLabel: "English",
+      },
+    ],
+    lccClassification: ["FICTION WAT"],
+    format: [
+      {
+        "@id": "resourcetypes:txt",
+        prefLabel: "Text",
+      },
+    ],
+    mediaType: [
+      {
+        "@id": "mediatypes:n",
+        prefLabel: "unmediated",
+      },
+    ],
+    numAvailable: 0,
+    numCheckinCardItems: 0,
+    numElectronicResources: 1,
+    numItemDatesParsed: 0,
+    numItemVolumesParsed: 0,
+    numItems: 0,
+    numItemsMatched: 0,
+    numItemsTotal: 0,
+    nyplSource: ["sierra-nypl"],
+    placeOfPublication: ["New York, NY"],
+    publicationStatement: [
+      "New York, NY : Harper, An Imprint of HarperCollinsPublishers, [2016]",
+    ],
+    publisherLiteral: ["Harper, An Imprint of HarperCollinsPublishers"],
+    subjectLiteral: [
+      "Dogs -- Fiction.",
+      "Pasta products -- Fiction.",
+      "Friendship -- Fiction.",
+      "Illustrated children's books.",
+    ],
+    supplementaryContent: [
+      {
+        "@type": "nypl:SupplementaryContent",
+        label: "Image",
+        url: "http://images.contentreserve.com/ImageType-100/0293-1/{C87D2BB9-0E13-4851-A9E2-547643F41A0E}Img100.jpg",
+      },
+      {
+        "@type": "nypl:SupplementaryContent",
+        label: "Finding Aid",
+        url: "http://archives.nypl.org/scm/20601",
+      },
     ],
     title: ["Stick Dog slurps spaghetti"],
     titleDisplay: [

--- a/__test__/fixtures/bibFixtures.ts
+++ b/__test__/fixtures/bibFixtures.ts
@@ -3342,11 +3342,6 @@ export const bibWithSupplementaryContent = {
         label: "Image",
         url: "http://images.contentreserve.com/ImageType-100/0293-1/{C87D2BB9-0E13-4851-A9E2-547643F41A0E}Img100.jpg",
       },
-      {
-        "@type": "nypl:SupplementaryContent",
-        label: "Finding Aid",
-        url: "http://archives.nypl.org/scm/20601",
-      },
     ],
     title: ["Stick Dog slurps spaghetti"],
     titleDisplay: [

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -212,17 +212,17 @@ export default function BibPage({
         </Heading>
         <BibDetails key="top-details" details={topDetails} />
         <Box mt="s">
-          {findingAid ? (
+          {findingAid && (
             <FindingAid
               findingAidURL={findingAid.url}
               hasElectronicResources={bib.hasElectronicResources}
             />
-          ) : null}
-          {bib.hasElectronicResources ? (
+          )}
+          {bib.hasElectronicResources && (
             <ElectronicResources
               electronicResources={bib.electronicResources}
             />
-          ) : null}
+          )}
         </Box>
         {bib.showItemTable ? (
           <>

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -214,7 +214,7 @@ export default function BibPage({
         <Box mt="s">
           {findingAid && (
             <FindingAid
-              findingAidURL={findingAid.url}
+              findingAidURL={findingAid}
               hasElectronicResources={bib.hasElectronicResources}
             />
           )}

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -203,9 +203,11 @@ export default function BibPage({
       <RCHead metadataTitle={metadataTitle} />
       <Layout isAuthenticated={isAuthenticated} activePage="bib">
         {findingAid && (
-          <StatusBadge type="informative">FINDING AID AVAILABLE</StatusBadge>
+          <StatusBadge mb="s" type="informative">
+            FINDING AID AVAILABLE
+          </StatusBadge>
         )}
-        <Heading level="h2" size="heading3" mb="l" mt={findingAid ? "s" : 0}>
+        <Heading level="h2" size="heading3" mb="l">
           {bib.title}
         </Heading>
         <BibDetails key="top-details" details={topDetails} />

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -45,6 +45,7 @@ import {
   areFiltersApplied,
 } from "../../../src/utils/itemFilterUtils"
 import RCHead from "../../../src/components/Head/RCHead"
+import FindingAid from "../../../src/components/BibPage/FindingAid"
 
 interface BibPropsType {
   discoveryBibResult: DiscoveryBibResult
@@ -219,7 +220,10 @@ export default function BibPage({
         </Heading>
         <BibDetails key="top-details" details={topDetails} />
         {findingAid ? (
-          <ElectronicResources electronicResources={bib.electronicResources} />
+          <FindingAid
+            findingAid={findingAid}
+            hasElectronicResources={bib.hasElectronicResources}
+          />
         ) : null}
         {bib.hasElectronicResources ? (
           <ElectronicResources electronicResources={bib.electronicResources} />

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -8,7 +8,6 @@ import {
   Banner,
   StatusBadge,
 } from "@nypl/design-system-react-components"
-
 import Layout from "../../../src/components/Layout/Layout"
 import {
   PATHS,
@@ -82,20 +81,11 @@ export default function BibPage({
   const viewAllLoadingTextRef = useRef<HTMLDivElement & HTMLLabelElement>(null)
   const controllerRef = useRef<AbortController>()
 
-  const {
-    topDetails,
-    bottomDetails,
-    holdingsDetails,
-    supplementaryContent,
-    findingAid,
-  } = new BibDetailsModel(discoveryBibResult, annotatedMarc)
+  const { topDetails, bottomDetails, holdingsDetails, findingAid } =
+    new BibDetailsModel(discoveryBibResult, annotatedMarc)
   const displayLegacyCatalogLink = isNyplBibID(bib.id)
 
   const filtersAreApplied = areFiltersApplied(appliedFilters)
-
-  console.log("supplementary content", supplementaryContent)
-  console.log("topDetails", topDetails)
-  console.log("finding aid", findingAid)
 
   const refreshItemTable = async (
     newQuery: BibQueryParams,
@@ -219,15 +209,19 @@ export default function BibPage({
           {bib.title}
         </Heading>
         <BibDetails key="top-details" details={topDetails} />
-        {findingAid ? (
-          <FindingAid
-            findingAid={findingAid}
-            hasElectronicResources={bib.hasElectronicResources}
-          />
-        ) : null}
-        {bib.hasElectronicResources ? (
-          <ElectronicResources electronicResources={bib.electronicResources} />
-        ) : null}
+        <Box mt="s">
+          {findingAid ? (
+            <FindingAid
+              findingAidURL={findingAid.url}
+              hasElectronicResources={bib.hasElectronicResources}
+            />
+          ) : null}
+          {bib.hasElectronicResources ? (
+            <ElectronicResources
+              electronicResources={bib.electronicResources}
+            />
+          ) : null}
+        </Box>
         {bib.showItemTable ? (
           <>
             <Heading

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -6,6 +6,7 @@ import {
   SkeletonLoader,
   Box,
   Banner,
+  StatusBadge,
 } from "@nypl/design-system-react-components"
 
 import Layout from "../../../src/components/Layout/Layout"
@@ -80,13 +81,20 @@ export default function BibPage({
   const viewAllLoadingTextRef = useRef<HTMLDivElement & HTMLLabelElement>(null)
   const controllerRef = useRef<AbortController>()
 
-  const { topDetails, bottomDetails, holdingsDetails } = new BibDetailsModel(
-    discoveryBibResult,
-    annotatedMarc
-  )
+  const {
+    topDetails,
+    bottomDetails,
+    holdingsDetails,
+    supplementaryContent,
+    findingAid,
+  } = new BibDetailsModel(discoveryBibResult, annotatedMarc)
   const displayLegacyCatalogLink = isNyplBibID(bib.id)
 
   const filtersAreApplied = areFiltersApplied(appliedFilters)
+
+  console.log("supplementary content", supplementaryContent)
+  console.log("topDetails", topDetails)
+  console.log("finding aid", findingAid)
 
   const refreshItemTable = async (
     newQuery: BibQueryParams,
@@ -203,10 +211,16 @@ export default function BibPage({
     <>
       <RCHead metadataTitle={metadataTitle} />
       <Layout isAuthenticated={isAuthenticated} activePage="bib">
-        <Heading level="h2" size="heading3" mb="l">
+        {findingAid && (
+          <StatusBadge type="informative">FINDING AID AVAILABLE</StatusBadge>
+        )}
+        <Heading level="h2" size="heading3" mb="l" mt={findingAid ? "s" : 0}>
           {bib.title}
         </Heading>
         <BibDetails key="top-details" details={topDetails} />
+        {findingAid ? (
+          <ElectronicResources electronicResources={bib.electronicResources} />
+        ) : null}
         {bib.hasElectronicResources ? (
           <ElectronicResources electronicResources={bib.electronicResources} />
         ) : null}

--- a/src/components/BibPage/BibDetail.test.tsx
+++ b/src/components/BibPage/BibDetail.test.tsx
@@ -1,6 +1,7 @@
 // import userEvent from "@testing-library/user-event"
 import {
   bibWithSupplementaryContent,
+  bibWithFindingAidAndTOC,
   noParallels,
   parallelsBib,
 } from "../../../__test__/fixtures/bibFixtures"
@@ -26,6 +27,10 @@ describe("BibDetail component", () => {
     parallelsBib.resource,
     parallelsBib.annotatedMarc
   )
+  const findingAidBibModel = new BibDetailsModel(
+    bibWithFindingAidAndTOC.resource,
+    bibWithFindingAidAndTOC.annotatedMarc
+  )
   describe("bottom details", () => {
     it.todo("")
   })
@@ -46,7 +51,7 @@ describe("BibDetail component", () => {
     })
   })
   describe("linked details", () => {
-    xit("internal link", async () => {
+    it("renders internal links", async () => {
       mockRouter.push("/bib/b12345678")
       render(<BibDetails details={noParallelsBibModel.topDetails} />, {
         wrapper: MemoryRouterProvider,
@@ -54,7 +59,9 @@ describe("BibDetail component", () => {
       const creatorLiteralLink = screen.getByText("Cortanze, Gérard de.")
       expect(creatorLiteralLink).toHaveAttribute(
         "href",
-        "/search?filters[creatorLiteral][0]=Cortanze,%20G%C3%A9rard%20de."
+        expect.stringContaining(
+          "/search?filters[creatorLiteral][0]=Cortanze,%20G%C3%A9rard%20de."
+        )
       )
       // @TODO: This will work once the Nextjs `Link` component is used again
       // await userEvent.click(creatorLiteralLink)
@@ -62,7 +69,7 @@ describe("BibDetail component", () => {
       //   "/search?filters%5BcreatorLiteral%5D%5B0%5D=Cortanze%2C+G%C3%A9rard+de."
       // )
     })
-    it("external link", async () => {
+    it("renders external links", async () => {
       render(<BibDetails details={supplementaryContentModel.topDetails} />, {
         wrapper: MemoryRouterProvider,
       })
@@ -71,6 +78,12 @@ describe("BibDetail component", () => {
         "href",
         expect.stringContaining("images.contentreserve.com")
       )
+    })
+    it("does not render finding aid in supplementary content", async () => {
+      render(<BibDetails details={findingAidBibModel.topDetails} />, {
+        wrapper: MemoryRouterProvider,
+      })
+      expect(screen.queryByText("Finding aid")).not.toBeInTheDocument()
     })
   })
   describe("subject heading links", () => {

--- a/src/components/BibPage/ElectronicResources.test.tsx
+++ b/src/components/BibPage/ElectronicResources.test.tsx
@@ -5,9 +5,7 @@ import {
 } from "../../../__test__/fixtures/bibFixtures"
 import Bib from "../../models/Bib"
 import ElectronicResources from "./ElectronicResources"
-
 import { render, screen } from "@testing-library/react"
-import exp from "constants"
 
 describe("ElectronicResources component", () => {
   describe("Many eResources", () => {

--- a/src/components/BibPage/ElectronicResources.tsx
+++ b/src/components/BibPage/ElectronicResources.tsx
@@ -50,7 +50,7 @@ const ElectronicResources = ({
 
   return (
     <Card ref={scrollToRef} isBordered data-testid="electronic-resources">
-      <CardHeading level="three" size="body1" mb="xs">
+      <CardHeading level="four" size="body1" mb="xs">
         Available online
       </CardHeading>
       <CardContent aria-expanded={!showMore}>

--- a/src/components/BibPage/ElectronicResources.tsx
+++ b/src/components/BibPage/ElectronicResources.tsx
@@ -49,22 +49,21 @@ const ElectronicResources = ({
   }
 
   return (
-    <Card
-      ref={scrollToRef}
-      isBordered
-      mt="l"
-      data-testid="electronic-resources"
-    >
-      <CardHeading level="three" size="body1" mb="s">
+    <Card ref={scrollToRef} isBordered data-testid="electronic-resources">
+      <CardHeading level="three" size="body1" mb="xs">
         Available online
       </CardHeading>
       <CardContent aria-expanded={!showMore}>
         <List
           type="ul"
+          mb="0"
           noStyling
-          mb="s"
           listItems={electronicResourcesToDisplay.map((resource) => (
-            <ExternalLink href={resource.url} key={kebabCase(resource.title)}>
+            <ExternalLink
+              href={resource.url}
+              key={kebabCase(resource.title)}
+              type="standalone"
+            >
               <Box
                 as="span"
                 display="inline-block"
@@ -83,6 +82,7 @@ const ElectronicResources = ({
             id="see-more-eresources-button"
             data-testid="see-more-eresources-button"
             p={0}
+            mt="s"
             onClick={onClick}
             buttonType="link"
             aria-expanded={!showMore}

--- a/src/components/BibPage/FindingAid.test.tsx
+++ b/src/components/BibPage/FindingAid.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react"
+import FindingAid from "./FindingAid"
+
+describe("FindingAid component", () => {
+  beforeEach(() => {
+    render(
+      <FindingAid findingAidURL={"mockUrl"} hasElectronicResources={false} />
+    )
+  })
+
+  it("renders the correct heading", () => {
+    expect(screen.queryByText("Collection information")).toBeInTheDocument()
+  })
+
+  it("renders the given Archives link", () => {
+    const findingAidContainer = screen.queryByTestId("collection-information")
+    expect(findingAidContainer).toBeInTheDocument()
+
+    const archivesLink = screen.getByRole("link", {
+      name: "Finding aid",
+    })
+    expect(archivesLink).toHaveAttribute("href", "mockUrl")
+  })
+
+  it("renders the appointments link", () => {
+    const appointmentsLink = screen.getByRole("link", {
+      name: "require an appointment",
+    })
+    expect(appointmentsLink).toHaveAttribute(
+      "href",
+      "https://www.nypl.org/research/appointments"
+    )
+  })
+})

--- a/src/components/BibPage/FindingAid.tsx
+++ b/src/components/BibPage/FindingAid.tsx
@@ -8,32 +8,30 @@ import {
   Flex,
 } from "@nypl/design-system-react-components"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
-import type { BibDetailURL } from "../../types/bibDetailsTypes"
 
 interface FindingAidProps {
-  findingAid: BibDetailURL
+  findingAidURL: string
   hasElectronicResources: boolean
 }
 
 const FindingAid = ({
-  findingAid,
+  findingAidURL,
   hasElectronicResources,
 }: FindingAidProps) => {
   return (
     <Card
       isBordered
-      mt="m"
       data-testid="collection-information"
       sx={{
         borderBottom: hasElectronicResources ? "0px" : "1px ui.gray solid",
       }}
     >
-      <CardHeading level="three" size="body1" mb="xs">
+      <CardHeading level="four" size="body1" mb="xs">
         Collection information
       </CardHeading>
       <CardContent>
         <ExternalLink
-          href={findingAid.url}
+          href={findingAidURL}
           type="standalone"
           fontSize={{
             base: "mobile.body.body2",
@@ -50,7 +48,7 @@ const FindingAid = ({
             collections{" "}
             <Link
               hasVisitedState={false}
-              href={"https://libguides.nypl.org/c.php?g=1184379&p=9157736"}
+              href={"https://www.nypl.org/research/appointments"}
             >
               require an appointment
             </Link>{" "}

--- a/src/components/BibPage/FindingAid.tsx
+++ b/src/components/BibPage/FindingAid.tsx
@@ -1,0 +1,65 @@
+import {
+  Card,
+  CardContent,
+  CardHeading,
+  Icon,
+  Text,
+  Link,
+  Flex,
+} from "@nypl/design-system-react-components"
+import ExternalLink from "../Links/ExternalLink/ExternalLink"
+import type { BibDetailURL } from "../../types/bibDetailsTypes"
+
+interface FindingAidProps {
+  findingAid: BibDetailURL
+  hasElectronicResources: boolean
+}
+
+const FindingAid = ({
+  findingAid,
+  hasElectronicResources,
+}: FindingAidProps) => {
+  return (
+    <Card
+      isBordered
+      mt="m"
+      data-testid="collection-information"
+      sx={{
+        borderBottom: hasElectronicResources ? "0px" : "1px ui.gray solid",
+      }}
+    >
+      <CardHeading level="three" size="body1" mb="xs">
+        Collection information
+      </CardHeading>
+      <CardContent>
+        <ExternalLink
+          href={findingAid.url}
+          type="standalone"
+          fontSize={{
+            base: "mobile.body.body2",
+            md: "desktop.body.body2",
+          }}
+        >
+          Finding aid
+        </ExternalLink>
+        <Flex justifyContent="center" gap="xxs" mt="xs">
+          <Icon name="errorOutline" iconRotation="rotate180" size="medium" />
+          <Text size="caption" mb="0">
+            The finding aid is a document containing details about the
+            organization and contents of this archival collection. Archival
+            collections{" "}
+            <Link
+              hasVisitedState={false}
+              href={"https://libguides.nypl.org/c.php?g=1184379&p=9157736"}
+            >
+              require an appointment
+            </Link>{" "}
+            to view and use on-site.
+          </Text>
+        </Flex>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default FindingAid

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -82,7 +82,7 @@ const Layout = ({
               </div>
               {showSearch && (
                 <Flex
-                  gap="l"
+                  gap="s"
                   align="center"
                   direction="column"
                   sx={{

--- a/src/components/SearchResults/ElectronicResourcesLink.tsx
+++ b/src/components/SearchResults/ElectronicResourcesLink.tsx
@@ -40,6 +40,7 @@ const ElectronicResourcesLink = ({
             fontSize={{ base: "mobile.body.body2", md: "desktop.body.body2" }}
             isUnderlined={false}
             hasVisitedState={false}
+            whiteSpace="wrap"
           >
             View all available online resources
           </RCLink>

--- a/src/components/SearchResults/ElectronicResourcesLink.tsx
+++ b/src/components/SearchResults/ElectronicResourcesLink.tsx
@@ -1,5 +1,8 @@
-import { Box, Text } from "@nypl/design-system-react-components"
-
+import {
+  Card,
+  CardContent,
+  CardHeading,
+} from "@nypl/design-system-react-components"
 import RCLink from "../Links/RCLink/RCLink"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
 import type { ElectronicResource } from "../../types/bibTypes"
@@ -9,46 +12,40 @@ interface ElectronicResourcesLinkProps {
   electronicResources: ElectronicResource[]
 }
 
-/**
- * The SearchResult component displays a single search result element.
- */
 const ElectronicResourcesLink = ({
   bibUrl,
   electronicResources,
 }: ElectronicResourcesLinkProps) => {
   return (
-    <Box mt="s" data-testid="electronic-resources-link">
-      <Text
-        mb="xxs"
-        fontSize={{ base: "mobile.body.body1", md: "desktop.body.body1" }}
-        fontWeight="bold"
-      >
+    <Card isBordered data-testid="electronic-resources-link">
+      <CardHeading level="four" size="body1" mb="xs">
         Available online
-      </Text>
-      {electronicResources.length === 1 ? (
-        <ExternalLink
-          href={electronicResources[0].url}
-          rel="noreferrer"
-          type="standalone"
-          fontSize={{ base: "mobile.body.body2", md: "desktop.body.body2" }}
-          fontWeight="bold"
-          isUnderlined={false}
-        >
-          {electronicResources[0].prefLabel || electronicResources[0].url}
-        </ExternalLink>
-      ) : (
-        <RCLink
-          href={`${bibUrl}#electronic-resources`}
-          type="standalone"
-          fontSize={{ base: "mobile.body.body2", md: "desktop.body.body2" }}
-          fontWeight="medium"
-          isUnderlined={false}
-          hasVisitedState={false}
-        >
-          View all available online resources
-        </RCLink>
-      )}
-    </Box>
+      </CardHeading>
+      <CardContent>
+        {electronicResources.length === 1 ? (
+          <ExternalLink
+            href={electronicResources[0].url}
+            rel="noreferrer"
+            type="standalone"
+            fontSize={{ base: "mobile.body.body2", md: "desktop.body.body2" }}
+            isUnderlined={false}
+            hasVisitedState={false}
+          >
+            {electronicResources[0].prefLabel || electronicResources[0].url}
+          </ExternalLink>
+        ) : (
+          <RCLink
+            href={`${bibUrl}#electronic-resources`}
+            type="standalone"
+            fontSize={{ base: "mobile.body.body2", md: "desktop.body.body2" }}
+            isUnderlined={false}
+            hasVisitedState={false}
+          >
+            View all available online resources
+          </RCLink>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -28,6 +28,9 @@ const SearchResult = ({ bib }: SearchResultProps) => {
       sx={{
         borderBottom: "1px solid var(--nypl-colors-ui-border-default)",
         paddingBottom: "l",
+        " > div": {
+          width: "100% !important",
+        },
       }}
     >
       <CardHeading
@@ -42,7 +45,7 @@ const SearchResult = ({ bib }: SearchResultProps) => {
         )}
         <RCLink href={`${PATHS.BIB}/${bib.id}`}>{bib.titleDisplay}</RCLink>
       </CardHeading>
-      <CardContent>
+      <CardContent data-testid="card-content">
         <Box
           sx={{
             p: { display: "inline-block", marginRight: "s", marginBottom: "s" },

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -6,13 +6,14 @@ import {
   Text,
   CardActions,
   SimpleGrid,
+  StatusBadge,
 } from "@nypl/design-system-react-components"
-
 import RCLink from "../Links/RCLink/RCLink"
 import ElectronicResourcesLink from "./ElectronicResourcesLink"
 import ItemTable from "../ItemTable/ItemTable"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import { PATHS } from "../../config/constants"
+import FindingAid from "../BibPage/FindingAid"
 
 interface SearchResultProps {
   bib: SearchResultsBib
@@ -34,6 +35,11 @@ const SearchResult = ({ bib }: SearchResultProps) => {
         size="heading5"
         sx={{ a: { textDecoration: "none" } }}
       >
+        {bib.findingAid && (
+          <StatusBadge type="informative" mb="s">
+            FINDING AID AVAILABLE
+          </StatusBadge>
+        )}
         <RCLink href={`${PATHS.BIB}/${bib.id}`}>{bib.titleDisplay}</RCLink>
       </CardHeading>
       <CardContent>
@@ -47,14 +53,19 @@ const SearchResult = ({ bib }: SearchResultProps) => {
           {bib.yearPublished && <Text>{bib.yearPublished}</Text>}
           <Text>{bib.getNumItemsMessage()}</Text>
         </Box>
-
-        <SimpleGrid columns={1} gap="grid.l">
-          {bib.hasElectronicResources && (
-            <ElectronicResourcesLink
-              bibUrl={bib.url}
-              electronicResources={bib.electronicResources}
-            />
-          )}
+        {bib.findingAid ? (
+          <FindingAid
+            findingAidURL={bib.findingAid}
+            hasElectronicResources={bib.hasElectronicResources}
+          />
+        ) : null}
+        {bib.hasElectronicResources ? (
+          <ElectronicResourcesLink
+            bibUrl={bib.url}
+            electronicResources={bib.electronicResources}
+          />
+        ) : null}
+        <SimpleGrid columns={1} mt="l" gap="grid.l">
           {bib.itemTables && (
             <>
               {bib.itemTables.map((itemTableData) => (

--- a/src/models/Bib.ts
+++ b/src/models/Bib.ts
@@ -45,9 +45,9 @@ export default class Bib {
     this.itemAggregations = result.itemAggregations || null
     this.hasItemDates = result.hasItemDates || false
     this.subjectHeadings = result.subjectHeadings || null
-    this.findingAid = result.supplementaryContent
-      ? getFindingAidFromSupplementaryContent(result.supplementaryContent)
-      : null
+    this.findingAid = getFindingAidFromSupplementaryContent(
+      result.supplementaryContent
+    )
     this.items = this.getItemsFromResult(result)
   }
 

--- a/src/models/Bib.ts
+++ b/src/models/Bib.ts
@@ -8,6 +8,7 @@ import type { Aggregation } from "../types/filterTypes"
 import Item from "../models/Item"
 import { ITEM_PAGINATION_BATCH_SIZE } from "../config/constants"
 import ItemTableData from "./ItemTableData"
+import { getFindingAidFromSupplementaryContent } from "../utils/bibUtils"
 
 /**
  * The Bib class represents a single Bib entity and contains the data
@@ -44,10 +45,9 @@ export default class Bib {
     this.itemAggregations = result.itemAggregations || null
     this.hasItemDates = result.hasItemDates || false
     this.subjectHeadings = result.subjectHeadings || null
-    this.findingAid =
-      result.supplementaryContent?.find(
-        (el) => el.label?.toLocaleLowerCase() === "finding aid"
-      )?.url || null
+    this.findingAid = result.supplementaryContent
+      ? getFindingAidFromSupplementaryContent(result.supplementaryContent)
+      : null
     this.items = this.getItemsFromResult(result)
   }
 

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -374,13 +374,13 @@ export default class BibDetails {
 
     const isFindingAid = (label: string) => label.includes("finding aid")
 
-    const isTOC = (label: string) =>
+    const hasTOCERandTOC = (label: string) =>
       hasTOCElectronicResource && label.includes("table of contents")
 
     const values = this.bib.supplementaryContent
       .filter((sc) => {
         const scLabel = sc.label?.toLowerCase() || ""
-        return !isFindingAid(scLabel) && !isTOC(scLabel)
+        return !isFindingAid(scLabel) && !hasTOCERandTOC(scLabel)
       })
       .map((sc) => ({
         url: sc.url,

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -379,6 +379,9 @@ export default class BibDetails {
       hasTOCElectronicResource && label.includes("table of contents")
 
     const values = this.bib.supplementaryContent
+      // If supplementary content contains a finding aid, don't display it
+      // Or, if supplementary content contains a table of contents
+      // and there's also a table of contents in electronic resources, don't display it
       .filter((sc) => {
         const scLabel = sc.label?.toLowerCase() || ""
         return !isFindingAid(scLabel) && !hasTOCERandTOC(scLabel)

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -9,6 +9,7 @@ import type {
   AnyBibDetail,
 } from "../types/bibDetailsTypes"
 import { convertToSentenceCase } from "../utils/appUtils"
+import { getFindingAidFromSupplementaryContent } from "../utils/bibUtils"
 
 export default class BibDetails {
   bib: DiscoveryBibResult
@@ -21,7 +22,7 @@ export default class BibDetails {
   extent: string[]
   subjectLiteral: BibDetailURL[][]
   owner: string[]
-  findingAid?: BibDetailURL
+  findingAid?: string
 
   constructor(
     discoveryBibResult: DiscoveryBibResult,
@@ -390,13 +391,7 @@ export default class BibDetails {
   }
 
   buildFindingAid() {
-    if (!this.bib.supplementaryContent?.length) {
-      return null
-    }
-    const findingAid = this.bib.supplementaryContent.find(
-      (sc) => sc.label.toLowerCase().includes("finding aid") && !!sc.url
-    )
-    return findingAid || null
+    return getFindingAidFromSupplementaryContent(this.bib.supplementaryContent)
   }
 
   buildSubjectHeadings(): BibDetailURL[][] {

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -21,6 +21,7 @@ export default class BibDetails {
   extent: string[]
   subjectLiteral: BibDetailURL[][]
   owner: string[]
+  findingAid?: BibDetailURL
 
   constructor(
     discoveryBibResult: DiscoveryBibResult,
@@ -29,6 +30,7 @@ export default class BibDetails {
     this.bib = this.matchParallelToPrimaryValues(discoveryBibResult)
     // these properties are not string[] so they require separate processing
     this.supplementaryContent = this.buildSupplementaryContent()
+    this.findingAid = this.buildFindingAid()
     this.groupedNotes = this.buildGroupedNotes()
     this.extent = this.buildExtent()
     this.owner = this.buildOwner()
@@ -363,13 +365,23 @@ export default class BibDetails {
       return null
     }
     const label = "Supplementary content"
-    const values = this.bib.supplementaryContent.map((sc) => {
-      return {
+    const values = this.bib.supplementaryContent
+      .filter((sc) => sc.label !== "Finding Aid")
+      .map((sc) => ({
         url: sc.url,
         urlLabel: sc.label,
-      }
-    })
+      }))
     return this.buildExternalLinkedDetail(convertToSentenceCase(label), values)
+  }
+
+  buildFindingAid() {
+    if (!this.bib.supplementaryContent?.length) {
+      return null
+    }
+    const findingAid = this.bib.supplementaryContent.find(
+      (sc) => sc.label === "Finding Aid" && !!sc.url
+    )
+    return findingAid || null
   }
 
   buildSubjectHeadings(): BibDetailURL[][] {

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -367,24 +367,13 @@ export default class BibDetails {
     }
     const label = "Supplementary content"
 
-    const hasTOCElectronicResource = this.bib.electronicResources.find(
-      (resource) =>
-        resource.prefLabel &&
-        resource.prefLabel.toLowerCase().includes("table of contents")
-    )
-
     const isFindingAid = (label: string) => label.includes("finding aid")
-
-    const hasTOCERandTOC = (label: string) =>
-      hasTOCElectronicResource && label.includes("table of contents")
 
     const values = this.bib.supplementaryContent
       // If supplementary content contains a finding aid, don't display it
-      // Or, if supplementary content contains a table of contents
-      // and there's also a table of contents in electronic resources, don't display it
       .filter((sc) => {
         const scLabel = sc.label?.toLowerCase() || ""
-        return !isFindingAid(scLabel) && !hasTOCERandTOC(scLabel)
+        return !isFindingAid(scLabel)
       })
       .map((sc) => ({
         url: sc.url,

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -366,7 +366,7 @@ export default class BibDetails {
     }
     const label = "Supplementary content"
     const values = this.bib.supplementaryContent
-      .filter((sc) => sc.label !== "Finding Aid")
+      .filter((sc) => !sc.label.toLowerCase().includes("finding aid"))
       .map((sc) => ({
         url: sc.url,
         urlLabel: sc.label,
@@ -379,7 +379,7 @@ export default class BibDetails {
       return null
     }
     const findingAid = this.bib.supplementaryContent.find(
-      (sc) => sc.label === "Finding Aid" && !!sc.url
+      (sc) => sc.label.toLowerCase().includes("finding aid") && !!sc.url
     )
     return findingAid || null
   }

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -365,8 +365,19 @@ export default class BibDetails {
       return null
     }
     const label = "Supplementary content"
+    const hasTOCElectronicResource = this.bib.electronicResources.find(
+      (resource) =>
+        resource.prefLabel &&
+        resource.prefLabel.toLowerCase().includes("table of contents")
+    )
     const values = this.bib.supplementaryContent
-      .filter((sc) => !sc.label.toLowerCase().includes("finding aid"))
+      .filter((sc) => {
+        const label = sc.label?.toLowerCase() || ""
+        return (
+          !label.includes("finding aid") &&
+          !(hasTOCElectronicResource && label.includes("table of contents"))
+        )
+      })
       .map((sc) => ({
         url: sc.url,
         urlLabel: sc.label,

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -365,18 +365,22 @@ export default class BibDetails {
       return null
     }
     const label = "Supplementary content"
+
     const hasTOCElectronicResource = this.bib.electronicResources.find(
       (resource) =>
         resource.prefLabel &&
         resource.prefLabel.toLowerCase().includes("table of contents")
     )
+
+    const isFindingAid = (label: string) => label.includes("finding aid")
+
+    const isTOC = (label: string) =>
+      hasTOCElectronicResource && label.includes("table of contents")
+
     const values = this.bib.supplementaryContent
       .filter((sc) => {
-        const label = sc.label?.toLowerCase() || ""
-        return (
-          !label.includes("finding aid") &&
-          !(hasTOCElectronicResource && label.includes("table of contents"))
-        )
+        const scLabel = sc.label?.toLowerCase() || ""
+        return !isFindingAid(scLabel) && !isTOC(scLabel)
       })
       .map((sc) => ({
         url: sc.url,

--- a/src/models/modelTests/Bib.test.ts
+++ b/src/models/modelTests/Bib.test.ts
@@ -42,12 +42,12 @@ describe("Bib model", () => {
         )
       })
 
-      // it("does not initialize finding aid when no aid but supp content", () => {
-      //   const bibWithSupplementaryContentModel = new Bib(
-      //     bibWithSupplementaryContent.resource
-      //   )
-      //   expect(bibWithSupplementaryContentModel.findingAid).toBe(null)
-      // })
+      it("does not initialize finding aid when no aid but supp content", () => {
+        const bibWithSupplementaryContentModel = new Bib(
+          bibWithSupplementaryContent.resource
+        )
+        expect(bibWithSupplementaryContentModel.findingAid).toBe(null)
+      })
 
       it("can handle no supplementary content", () => {
         expect(bib.findingAid).toBe(null)

--- a/src/models/modelTests/Bib.test.ts
+++ b/src/models/modelTests/Bib.test.ts
@@ -41,12 +41,14 @@ describe("Bib model", () => {
           "http://archives.nypl.org/scm/29990"
         )
       })
-      it("does not initialize finding aid when no aid but supp content", () => {
-        const bibWithSupplementaryContentModel = new Bib(
-          bibWithSupplementaryContent.resource
-        )
-        expect(bibWithSupplementaryContentModel.findingAid).toBe(null)
-      })
+
+      // it("does not initialize finding aid when no aid but supp content", () => {
+      //   const bibWithSupplementaryContentModel = new Bib(
+      //     bibWithSupplementaryContent.resource
+      //   )
+      //   expect(bibWithSupplementaryContentModel.findingAid).toBe(null)
+      // })
+
       it("can handle no supplementary content", () => {
         expect(bib.findingAid).toBe(null)
       })

--- a/src/models/modelTests/BibDetails.test.ts
+++ b/src/models/modelTests/BibDetails.test.ts
@@ -1,5 +1,6 @@
 import {
   bibWithSupplementaryContent,
+  bibWithFindingAidAndTOC,
   noParallels,
   parallelsBib,
   yiddishBib,
@@ -10,10 +11,14 @@ import {
 import type { LinkedBibDetail } from "../../types/bibDetailsTypes"
 import BibDetailsModel from "../BibDetails"
 
-describe("Bib model", () => {
+describe("Bib Details model", () => {
   const bibWithSupContentModel = new BibDetailsModel(
     bibWithSupplementaryContent.resource,
     bibWithSupplementaryContent.annotatedMarc
+  )
+  const bibWithFindingAid = new BibDetailsModel(
+    bibWithFindingAidAndTOC.resource,
+    bibWithFindingAidAndTOC.annotatedMarc
   )
   const bibWithParallelsModel = new BibDetailsModel(
     parallelsBib.resource,
@@ -252,6 +257,33 @@ describe("Bib model", () => {
           },
         ],
       })
+    })
+    it("drops finding aid and table of contents links when necessary", () => {
+      // Bib with finding aid, and a table of contents in its electronic resources
+      expect(bibWithFindingAid.supplementaryContent).toStrictEqual({
+        link: "external",
+        label: "Supplementary content",
+        value: [
+          {
+            urlLabel: "Image",
+            url: "http://images.contentreserve.com/ImageType-100/0293-1/{C87D2BB9-0E13-4851-A9E2-547643F41A0E}Img100.jpg",
+          },
+        ],
+      })
+    })
+  })
+  describe("finding aid", () => {
+    it("populates finding aid when finding aid is present in supplementary content", () => {
+      const findingAidBibModel = new BibDetailsModel(
+        bibWithFindingAidAndTOC.resource
+      )
+      expect(findingAidBibModel.findingAid.url).toStrictEqual(
+        "http://archives.nypl.org/scm/20601"
+      )
+    })
+    it("sets finding aid to null when there is none", () => {
+      const noItemsBib = new BibDetailsModel(bibNoItems.resource)
+      expect(noItemsBib.findingAid).toBe(null)
     })
   })
   describe("internal linking fields", () => {

--- a/src/models/modelTests/BibDetails.test.ts
+++ b/src/models/modelTests/BibDetails.test.ts
@@ -277,7 +277,7 @@ describe("Bib Details model", () => {
       const findingAidBibModel = new BibDetailsModel(
         bibWithFindingAidAndTOC.resource
       )
-      expect(findingAidBibModel.findingAid.url).toStrictEqual(
+      expect(findingAidBibModel.findingAid).toStrictEqual(
         "http://archives.nypl.org/scm/20601"
       )
     })

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -120,3 +120,17 @@ export function getBibQueryString(
 
   return `?${paginationOrAllQuery}${itemFilterQuery}${mergeCheckinQuery}`
 }
+
+export function getFindingAidFromSupplementaryContent(
+  supplementaryContent?: { label?: string; url: string }[]
+) {
+  if (!supplementaryContent?.length) {
+    return null
+  }
+
+  const findingAid = supplementaryContent.find(
+    (sc) => sc.label?.toLowerCase().includes("finding aid") && !!sc.url
+  )
+
+  return findingAid?.url || null
+}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4105](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4105)

## This PR does the following:

- Creates `FindingAid` component and adds it to search results and bib page
- Adjusts `ElectronicResource` (bib page) and `ElectronicResourceLink` (search result) styling
- Updates `BibDetails` model to filter the finding aid out of `topDetails`' `supplementaryContent` where necessary
    - Adds standalone `findingAid` property to `BibDetails`
- Adds `getFindingAidFromSupplementaryContent` to `bibUtils`, used for both `BibDetails` and `Bib` model

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.


[SCC-4105]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ