### PR TITLE
Hot fix: results count `undefined` on prod

### DIFF
--- a/src/components/SearchFilters/SearchFilterModal.tsx
+++ b/src/components/SearchFilters/SearchFilterModal.tsx
@@ -110,11 +110,11 @@ const SearchFilterModal = ({
               paddingTop="s"
             >
               <Button id="show-results" onClick={onClose}>
-                {`Show ${
-                  searchResultsCount === 10000
-                    ? "over 10,000"
-                    : searchResultsCount.toLocaleString()
-                } results`}
+                {searchResultsCount === 10000
+                  ? "Show over 10,000 results"
+                  : typeof searchResultsCount === "number"
+                  ? `Show ${searchResultsCount.toLocaleString()} results`
+                  : "Show results"}
               </Button>
               <Button
                 id="clear-filters"


### PR DESCRIPTION
## Ticket:

hot fix post v1.4.8 release

## This PR does the following:

- Makes the modal button using the search result count fail proof by catching the case where the result count is undefined (not observable locally/Vercel but I think the time between requests on an empty search query creates this issue on prod)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

- Does not affect behavior otherwise (safe to keep in prod even if this doesn't resolve the clientside exception issue)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
