### PR TITLE
SCC-4771: Language display bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Added langauge back into resoruce feilds under `BibDetails` [SCC-4771](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4771)
+- Added language back into resource fields under `BibDetails` [SCC-4771](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4771)
 
 ## [1.5.0] 2025-06-18
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,13 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Prerelease
+
+### Fixed
+
+- Added langauge back into resoruce feilds under `BibDetails` [SCC-4771](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4771)
+
 ## [1.5.0] 2025-06-18
 
 ### Added
 
 - Added test for View all behavior on bib page [SCC-4296](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4296)
 
-### Update
+### Updated
 
 - send subject search scope queries to bib results instead of SHEP ([SCC-4726](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4726))
 - bib 404's maintain bib urls

--- a/src/components/BibPage/BibDetail.test.tsx
+++ b/src/components/BibPage/BibDetail.test.tsx
@@ -32,7 +32,28 @@ describe("BibDetail component", () => {
     bibWithFindingAidAndTOC.annotatedMarc
   )
   describe("bottom details", () => {
-    it.todo("")
+    it("renders resource fields", () => {
+      render(<BibDetails details={noParallelsBibModel.bottomDetails} />, {
+        wrapper: MemoryRouterProvider,
+      })
+
+      expect(screen.getByText("Language")).toBeInTheDocument()
+      expect(screen.getByText("French")).toBeInTheDocument()
+      expect(screen.getByText("Series statement")).toBeInTheDocument()
+      expect(screen.queryAllByText(/Haute enfance/)[0]).toBeInTheDocument()
+    })
+    it("merges annotated MARC and resource fields without duplicates", () => {
+      const combinedDetails = noParallelsBibModel.bottomDetails
+      const labels = combinedDetails.map((d) => d.label)
+      const labelCounts = labels.reduce((acc, label) => {
+        acc[label] = (acc[label] || 0) + 1
+        return acc
+      }, {})
+
+      Object.values(labelCounts).forEach((count) => {
+        expect(count).toBeLessThanOrEqual(1)
+      })
+    })
   })
   describe("text only details", () => {
     it("single value", () => {

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -10,7 +10,6 @@ import type {
 } from "../types/bibDetailsTypes"
 import { convertToSentenceCase } from "../utils/appUtils"
 import { getFindingAidFromSupplementaryContent } from "../utils/bibUtils"
-import type { JSONLDValue } from "../types/itemTypes"
 
 export default class BibDetails {
   bib: DiscoveryBibResult
@@ -140,8 +139,6 @@ export default class BibDetails {
         let detail: AnyBibDetail
         if (fieldMapping.field === "contributorLiteral")
           detail = this.buildSearchFilterUrl(fieldMapping)
-        else if (fieldMapping.field === "language")
-          detail = this.buildLanguageDetail(fieldMapping)
         else detail = this.buildStandardDetail(fieldMapping)
         return detail
       })
@@ -185,9 +182,12 @@ export default class BibDetails {
   }
 
   buildStandardDetail(fieldMapping: FieldMapping) {
-    const bibFieldValue =
-      this[fieldMapping.field] || this.bib[fieldMapping.field]
+    let bibFieldValue = this[fieldMapping.field] || this.bib[fieldMapping.field]
     if (!bibFieldValue) return
+    // "language" is the only resource field with JSON-LD format
+    if (fieldMapping.field === "language") {
+      bibFieldValue = [bibFieldValue[0]?.prefLabel]
+    }
     return this.buildDetail(
       convertToSentenceCase(fieldMapping.label),
       bibFieldValue
@@ -200,15 +200,6 @@ export default class BibDetails {
     return {
       label: convertToSentenceCase(label),
       value,
-    }
-  }
-
-  buildLanguageDetail(fieldMapping: FieldMapping): BibDetail {
-    const bibFieldValue =
-      this[fieldMapping.field] || this.bib[fieldMapping.field]
-    return {
-      label: "Language",
-      value: [bibFieldValue[0].prefLabel],
     }
   }
 

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -10,6 +10,7 @@ import type {
 } from "../types/bibDetailsTypes"
 import { convertToSentenceCase } from "../utils/appUtils"
 import { getFindingAidFromSupplementaryContent } from "../utils/bibUtils"
+import type { JSONLDValue } from "../types/itemTypes"
 
 export default class BibDetails {
   bib: DiscoveryBibResult
@@ -133,11 +134,14 @@ export default class BibDetails {
       { field: "oclc", label: "OCLC" },
       { field: "lccn", label: "LCCN" },
       { field: "owner", label: "Owning institution" },
+      { field: "language", label: "Language" },
     ]
       .map((fieldMapping: FieldMapping): AnyBibDetail => {
         let detail: AnyBibDetail
         if (fieldMapping.field === "contributorLiteral")
           detail = this.buildSearchFilterUrl(fieldMapping)
+        else if (fieldMapping.field === "language")
+          detail = this.buildLanguageDetail(fieldMapping)
         else detail = this.buildStandardDetail(fieldMapping)
         return detail
       })
@@ -196,6 +200,15 @@ export default class BibDetails {
     return {
       label: convertToSentenceCase(label),
       value,
+    }
+  }
+
+  buildLanguageDetail(fieldMapping: FieldMapping): BibDetail {
+    const bibFieldValue =
+      this[fieldMapping.field] || this.bib[fieldMapping.field]
+    return {
+      label: "Language",
+      value: [bibFieldValue[0].prefLabel],
     }
   }
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4771](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4771)

## This PR does the following:

- Adds language back into the resource fields that we display in`bottomDetails` for `BibDetails` (probably missed in the migration to DFE)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4771]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ