### PR TITLE
SCC-4148: Renaming search result types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Updated
+
+- Adding "Discovery" to `SearchResults`, `AggregationResults`, and `SearchResultsElement` to parallel `DiscoveryBibResult` and indicate the API structure [SCC-4148](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4148)
+
 ### Fixed
 
 - Added language back into resource fields under `BibDetails` [SCC-4771](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4771)

--- a/src/types/searchTypes.ts
+++ b/src/types/searchTypes.ts
@@ -46,21 +46,21 @@ export type SortOrder = "asc" | "desc"
 
 export interface SearchResultsResponse {
   status: HTTPStatusCode
-  results?: SearchResults
-  aggregations?: AggregationResults
+  results?: DiscoverySearchResults
+  aggregations?: DiscoveryAggregationResults
   page?: number
 }
 
-export interface AggregationResults {
+export interface DiscoveryAggregationResults {
   totalResults: number
   itemListElement: Aggregation[]
 }
-export interface SearchResults {
+export interface DiscoverySearchResults {
   totalResults: number
-  itemListElement: SearchResultsElement[]
+  itemListElement: DiscoverySearchResultsElement[]
 }
 
-export interface SearchResultsElement {
+export interface DiscoverySearchResultsElement {
   result?: DiscoveryBibResult
   field?: string
 }

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -6,8 +6,7 @@ import type {
   SearchQueryParams,
   SearchFilters,
   Identifiers,
-  SearchResultsElement,
-  SearchResultsResponse,
+  DiscoverySearchResultsElement,
 } from "../types/searchTypes"
 import SearchResultsBib from "../models/SearchResultsBib"
 import { RESULTS_PER_PAGE, SEARCH_FORM_OPTIONS } from "../config/constants"
@@ -246,10 +245,10 @@ export function mapRequestBodyToSearchParams(
 
 /**
  * mapElementsToSearchResultsBibs
- * Maps the SearchResultsElement structure from the search results response to an array of SearchResultsBib objects
+ * Maps the DiscoverySearchResultsElement structure from the search results response to an array of SearchResultsBib objects
  */
 export function mapElementsToSearchResultsBibs(
-  elements: SearchResultsElement[]
+  elements: DiscoverySearchResultsElement[]
 ): SearchResultsBib[] | null {
   return (
     elements


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4148](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4148)

## This PR does the following:

- Renames search result types to indicate they come from Discovery API, paralleling the name for `DiscoveryBibResult`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
