### PR TITLE
Noref optimize filters

### DIFF
--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -77,18 +77,6 @@ export default function Search({
 
   const { setPersistentFocus } = useFocusContext()
 
-  // Focus should not be set on any specific element on first page load
-  const isFirstLoad = useRef<boolean>(true)
-
-  useEffect(() => {
-    if (isLoading) return
-    if (!isFirstLoad.current) {
-      searchResultsHeadingRef.current?.focus()
-    }
-
-    isFirstLoad.current = false
-  }, [isLoading])
-
   const handlePageChange = async (page: number) => {
     const newQuery = getSearchQuery({ ...searchParams, page })
     setPersistentFocus(null)
@@ -184,6 +172,7 @@ export default function Search({
               {displayAppliedFilters && <AppliedFilters aggregations={aggs} />}
               <Flex justifyContent="space-between" marginTop="xxs">
                 <Heading
+                  id="search-results-heading"
                   data-testid="search-results-heading"
                   level="h2"
                   size="heading5"

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -38,7 +38,7 @@ import initializePatronTokenAuth from "../../src/server/auth"
 import RCHead from "../../src/components/Head/RCHead"
 import type { Aggregation } from "../../src/types/filterTypes"
 import SearchFilters from "../../src/components/SearchFilters/SearchFilters"
-import { useFocusContext } from "../../src/context/FocusContext"
+import { useFocusContext, idConstants } from "../../src/context/FocusContext"
 
 interface SearchProps {
   bannerNotification?: string
@@ -98,7 +98,7 @@ export default function Search({
       SortKey,
       SortOrder | undefined
     ]
-    setPersistentFocus("search-results-sort")
+    setPersistentFocus(idConstants.searchResultsSort)
     // Push the new query values, removing the page number if set.
     await push(
       getSearchQuery({ ...searchParams, sortBy, order, page: undefined }),

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -75,23 +75,14 @@ export default function Search({
 
   const searchResultsHeadingRef = useRef(null)
 
-  const { lastFocusedId, setLastFocusedId } = useFocusContext()
+  const { setPersistentFocus } = useFocusContext()
 
   // Focus should not be set on any specific element on first page load
   const isFirstLoad = useRef<boolean>(true)
 
   useEffect(() => {
     if (isLoading) return
-
-    // If user updated search query with filter/sort/pagination/keyword,
-    // focus on the last used control or the "Display results heading"
-    if (lastFocusedId) {
-      const el = document.getElementById(lastFocusedId)
-      if (el instanceof HTMLElement) {
-        el.focus()
-      }
-      // In all other cases besides first load, focus on the "Display results heading"
-    } else if (!isFirstLoad.current) {
+    if (!isFirstLoad.current) {
       searchResultsHeadingRef.current?.focus()
     }
 
@@ -100,7 +91,7 @@ export default function Search({
 
   const handlePageChange = async (page: number) => {
     const newQuery = getSearchQuery({ ...searchParams, page })
-    setLastFocusedId(null)
+    setPersistentFocus(null)
     await push(
       `${newQuery}${searchedFromAdvanced ? "&searched_from=advanced" : ""}`
     )
@@ -119,7 +110,7 @@ export default function Search({
       SortKey,
       SortOrder | undefined
     ]
-    setLastFocusedId("search-results-sort")
+    setPersistentFocus("search-results-sort")
     // Push the new query values, removing the page number if set.
     await push(
       getSearchQuery({ ...searchParams, sortBy, order, page: undefined }),

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -79,7 +79,7 @@ export default function Search({
 
   const handlePageChange = async (page: number) => {
     const newQuery = getSearchQuery({ ...searchParams, page })
-    setPersistentFocus(null)
+    setPersistentFocus(idConstants.searchResultsHeading)
     await push(
       `${newQuery}${searchedFromAdvanced ? "&searched_from=advanced" : ""}`
     )

--- a/src/components/AppliedFilters/AppliedFilters.tsx
+++ b/src/components/AppliedFilters/AppliedFilters.tsx
@@ -23,7 +23,7 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
     appliedFilters
   )
 
-  const { setLastFocusedId } = useFocusContext()
+  const { setPersistentFocus } = useFocusContext()
 
   // this type cast is happening because Option type had to be updated to
   // account for Offsite's Element label. That label does
@@ -34,7 +34,7 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
   ) as TagSetFilterDataProps[]
   const handleRemove = (tag: TagSetFilterDataProps) => {
     if (tag.label === "Clear filters") {
-      setLastFocusedId("filter-results-heading")
+      setPersistentFocus("filter-results-heading")
       router.push({
         pathname: "/search",
         query: getQueryWithoutFiltersOrPage(router.query),
@@ -50,9 +50,9 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
       ...buildFilterQuery(updatedFilters),
     }
     if (tagSetData.length >= 2) {
-      setLastFocusedId("active-filters-heading")
+      setPersistentFocus("active-filters-heading")
     } else {
-      setLastFocusedId("filter-results-heading")
+      setPersistentFocus("filter-results-heading")
     }
     router.push(
       {

--- a/src/components/AppliedFilters/AppliedFilters.tsx
+++ b/src/components/AppliedFilters/AppliedFilters.tsx
@@ -1,5 +1,8 @@
 import { useRouter } from "next/router"
-import { type TagSetFilterDataProps } from "@nypl/design-system-react-components"
+import {
+  useNYPLBreakpoints,
+  type TagSetFilterDataProps,
+} from "@nypl/design-system-react-components"
 
 import {
   getQueryWithoutFiltersOrPage,
@@ -22,7 +25,7 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
     aggregations,
     appliedFilters
   )
-
+  const { isLargerThanMobile } = useNYPLBreakpoints()
   const { setPersistentFocus } = useFocusContext()
 
   // this type cast is happening because Option type had to be updated to
@@ -52,7 +55,11 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
     if (tagSetData.length >= 2) {
       setPersistentFocus(idConstants.activeFiltersHeading)
     } else {
-      setPersistentFocus(idConstants.filterResultsHeading)
+      setPersistentFocus(
+        isLargerThanMobile
+          ? idConstants.filterResultsHeading
+          : idConstants.searchFiltersModal
+      )
     }
     router.push(
       {

--- a/src/components/AppliedFilters/AppliedFilters.tsx
+++ b/src/components/AppliedFilters/AppliedFilters.tsx
@@ -13,7 +13,7 @@ import {
 } from "./appliedFilterUtils"
 import type { Aggregation } from "../../types/filterTypes"
 import ActiveFilters from "../ItemFilters/ActiveFilters"
-import { useFocusContext } from "../../context/FocusContext"
+import { useFocusContext, idConstants } from "../../context/FocusContext"
 
 const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
   const router = useRouter()
@@ -34,7 +34,7 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
   ) as TagSetFilterDataProps[]
   const handleRemove = (tag: TagSetFilterDataProps) => {
     if (tag.label === "Clear filters") {
-      setPersistentFocus("filter-results-heading")
+      setPersistentFocus(idConstants.filterResultsHeading)
       router.push({
         pathname: "/search",
         query: getQueryWithoutFiltersOrPage(router.query),
@@ -50,9 +50,9 @@ const AppliedFilters = ({ aggregations }: { aggregations: Aggregation[] }) => {
       ...buildFilterQuery(updatedFilters),
     }
     if (tagSetData.length >= 2) {
-      setPersistentFocus("active-filters-heading")
+      setPersistentFocus(idConstants.activeFiltersHeading)
     } else {
-      setPersistentFocus("filter-results-heading")
+      setPersistentFocus(idConstants.filterResultsHeading)
     }
     router.push(
       {

--- a/src/components/SearchFilters/SearchFilterModal.tsx
+++ b/src/components/SearchFilters/SearchFilterModal.tsx
@@ -17,7 +17,7 @@ import {
 import router from "next/router"
 import { getQueryWithoutFiltersOrPage } from "../../utils/refineSearchUtils"
 import SearchFilters from "./SearchFilters"
-import { useFocusContext } from "../../context/FocusContext"
+import { useFocusContext, idConstants } from "../../context/FocusContext"
 import { FilterCount } from "./FilterCount"
 
 const SearchFilterModal = ({
@@ -31,7 +31,7 @@ const SearchFilterModal = ({
   const { setPersistentFocus } = useFocusContext()
 
   const closeModal = () => {
-    setPersistentFocus("search-filters-modal")
+    setPersistentFocus(idConstants.searchFiltersModal)
     setIsModalOpen(false)
   }
 

--- a/src/components/SearchFilters/SearchFilterModal.tsx
+++ b/src/components/SearchFilters/SearchFilterModal.tsx
@@ -28,10 +28,10 @@ const SearchFilterModal = ({
   searchResultsCount?: number
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const { lastFocusedId, setLastFocusedId } = useFocusContext()
+  const { setPersistentFocus } = useFocusContext()
 
   const closeModal = () => {
-    setLastFocusedId("search-filters-modal")
+    setPersistentFocus("search-filters-modal")
     setIsModalOpen(false)
   }
 
@@ -42,13 +42,6 @@ const SearchFilterModal = ({
     })
     closeModal()
   }
-
-  useEffect(() => {
-    if (lastFocusedId === "search-filters-modal") {
-      const el = document.querySelector("button[id=search-filters-modal]")
-      ;(el as HTMLElement)?.focus()
-    }
-  }, [isModalOpen, lastFocusedId])
 
   return (
     <>

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -18,7 +18,7 @@ import {
 import type { Aggregation } from "../../types/filterTypes"
 import DateFilter from "./DateFilter"
 import { useDateFilter } from "../../hooks/useDateFilter"
-import { useFocusContext } from "../../context/FocusContext"
+import { useFocusContext, idConstants } from "../../context/FocusContext"
 
 const fields = [
   { value: "buildingLocation", label: "Item location" },
@@ -147,7 +147,7 @@ const SearchFilters = ({ aggregations }: { aggregations?: Aggregation[] }) => {
         setFocusedFilter(null)
         return
       }
-      setPersistentFocus("apply-dates")
+      setPersistentFocus(idConstants.applyDates)
       buildAndPushFilterQuery(appliedFilters)
     },
   })

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -57,36 +57,28 @@ const SearchFilters = ({ aggregations }: { aggregations?: Aggregation[] }) => {
   }
 
   const handleFilterClear = (field: string) => {
-    setAppliedFilters((prevFilters) => {
-      const newFilters = {
-        ...prevFilters,
-        [field]: [],
-      }
-      setLastFocusedId(
-        `accordion-button-multi-select-accordion-${field}-item-0`
-      )
-      buildAndPushFilterQuery(newFilters)
-      return newFilters
-    })
+    const newFilters = {
+      ...appliedFilters,
+      [field]: [],
+    }
+    setPersistentFocus(
+      `accordion-button-multi-select-accordion-${field}-item-0`
+    )
+    setAppliedFilters(newFilters)
+    buildAndPushFilterQuery(newFilters)
   }
-
   const handleCheckboxChange = (field: string, optionValue: string) => {
-    setAppliedFilters((prevFilters) => {
-      const currentValues = prevFilters[field] || []
-      const isAlreadySelected = currentValues.includes(optionValue)
-      const updatedValues = isAlreadySelected
-        ? currentValues.filter((val) => val !== optionValue)
-        : [...currentValues, optionValue]
-
-      const newFilters = {
-        ...prevFilters,
-        [field]: updatedValues,
-      }
-
-      setLastFocusedId(optionValue)
-      buildAndPushFilterQuery(newFilters)
-      return newFilters
-    })
+    const currentValues = appliedFilters[field] || []
+    const isAlreadySelected = currentValues.includes(optionValue)
+    const updatedValues = isAlreadySelected
+      ? currentValues.filter((val) => val !== optionValue)
+      : [...currentValues, optionValue]
+    const newFilters = {
+      ...appliedFilters,
+      [field]: updatedValues,
+    }
+    setAppliedFilters(newFilters)
+    buildAndPushFilterQuery(newFilters)
   }
 
   const [focusedFilter, setFocusedFilter] = useState<string | null>(null)

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -34,7 +34,7 @@ const SearchFilters = ({ aggregations }: { aggregations?: Aggregation[] }) => {
   const [appliedFilters, setAppliedFilters] = useState(
     collapseMultiValueQueryParams(router.query)
   )
-  const { setLastFocusedId } = useFocusContext()
+  const { setPersistentFocus } = useFocusContext()
   useEffect(() => {
     const collapsedFilters = collapseMultiValueQueryParams(router.query)
     setAppliedFilters(collapsedFilters)
@@ -146,7 +146,7 @@ const SearchFilters = ({ aggregations }: { aggregations?: Aggregation[] }) => {
         setFocusedFilter(null)
         return
       }
-      setLastFocusedId("apply-dates")
+      setPersistentFocus("apply-dates")
       buildAndPushFilterQuery(appliedFilters)
     },
   })

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -77,6 +77,7 @@ const SearchFilters = ({ aggregations }: { aggregations?: Aggregation[] }) => {
       ...appliedFilters,
       [field]: updatedValues,
     }
+    setPersistentFocus(optionValue)
     setAppliedFilters(newFilters)
     buildAndPushFilterQuery(newFilters)
   }

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -47,7 +47,7 @@ const SearchForm = ({
 
   const isLoading = useLoading()
 
-  const { setLastFocusedId } = useFocusContext()
+  const { setPersistentFocus } = useFocusContext()
 
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
@@ -67,7 +67,7 @@ const SearchForm = ({
 
     const queryString = getSearchQuery(searchParams)
 
-    setLastFocusedId(null)
+    setPersistentFocus(null)
     await router.push(`${PATHS.SEARCH}${queryString}`)
   }
 

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -67,7 +67,10 @@ const SearchForm = ({
 
     const queryString = getSearchQuery(searchParams)
 
-    setPersistentFocus(null)
+    if (router.asPath.includes("/search?"))
+      setPersistentFocus("search-results-heading")
+    // if we are doing a search from the home page, there should be no focused element when results are delivered
+    else setPersistentFocus(null)
     await router.push(`${PATHS.SEARCH}${queryString}`)
   }
 

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -19,7 +19,7 @@ import useLoading from "../../hooks/useLoading"
 import type { Aggregation } from "../../types/filterTypes"
 import { collapseMultiValueQueryParams } from "../../utils/refineSearchUtils"
 import SearchFilterModal from "../SearchFilters/SearchFilterModal"
-import { useFocusContext } from "../../context/FocusContext"
+import { useFocusContext, idConstants } from "../../context/FocusContext"
 
 /**
  * The SearchForm component renders and controls the Search form,
@@ -68,7 +68,7 @@ const SearchForm = ({
     const queryString = getSearchQuery(searchParams)
 
     if (router.asPath.includes("/search?"))
-      setPersistentFocus("search-results-heading")
+      setPersistentFocus(idConstants.searchResultsHeading)
     // if we are doing a search from the home page, there should be no focused element when results are delivered
     else setPersistentFocus(null)
     await router.push(`${PATHS.SEARCH}${queryString}`)

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -21,6 +21,15 @@ interface FocusContextType {
  */
 const FocusContext = createContext<FocusContextType | undefined>(undefined)
 
+export const idConstants = {
+  searchResultsHeading: "search-results-heading",
+  searchResultsSort: "search-results-sort",
+  filterResultsHeading: "filter-results-heading",
+  activeFiltersHeading: "active-filters-heading",
+  searchFiltersModal: "search-filters-modal",
+  applyDates: "apply-dates",
+}
+
 export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
   const [activeElementId, setActiveElementId] = useState<string | null>(
     undefined

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -3,13 +3,12 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useState,
 } from "react"
 
 interface FocusContextType {
-  // lastFocusedId: string | null
-  // setLastFocusedId: (id: string | null) => void
+  activeElementId: string | null
+  // setActiveElementId: (id: string | null) => void
   setPersistentFocus: (id: string | null) => void
 }
 
@@ -23,7 +22,10 @@ interface FocusContextType {
 const FocusContext = createContext<FocusContextType | undefined>(undefined)
 
 export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
-  const [lastFocusedId, setLastFocusedId] = useState<string | null>(null)
+  const [activeElementId, setActiveElementId] = useState<string | null>(
+    undefined
+  )
+  // Use this flag to avoid accessing document on the server
   const [isClient, setIsClient] = useState(false)
 
   const setFocusById = useCallback(
@@ -38,23 +40,22 @@ export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
     [isClient]
   )
 
-  setFocusById(lastFocusedId)
+  setFocusById(activeElementId)
 
   const setPersistentFocus = useCallback(
     (id) => {
       setFocusById(id)
-      setLastFocusedId(id)
+      setActiveElementId(id)
     },
     [setFocusById]
   )
 
   useEffect(() => {
-    // This code only runs on the client side
     setIsClient(true)
   }, [])
 
   return (
-    <FocusContext.Provider value={{ setPersistentFocus }}>
+    <FocusContext.Provider value={{ setPersistentFocus, activeElementId }}>
       {children}
     </FocusContext.Provider>
   )

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -34,6 +34,8 @@ export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
   const [activeElementId, setActiveElementId] = useState<string | null>(
     undefined
   )
+  const [prevActiveElementId, setPrevActiveElementId] =
+    useState(activeElementId)
   // Use this flag to avoid accessing document on the server
   const [isClient, setIsClient] = useState(false)
 
@@ -49,7 +51,10 @@ export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
     [isClient]
   )
 
-  setFocusById(activeElementId)
+  if (activeElementId !== prevActiveElementId) {
+    setPrevActiveElementId(activeElementId)
+    setFocusById(activeElementId)
+  }
 
   const setPersistentFocus = useCallback(
     (id) => {

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -1,21 +1,60 @@
-import React, { createContext, useContext, useState } from "react"
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 
 interface FocusContextType {
-  lastFocusedId: string | null
-  setLastFocusedId: (id: string | null) => void
+  // lastFocusedId: string | null
+  // setLastFocusedId: (id: string | null) => void
+  setPersistentFocus: (id: string | null) => void
 }
 
 /**
  * Wrapper context component that maintains state of last used search control,
- * allowing focus to go to the correct element on re-render
+ * allowing focus to go to the correct element on re-render. Exposes
+ * method setPersistentFocus, which focuses on the id provided, and then
+ * maintains that focus in state so the hook can refocus on the correct
+ * component on the next render
  */
 const FocusContext = createContext<FocusContextType | undefined>(undefined)
 
 export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
   const [lastFocusedId, setLastFocusedId] = useState<string | null>(null)
+  const [isClient, setIsClient] = useState(false)
+
+  const setFocusById = useCallback(
+    (id: string) => {
+      if (isClient) {
+        const el = document.getElementById(id)
+        if (el) {
+          el.focus()
+        }
+      }
+    },
+    [isClient]
+  )
+
+  setFocusById(lastFocusedId)
+
+  const setPersistentFocus = useCallback(
+    (id) => {
+      setFocusById(id)
+      setLastFocusedId(id)
+    },
+    [setFocusById]
+  )
+
+  useEffect(() => {
+    // This code only runs on the client side
+    setIsClient(true)
+  }, [])
 
   return (
-    <FocusContext.Provider value={{ lastFocusedId, setLastFocusedId }}>
+    <FocusContext.Provider value={{ setPersistentFocus }}>
       {children}
     </FocusContext.Provider>
   )


### PR DESCRIPTION
Optimize might be optimistic... This pr does the following:
- refactor change handlers on the multiselect so the query update happens after applied filters are updated
   - I'm no longer seeing chrome reporting any violation for the click handler, which was once reporting at >1000ms 
- Not really necessary, but I thought that it might be a slightly easier flow if the `FocusContext` was responsible for the focus state and for refocusing upon page rerender/reload. This might require some more involved QA, but as far as I can see, this update maintains the focus requirements. I would advocate for this approach because it can help us remove some more of the components' knowledge of focus logic. 

I was sporadically seeing some "update depth maximum reached" warnings in the console, but not consistently, so there maybe some sniffing around before this is ready to rock. 