### PR TITLE
Remove duplicate SearchResultSort component between mobile and desktop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Adding "Discovery" to `SearchResults`, `AggregationResults`, and `SearchResultsElement` to parallel `DiscoveryBibResult` and indicate the API structure [SCC-4148](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4148)
+- Remove duplicate SearchResultSort component between mobile and desktop [SCC-4086](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4086)
 
 ### Fixed
 

--- a/__test__/pages/search/searchResults.test.tsx
+++ b/__test__/pages/search/searchResults.test.tsx
@@ -51,22 +51,13 @@ describe("Search Results page", () => {
           results={{ results, status: 200 }}
         />
       )
-      const mobileSortBy = screen.getAllByLabelText("Sort by")[0]
-      expect(mobileSortBy).toHaveValue("relevance")
-      await userEvent.selectOptions(mobileSortBy, "Title (A - Z)")
-      expect(mobileSortBy).toHaveValue("title_asc")
+      const sortBy = screen.getAllByLabelText("Sort by")[0]
+      expect(sortBy).toHaveValue("relevance")
+      await userEvent.selectOptions(sortBy, "Title (A - Z)")
+      expect(sortBy).toHaveValue("title_asc")
 
       expect(mockRouter.asPath).toBe(
         "/?q=spaghetti&sort=title&sort_direction=asc"
-      )
-
-      const desktopSortBy = screen.getAllByLabelText("Sort by")[1]
-      expect(desktopSortBy).toHaveValue("title_asc")
-      await userEvent.selectOptions(desktopSortBy, "Title (Z - A)")
-      expect(desktopSortBy).toHaveValue("title_desc")
-
-      expect(mockRouter.asPath).toBe(
-        "/?q=spaghetti&sort=title&sort_direction=desc"
       )
     })
     it("returns the user to the first page on sorting changes", async () => {

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -167,7 +167,11 @@ export default function Search({
         >
           <Flex flexDir="column">
             {displayAppliedFilters && <AppliedFilters aggregations={aggs} />}
-            <Flex justifyContent="space-between" marginTop="xxs">
+            <Flex
+              justifyContent="space-between"
+              marginTop="xxs"
+              direction={{ base: "column", md: "row" }}
+            >
               <Heading
                 id="search-results-heading"
                 data-testid="search-results-heading"
@@ -185,28 +189,10 @@ export default function Search({
               <SearchResultsSort
                 searchParams={searchParams}
                 handleSortChange={handleSortChange}
-                // TODO: Extend the Layout component to receive a prop that contains content to be shown below the
-                //  main header, which will include the search results heading and the sort select, which would allow us
-                //  to only render the sort select once.
-                display={{
-                  base: "none",
-                  md: "block",
-                }}
               />
             </Flex>
           </Flex>
 
-          <SearchResultsSort
-            // Mobile only Search Results Sort Select
-            // Necessary due to the placement of the Select in the main content on mobile only.
-            id="search-results-sort-mobile"
-            searchParams={searchParams}
-            handleSortChange={handleSortChange}
-            display={{
-              base: "block",
-              md: "none",
-            }}
-          />
           {isLoading ? (
             <>
               <SkeletonLoader showImage={false} mb="m" />


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4086](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4086)

## This PR does the following:

- No longer renders the Sort select component twice (once for desktop, once for mobile) and instead just places it in a flex row (inline) or column (new line) dynamically when we are using mobile width.
- Functionally, this should look and feel exactly like what we have today just without the double component in the code.

## How has this been tested?

- Tested locally to confirm that the sort select moves where you'd expect when using a mobile width.

## Accessibility concerns or updates

- No new concerns- this should be functionally the same as before.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [N/A] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
