### PR TITLE
SCC-4649: GA events for catalog requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Added
+
+- Adds GA events to onsite and EDD requests [SCC-4649](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4649)
+
 ### Updated
 
 - Updates DS to v3.6.1 [SCC-4630](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4630)

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -5,9 +5,7 @@ import {
   Box,
   SkeletonLoader,
 } from "@nypl/design-system-react-components"
-
 import sierraClient from "../../../../src/server/sierraClient"
-
 import Layout from "../../../../src/components/Layout/Layout"
 import EDDRequestForm from "../../../../src/components/HoldPages/EDDRequestForm"
 import HoldRequestErrorBanner from "../../../../src/components/HoldPages/HoldRequestErrorBanner"
@@ -116,6 +114,21 @@ export default function EDDRequestPage({
     setErrorStatus("failed")
   }
 
+  const handleEDDRequestGAEvent = (item: Item) => {
+    if (typeof window !== "undefined") {
+      window.dataLayer = window.dataLayer || []
+      window.dataLayer.push({
+        event: "catalog_request",
+        catalog_type: "research",
+        request_type: "scan",
+        item_title: item.bibTitle,
+        item_author: null,
+        record_i_number: item.id,
+        record_b_number: item.bibId,
+      })
+    }
+  }
+
   const postEDDRequest = async (eddParams: EDDRequestParams) => {
     try {
       setFormPosting(true)
@@ -183,6 +196,7 @@ export default function EDDRequestPage({
             handleSubmit={postEDDRequest}
             setErrorStatus={setErrorStatus}
             errorStatus={errorStatus}
+            handleGAEvent={() => handleEDDRequestGAEvent(item)}
             holdId={holdId}
           />
         ) : null}

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -94,6 +94,21 @@ export default function HoldRequestPage({
     setErrorStatus("failed")
   }
 
+  const handleHoldRequestGAEvent = (item: Item) => {
+    if (typeof window !== "undefined") {
+      window.dataLayer = window.dataLayer || []
+      window.dataLayer.push({
+        event: "catalog_request",
+        catalog_type: "research",
+        request_type: "on_site",
+        item_title: item.bibTitle,
+        item_author: null,
+        record_i_number: item.id,
+        record_b_number: item.bibId,
+      })
+    }
+  }
+
   const handleSubmit = async (e) => {
     e.preventDefault()
     try {
@@ -128,6 +143,7 @@ export default function HoldRequestPage({
         default:
           setFormPosting(false)
           // Success state
+          handleHoldRequestGAEvent(item)
           await router.push(
             `${PATHS.HOLD_CONFIRMATION}/${holdId}?pickupLocation=${responseJson.pickupLocation}&requestId=${responseJson.requestId}`
           )

--- a/src/components/HoldPages/EDDRequestForm.tsx
+++ b/src/components/HoldPages/EDDRequestForm.tsx
@@ -34,6 +34,7 @@ interface EDDRequestFormProps {
   eddFormState: EDDRequestParams
   setEddFormState: React.Dispatch<React.SetStateAction<EDDRequestParams>>
   handleSubmit: (eddParams: EDDRequestParams) => void
+  handleGAEvent: () => void
   setErrorStatus: (errorStatus: HoldErrorStatus) => void
   holdId: string
   errorStatus?: HoldErrorStatus
@@ -46,6 +47,7 @@ const EDDRequestForm = ({
   eddFormState,
   setEddFormState,
   handleSubmit,
+  handleGAEvent,
   setErrorStatus,
   holdId,
   errorStatus,
@@ -106,6 +108,7 @@ const EDDRequestForm = ({
       validatedInputRefs?.[firstInvalidField.key]?.current.focus()
     } else {
       setErrorStatus(null)
+      handleGAEvent()
       handleSubmit(eddFormState)
     }
   }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  interface Window {
+    dataLayer: any[]
+  }
+}
+export {}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4649](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4649)

## This PR does the following:

- Adds global window type so that clientside components can access `window.dataLayer`
- Adds event to EDD request and on site hold request forms (on successful submission)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

- Needs to be tested in Google Tag Manager

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4649]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ