### PR TITLE
SCC-4749: Add bib title to tab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Prerelease
+
+## Added
+
+- Added bib title to metadata tab title on bib page [SCC-4749](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4749)
+
 ## [1.5.0] 2025-06-18
 
 ### Added

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -78,7 +78,7 @@ export default function BibPage({
     })
   )
 
-  const metadataTitle = buildBibMetadataTitle(bib.title)
+  const metadataTitle = buildBibMetadataTitle(bib?.title)
   const [itemsLoading, setItemsLoading] = useState(false)
   const [itemFetchError, setItemFetchError] = useState(false)
 

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -11,7 +11,6 @@ import {
 import Layout from "../../../src/components/Layout/Layout"
 import {
   PATHS,
-  SITE_NAME,
   BASE_URL,
   FOCUS_TIMEOUT,
   ERROR_MESSAGES,
@@ -22,6 +21,7 @@ import {
   getBibQueryString,
   buildItemTableDisplayingString,
   isNyplBibID,
+  buildBibMetadataTitle,
 } from "../../../src/utils/bibUtils"
 import BibDetailsModel from "../../../src/models/BibDetails"
 import BibDetails from "../../../src/components/BibPage/BibDetail"
@@ -69,7 +69,6 @@ export default function BibPage({
   notFound = false,
 }: BibPropsType) {
   const { push, query } = useRouter()
-  const metadataTitle = `Item Details | ${SITE_NAME}`
   const [bib, setBib] = useState(
     tryInstantiate({
       constructor: Bib,
@@ -78,6 +77,8 @@ export default function BibPage({
       errorMessage: "Bib undefined",
     })
   )
+
+  const metadataTitle = buildBibMetadataTitle(bib.title)
   const [itemsLoading, setItemsLoading] = useState(false)
   const [itemFetchError, setItemFetchError] = useState(false)
 

--- a/src/utils/bibUtils.ts
+++ b/src/utils/bibUtils.ts
@@ -2,6 +2,7 @@ import {
   ITEM_PAGINATION_BATCH_SIZE,
   ITEM_VIEW_ALL_BATCH_SIZE,
   ITEM_FILTER_PARAMS,
+  SITE_NAME,
 } from "../config/constants"
 import type { BibQueryParams } from "../types/bibTypes"
 import { getPaginationOffsetStrings } from "./appUtils"
@@ -133,4 +134,25 @@ export function getFindingAidFromSupplementaryContent(
   )
 
   return findingAid?.url || null
+}
+
+export function buildBibMetadataTitle(bibTitle?: string | null): string {
+  const TITLE_SUFFIX = `Item Details | ${SITE_NAME}`
+  const MAX_LENGTH = 100
+  const safeTitle = (bibTitle ?? "").trim()
+
+  if (!safeTitle) return TITLE_SUFFIX
+
+  const separator = " | "
+  const fullSuffix = `${separator}${TITLE_SUFFIX}`
+  const ellipsis = "..."
+
+  const maxTitleLength = MAX_LENGTH - fullSuffix.length
+
+  const truncatedTitle =
+    safeTitle.length > maxTitleLength
+      ? `${safeTitle.slice(0, maxTitleLength - ellipsis.length)}${ellipsis}`
+      : safeTitle
+
+  return `${truncatedTitle}${fullSuffix}`
 }

--- a/src/utils/utilsTests/bibUtils.test.ts
+++ b/src/utils/utilsTests/bibUtils.test.ts
@@ -4,6 +4,7 @@ import {
   getBibQueryString,
   buildItemTableDisplayingString,
   itemFiltersActive,
+  buildBibMetadataTitle,
 } from "../bibUtils"
 
 describe("bibUtils", () => {
@@ -154,6 +155,41 @@ describe("bibUtils", () => {
     it("returns the correct item table heading for when filters are applied and there are no matching items", () => {
       expect(buildItemTableDisplayingString(1, 0, false, true)).toBe(
         "No results found matching the applied filters"
+      )
+    })
+  })
+  describe("buildBibMetadataTitle", () => {
+    const suffix = " | Item Details | Research Catalog | NYPL"
+    const suffixLength = suffix.length
+
+    it("returns unmodified title if it's short enough", () => {
+      const title = "Short Title"
+      const result = buildBibMetadataTitle(title)
+      expect(result).toBe(`${title}${suffix}`)
+      expect(result.length).toBeLessThanOrEqual(100)
+    })
+
+    it("truncates long titles and appends suffix", () => {
+      const longTitle = "A".repeat(200)
+      const result = buildBibMetadataTitle(longTitle)
+
+      expect(result.endsWith(suffix)).toBe(true)
+      expect(result.length).toBe(100)
+
+      const expectedTruncatedLength = 100 - suffixLength
+      const prefix = result.slice(0, expectedTruncatedLength)
+      expect(prefix.endsWith("...")).toBe(true)
+    })
+
+    it("truncates at exact length and adds ellipsis", () => {
+      const exactLengthTitle = "A".repeat(100 - suffixLength)
+      const result = buildBibMetadataTitle(`${exactLengthTitle}EXTRA TEXT`)
+      expect(result.length).toBe(100)
+      expect(result.endsWith(suffix)).toBe(true)
+    })
+    it("returns fallback title if input is undefined", () => {
+      expect(buildBibMetadataTitle(undefined)).toBe(
+        "Item Details | Research Catalog | NYPL"
       )
     })
   })


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4749](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4749)

## This PR does the following:

- Adds the bib title (truncated if necessary so that entire string is <= 100 characters) to the tab title on the bib page
- Tests

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Already cleared by Clare

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4749]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ