### PR TITLE
SCC-4787: General error page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added bib title to metadata tab title on bib page [SCC-4749](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4749)
 - Adds warning to hold request pages if user has already completed the request [SCC-3360](https://newyorkpubliclibrary.atlassian.net/browse/SCC-3360)
 - Adds new 404 page, handling to cover common search response errors, and new search error view [SCC-3792](https://newyorkpubliclibrary.atlassian.net/browse/SCC-3792)
+- Adds general error boundary page `_error.tsx` and a test page that throws errors `testError.tsx` [SCC-4787](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4787)
 
 ## [1.5.0] 2025-06-18
 

--- a/__test__/pages/_error/_error.test.tsx
+++ b/__test__/pages/_error/_error.test.tsx
@@ -9,11 +9,4 @@ describe("500 error page", () => {
     const heading = within(container).getByRole("heading")
     expect(heading).toHaveTextContent("Something went wrong on our end")
   })
-  it("should have link to feedback box", () => {
-    render(<Error activePage="hold" />)
-    const container = screen.getByRole("main")
-
-    const feedbackLink = within(container).getByRole("link")
-    expect(feedbackLink).toHaveTextContent("contact us")
-  })
 })

--- a/__test__/pages/_error/_error.test.tsx
+++ b/__test__/pages/_error/_error.test.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { render, screen, within } from "../../../src/utils/testUtils"
+import Error from "../../../pages/_error"
+
+describe("500 error page", () => {
+  it("should display error text", () => {
+    render(<Error activePage="account" />)
+    const container = screen.getByRole("main")
+    const heading = within(container).getByRole("heading")
+    expect(heading).toHaveTextContent("Something went wrong on our end")
+  })
+  it("should have link to feedback box", () => {
+    render(<Error activePage="hold" />)
+    const container = screen.getByRole("main")
+
+    const feedbackLink = within(container).getByRole("link")
+    expect(feedbackLink).toHaveTextContent("contact us")
+  })
+})

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,0 +1,56 @@
+import { Heading, Text, Flex, Link } from "@nypl/design-system-react-components"
+import Layout from "../src/components/Layout/Layout"
+import { SITE_NAME } from "../src/config/constants"
+import RCHead from "../src/components/Head/RCHead"
+import type { RCPage } from "../src/types/pageTypes"
+import Image from "next/image"
+import errorImage from "../src/assets/errorImage.png"
+import { useContext } from "react"
+import { FeedbackContext } from "../src/context/FeedbackContext"
+
+type ErrorPageProps = {
+  activePage: RCPage
+}
+
+function Error({ activePage }: ErrorPageProps) {
+  const metadataTitle = `500 | ${SITE_NAME}`
+  const { onOpen } = useContext(FeedbackContext)
+  return (
+    <>
+      <RCHead metadataTitle={metadataTitle} />
+      <Layout activePage={activePage}>
+        <Flex
+          flexDir="column"
+          marginTop="xxl"
+          marginBottom="xxl"
+          marginLeft="l"
+          marginRight="l"
+          alignItems="center"
+          justifyContent="center"
+          textAlign="center"
+        >
+          <Image
+            src={errorImage}
+            alt="Error image"
+            width={98}
+            height={68}
+            style={{ marginBottom: "48px" }}
+          />
+          <Heading level="h3">Something went wrong on our end</Heading>
+          <Text marginBottom="0">
+            We encountered an error while trying to load the page.
+          </Text>
+          <Text marginBottom="0">
+            Try refreshing the page or{" "}
+            <Link onClick={onOpen} id="feedback-link">
+              contact us
+            </Link>{" "}
+            if the error persists.
+          </Text>
+        </Flex>
+      </Layout>
+    </>
+  )
+}
+
+export default Error

--- a/pages/testError.tsx
+++ b/pages/testError.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react"
+
+function TestError() {
+  //throw new Error("Throwing a client side test error")
+  useEffect(() => {
+    throw new Error("Throwing a client side error after mount")
+  }, [])
+}
+
+// SomePage.getInitialProps = () => {
+//   throw new Error("Throwing a server test error")
+// }
+
+export default TestError

--- a/pages/testError.tsx
+++ b/pages/testError.tsx
@@ -7,7 +7,7 @@ function TestError() {
   }, [])
 }
 
-// SomePage.getInitialProps = () => {
+// TestError.getInitialProps = () => {
 //   throw new Error("Throwing a server test error")
 // }
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4787](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4787)

## This PR does the following:

- Creates the custom error page for uncaught server/client errors that are not 404s
- Creates a test error page which throws an error
- Unit tests for the error page

## How has this been tested?

- Locally, you can uncomment one of the three potential errors in `testError.tsx`, then build and run the app in production mode (`npm run build`, `npm run start`), and go to `localhost:3000/research/research-catalog/testError` ) to see the app catch the error
   - If you do this with `npm run dev` it'll just show you the Next overlay with the error because it assumes you want to resolve it :)


## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4787]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ