### PR TITLE
SCC-4379: Timed logout modal responds to page activity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updates DS to v3.6.1 (SCC-4630)
+- Updates timed logout modal to reset on user activity [SCC-4379](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4379)
 
 ### Fixed
 

--- a/pages/account/[[...index]].tsx
+++ b/pages/account/[[...index]].tsx
@@ -52,7 +52,14 @@ export default function MyAccount({
       }, TIMEOUT_MINUTES)
     }
 
-    const events = ["mousemove", "keydown", "mousedown", "click", "touchstart"]
+    const events = [
+      "mousemove",
+      "keydown",
+      "mousedown",
+      "click",
+      "touchstart",
+      "scroll",
+    ]
     events.forEach((event) => window.addEventListener(event, handleActivity))
 
     handleActivity()

--- a/pages/account/[[...index]].tsx
+++ b/pages/account/[[...index]].tsx
@@ -37,6 +37,34 @@ export default function MyAccount({
     document.cookie = newExpirationTime
     setExpirationTime(inFive)
   }
+
+  useEffect(() => {
+    resetCountdown()
+
+    let inactivityTimer: ReturnType<typeof setTimeout>
+    const TIMEOUT_MINUTES = 5 * 60 * 1000
+
+    const handleActivity = () => {
+      clearTimeout(inactivityTimer)
+      resetCountdown()
+      inactivityTimer = setTimeout(() => {
+        setDisplayLogoutModal(true)
+      }, TIMEOUT_MINUTES)
+    }
+
+    const events = ["mousemove", "keydown", "mousedown", "click", "touchstart"]
+    events.forEach((event) => window.addEventListener(event, handleActivity))
+
+    handleActivity()
+
+    return () => {
+      clearTimeout(inactivityTimer)
+      events.forEach((event) =>
+        window.removeEventListener(event, handleActivity)
+      )
+    }
+  }, [])
+
   const serverError = (
     <Text>
       We are unable to display your account information at this time. Please
@@ -51,12 +79,6 @@ export default function MyAccount({
     </Text>
   )
 
-  useEffect(() => {
-    resetCountdown()
-    // to avoid a reference error on document in the modal, wait to render it
-    // until we are on the client side
-    setDisplayLogoutModal(true)
-  })
   try {
     return (
       <>

--- a/src/components/MyAccount/TimedLogoutModal.test.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.test.tsx
@@ -64,12 +64,50 @@ describe("Logout modal on my account page", () => {
     expect(screen.getByTestId("logout-modal")).toBeInTheDocument()
   })
 
-  it("resets the inactivity timer on user activity", () => {
+  it("resets the inactivity timer on mouse move", () => {
     renderAccountPageWithProviders(accountData)
 
     act(() => {
       jest.advanceTimersByTime(2 * 60 * 1000) // 2 mins
       window.dispatchEvent(new Event("mousemove"))
+      jest.advanceTimersByTime(4 * 60 * 1000) // 4 more mins
+    })
+
+    expect(screen.queryByTestId("logout-modal")).toBeNull()
+
+    // Now wait 5 more minutes
+    act(() => {
+      jest.advanceTimersByTime(8 * 60 * 1000)
+    })
+
+    expect(screen.getByTestId("logout-modal")).toBeInTheDocument()
+  })
+
+  it("resets the inactivity timer on scroll", () => {
+    renderAccountPageWithProviders(accountData)
+
+    act(() => {
+      jest.advanceTimersByTime(2 * 60 * 1000) // 2 mins
+      window.dispatchEvent(new Event("scroll"))
+      jest.advanceTimersByTime(4 * 60 * 1000) // 4 more mins
+    })
+
+    expect(screen.queryByTestId("logout-modal")).toBeNull()
+
+    // Now wait 5 more minutes
+    act(() => {
+      jest.advanceTimersByTime(8 * 60 * 1000)
+    })
+
+    expect(screen.getByTestId("logout-modal")).toBeInTheDocument()
+  })
+
+  it("resets the inactivity timer on touch", () => {
+    renderAccountPageWithProviders(accountData)
+
+    act(() => {
+      jest.advanceTimersByTime(2 * 60 * 1000) // 2 mins
+      window.dispatchEvent(new Event("touchstart"))
       jest.advanceTimersByTime(4 * 60 * 1000) // 4 more mins
     })
 

--- a/src/components/MyAccount/TimedLogoutModal.test.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.test.tsx
@@ -28,7 +28,7 @@ const accountData = {
   pickupLocations: filteredPickupLocations,
 }
 
-const renderWithPatronDataProvider = (data) => {
+const renderAccountPageWithProviders = (data) => {
   return render(
     <FeedbackProvider value={null}>
       <PatronDataProvider value={{ ...data }}>
@@ -50,12 +50,12 @@ describe("Logout modal on my account page", () => {
   })
 
   it("does not show the logout modal on initial load", () => {
-    renderWithPatronDataProvider(accountData)
+    renderAccountPageWithProviders(accountData)
     expect(screen.queryByTestId("logout-modal")).toBeNull()
   })
 
   it("shows the logout modal after 5 minutes of inactivity", () => {
-    renderWithPatronDataProvider(accountData)
+    renderAccountPageWithProviders(accountData)
 
     act(() => {
       jest.advanceTimersByTime(5 * 60 * 1000) // 5 minutes
@@ -65,7 +65,7 @@ describe("Logout modal on my account page", () => {
   })
 
   it("resets the inactivity timer on user activity", () => {
-    renderWithPatronDataProvider(accountData)
+    renderAccountPageWithProviders(accountData)
 
     act(() => {
       jest.advanceTimersByTime(2 * 60 * 1000) // 2 mins


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4379](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4379)

## This PR does the following:

- Adds an `inactivityTimer` to the account page that's counting down from 5 minutes, and then resets the logout timer on mouse/keyboard/touch interactions

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
