### PR TITLE
SCC-4379: Take 2 on logout modal

### DIFF
--- a/pages/account/[[...index]].tsx
+++ b/pages/account/[[...index]].tsx
@@ -1,5 +1,4 @@
 import { Text } from "@nypl/design-system-react-components"
-
 import Layout from "../../src/components/Layout/Layout"
 import initializePatronTokenAuth, {
   doRedirectBasedOnNyplAccountRedirects,
@@ -8,11 +7,10 @@ import initializePatronTokenAuth, {
 import ProfileContainer from "../../src/components/MyAccount/ProfileContainer"
 import type { MyAccountPatronData } from "../../src/types/myAccountTypes"
 import { PatronDataProvider } from "../../src/context/PatronDataContext"
-import TimedLogoutModal from "../../src/components/MyAccount/TimedLogoutModal"
-import { getIncrementedTime } from "../../src/utils/cookieUtils"
-import { useEffect, useState } from "react"
 import { getPatronData } from "../api/account/[id]"
 import RCHead from "../../src/components/Head/RCHead"
+import TimedLogoutModal from "../../src/components/MyAccount/TimedLogoutModal"
+
 interface MyAccountPropsType {
   accountData: MyAccountPatronData
   isAuthenticated: boolean
@@ -27,45 +25,6 @@ export default function MyAccount({
   tabsPath,
 }: MyAccountPropsType) {
   const errorRetrievingPatronData = !accountData.patron
-
-  const [expirationTime, setExpirationTime] = useState("")
-  const [displayLogoutModal, setDisplayLogoutModal] = useState(false)
-
-  const resetCountdown = () => {
-    const inFive = getIncrementedTime(5)
-    const newExpirationTime = `accountPageExp=${inFive}; expires=${inFive}`
-    document.cookie = newExpirationTime
-    setExpirationTime(inFive)
-  }
-
-  useEffect(() => {
-    resetCountdown()
-
-    let inactivityTimer: ReturnType<typeof setTimeout>
-    const TIMEOUT_MINUTES = 5 * 60 * 1000
-
-    const handleActivity = () => {
-      clearTimeout(inactivityTimer)
-      resetCountdown()
-      inactivityTimer = setTimeout(() => {
-        setDisplayLogoutModal(true)
-      }, TIMEOUT_MINUTES)
-    }
-
-    const events = ["mousemove", "keydown", "mousedown", "touchstart", "scroll"]
-    events.forEach((event) =>
-      window.addEventListener(event, handleActivity, { passive: true })
-    )
-
-    handleActivity()
-
-    return () => {
-      clearTimeout(inactivityTimer)
-      events.forEach((event) =>
-        window.removeEventListener(event, handleActivity)
-      )
-    }
-  }, [])
 
   const serverError = (
     <Text>
@@ -86,12 +45,7 @@ export default function MyAccount({
       <>
         <RCHead metadataTitle={"My Account"} />
         <Layout isAuthenticated={isAuthenticated} activePage="account">
-          {displayLogoutModal && (
-            <TimedLogoutModal
-              stayLoggedIn={resetCountdown}
-              expirationTime={expirationTime}
-            />
-          )}
+          <TimedLogoutModal />
           {renderAuthServerError ? (
             authError
           ) : errorRetrievingPatronData ? (

--- a/src/components/MyAccount/TimedLogoutModal.tsx
+++ b/src/components/MyAccount/TimedLogoutModal.tsx
@@ -1,121 +1,153 @@
-import React, { useEffect, useState } from "react"
 import {
   Box,
-  Button,
   Card,
-  CardActions,
-  CardContent,
   CardHeading,
+  CardContent,
+  CardActions,
   Spacer,
+  Button,
 } from "@nypl/design-system-react-components"
-
-import { buildTimeLeft, deleteCookie } from "../../utils/cookieUtils"
-import { useLogoutRedirect } from "../../server/auth"
-import { useRouter } from "next/router"
+import React, { useEffect, useState, useCallback, useRef } from "react"
 import styles from "../../../styles/components/TimedLogoutModal.module.scss"
+import { deleteCookie } from "../../utils/cookieUtils"
+import router from "next/router"
+import { useLogoutRedirect } from "../../server/auth"
+
+const INACTIVITY_LIMIT = 5 * 60 * 1000 // 5 minutes (milliseconds)
+const MODAL_COUNTDOWN = 2 * 60 // 2 minutes (seconds)
 
 /**
  * This renders a modal interface based on an early version from the
  * Reservoir Design System through the `old-ds-modal` CSS class.
  */
-const TimedLogoutModal = ({
-  stayLoggedIn,
-  expirationTime,
-  timeoutWindow = 2,
-}: {
-  expirationTime: string
-  stayLoggedIn: () => void
-  timeoutWindow?: number
-}) => {
-  const [open, setOpen] = useState(false)
-  const router = useRouter()
+const TimedLogoutModal = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [countdown, setCountdown] = useState(MODAL_COUNTDOWN)
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const countdownRef = useRef<NodeJS.Timeout | null>(null)
   const redirectUri = useLogoutRedirect()
+
+  const resetInactivityTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+    const expiration = new Date(Date.now() + INACTIVITY_LIMIT).toUTCString()
+    const newExpirationTime = `accountPageExp=${expiration}; expires=${expiration}`
+    document.cookie = newExpirationTime
+    timerRef.current = setTimeout(() => {
+      setIsModalOpen(true)
+    }, INACTIVITY_LIMIT)
+  }, [])
+
+  const startCountdown = () => {
+    if (countdownRef.current) clearTimeout(countdownRef.current)
+    // Recursively update the countdown and wait one second.
+    const tick = () => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          logOutAndRedirect()
+          return 0
+        } else {
+          countdownRef.current = setTimeout(tick, 1000)
+          return prev - 1
+        }
+      })
+    }
+    setCountdown(MODAL_COUNTDOWN)
+    countdownRef.current = setTimeout(tick, 1000)
+  }
+
+  const stayLoggedIn = () => {
+    setIsModalOpen(false)
+    setCountdown(MODAL_COUNTDOWN)
+    if (countdownRef.current) {
+      clearInterval(countdownRef.current)
+    }
+    resetInactivityTimer()
+  }
+
   const logOutAndRedirect = () => {
-    // If patron clicked Log Out before natural expiration of cookie,
-    // explicitly delete it:
     deleteCookie("accountPageExp")
     router.push(redirectUri)
   }
 
-  const [timeUntilExpiration, setTimeUntilExpiration] = useState(
-    buildTimeLeft(expirationTime)
-  )
-
-  // if (
-  //   typeof document !== "undefined" &&
-  //   !document.cookie.includes("accountPageExp")
-  // ) {
-  //   logOutAndRedirect()
-  // }
+  const handleActivity = useCallback(() => {
+    // Once modal is open, user needs to explicitly click the button to prevent logout,
+    // screen interaction isn't enough.
+    if (!isModalOpen) {
+      resetInactivityTimer()
+    }
+  }, [])
 
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      const { minutes, seconds } = buildTimeLeft(expirationTime)
-      if (minutes < timeoutWindow) setOpen(true)
-      setTimeUntilExpiration({
-        minutes,
-        seconds,
-      })
-    }, 1000)
-    return () => {
-      clearTimeout(timeout)
-    }
-  })
+    resetInactivityTimer()
 
-  if (timeUntilExpiration.minutes <= 0 && timeUntilExpiration.seconds <= 0) {
-    logOutAndRedirect()
-  }
-  if (!open) return null
+    const events = ["mousemove", "keydown", "mousedown", "touchstart", "scroll"]
+    events.forEach((event) => window.addEventListener(event, handleActivity))
+
+    return () => {
+      events.forEach((event) =>
+        window.removeEventListener(event, handleActivity)
+      )
+      if (timerRef.current) clearTimeout(timerRef.current)
+      if (countdownRef.current) clearInterval(countdownRef.current)
+    }
+  }, [handleActivity, resetInactivityTimer])
+
+  useEffect(() => {
+    if (isModalOpen) {
+      startCountdown()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isModalOpen])
 
   return (
-    <Box
-      tabIndex={0}
-      className={styles.logoutModalContainer}
-      role="dialog"
-      aria-labelledby="logout-modal-heading"
-      aria-describedby="logout-modal-content"
-    >
-      <Card
-        layout="row"
-        isBordered={true}
-        backgroundColor="ui.bg.default"
-        className={styles.logoutModalBody}
-      >
-        <CardHeading
-          sx={{ display: "flex", justifyContent: "space-between" }}
-          subtitle="Do you want to stay logged in?"
-          size="heading6"
+    <>
+      {isModalOpen && (
+        <Box
+          tabIndex={0}
+          className={styles.logoutModalContainer}
+          role="dialog"
+          aria-labelledby="logout-modal-heading"
+          aria-describedby="logout-modal-content"
+          data-testid="logout-modal"
         >
-          Your session is about to expire
-          <Box as="span">
-            {`${timeUntilExpiration.minutes}:${
-              timeUntilExpiration.seconds < 10 ? "0" : ""
-            }${timeUntilExpiration.seconds}`}
-          </Box>
-        </CardHeading>
-        <CardContent>
-          <CardActions className={styles.modalButtons}>
-            <Spacer />
-            <Button
-              buttonType="secondary"
-              onClick={logOutAndRedirect}
-              id="logout-button"
+          <Card
+            layout="row"
+            isBordered={true}
+            backgroundColor="ui.bg.default"
+            className={styles.logoutModalBody}
+          >
+            <CardHeading
+              sx={{ display: "flex", justifyContent: "space-between" }}
+              subtitle="Do you want to stay logged in?"
+              size="heading6"
             >
-              Log out
-            </Button>
-            <Button
-              onClick={() => {
-                stayLoggedIn()
-                setOpen(false)
-              }}
-              id="logged-in-button"
-            >
-              Stay logged in
-            </Button>
-          </CardActions>
-        </CardContent>
-      </Card>
-    </Box>
+              Your session is about to expire
+              <Box as="span">
+                {String(Math.floor(countdown / 60)).padStart(1, "0")}:
+                {String(countdown % 60).padStart(2, "0")}
+              </Box>
+            </CardHeading>
+            <CardContent>
+              <CardActions className={styles.modalButtons}>
+                <Spacer />
+                <Button
+                  buttonType="secondary"
+                  onClick={logOutAndRedirect}
+                  id="logout-button"
+                >
+                  Log out
+                </Button>
+                <Button onClick={stayLoggedIn} id="logged-in-button">
+                  Stay logged in
+                </Button>
+              </CardActions>
+            </CardContent>
+          </Card>
+        </Box>
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4379](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4379)

## This PR does the following:

- Rewrites the logout modal so it can be tested independently of the page
- Separates the inactivity timer and the modal countdown to account for changed behavior once the modal is open

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
