### PR TITLE
SCC-4776: Add requested URL to feedback data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Added Playwright, the end-to-end testing framework for automating and verifying browser interactions across Chromium, Firefox, and WebKit. [SCC-4772] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4772)
+- Adds Playwright, the end-to-end testing framework for automating and verifying browser interactions across Chromium, Firefox, and WebKit [SCC-4772](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4772)
+- Adds page error notification and requested URL to feedback box [SCC-4776](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4776)
 
 ### Updated
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -30,6 +30,17 @@ const mockPatronJwtDecodedObj = {
   scope: "openid",
 }
 
+// Mock the router for feedback box, local mock will take precedence
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    asPath: "/mock",
+    push: jest.fn(),
+    replace: jest.fn(),
+    pathname: "/mock",
+    query: {},
+  }),
+}))
+
 // Mock the "jose" library that does the JWT verification.
 jest.mock("jose", () => ({
   importSPKI: async () => Promise.resolve("testPublicKey"),

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -15,7 +15,7 @@ type ErrorPageProps = {
 
 export default function Custom404({ activePage }: ErrorPageProps) {
   const metadataTitle = `404 | ${SITE_NAME}`
-  const { onContact } = useContext(FeedbackContext)
+  const { onErrorContact } = useContext(FeedbackContext)
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
@@ -45,7 +45,7 @@ export default function Custom404({ activePage }: ErrorPageProps) {
           </Text>
           <Text noSpace>
             Try a <RCLink href="/">new search</RCLink> or{" "}
-            <Link onClick={onContact} id="feedback-link">
+            <Link onClick={onErrorContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -16,11 +16,11 @@ type ErrorPageProps = {
 
 export default function Custom404({ activePage }: ErrorPageProps) {
   const metadataTitle = `404 | ${SITE_NAME}`
-  const { onOpen, setRequestURL } = useContext(FeedbackContext)
+  const { onOpen, setRequestedURL } = useContext(FeedbackContext)
   const router = useRouter()
   const currentPath = router.asPath
   const onContact = () => {
-    setRequestURL(`${BASE_URL}${currentPath}`)
+    setRequestedURL(`${BASE_URL}${currentPath}`)
     onOpen()
   }
   return (

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -15,7 +15,7 @@ type ErrorPageProps = {
 
 export default function Custom404({ activePage }: ErrorPageProps) {
   const metadataTitle = `404 | ${SITE_NAME}`
-  const { onErrorContact } = useContext(FeedbackContext)
+  const { openFeedbackFormWithError } = useContext(FeedbackContext)
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
@@ -45,7 +45,7 @@ export default function Custom404({ activePage }: ErrorPageProps) {
           </Text>
           <Text noSpace>
             Try a <RCLink href="/">new search</RCLink> or{" "}
-            <Link onClick={onErrorContact} id="feedback-link">
+            <Link onClick={openFeedbackFormWithError} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -1,6 +1,6 @@
 import { Heading, Text, Flex, Link } from "@nypl/design-system-react-components"
 import Layout from "../../src/components/Layout/Layout"
-import { SITE_NAME } from "../../src/config/constants"
+import { BASE_URL, SITE_NAME } from "../../src/config/constants"
 import RCHead from "../../src/components/Head/RCHead"
 import type { RCPage } from "../../src/types/pageTypes"
 import Image from "next/image"
@@ -8,6 +8,7 @@ import errorImage from "../../src/assets/errorImage.png"
 import { useContext } from "react"
 import { FeedbackContext } from "../../src/context/FeedbackContext"
 import RCLink from "../../src/components/Links/RCLink/RCLink"
+import { useRouter } from "next/router"
 
 type ErrorPageProps = {
   activePage: RCPage
@@ -15,7 +16,13 @@ type ErrorPageProps = {
 
 export default function Custom404({ activePage }: ErrorPageProps) {
   const metadataTitle = `404 | ${SITE_NAME}`
-  const { onOpen } = useContext(FeedbackContext)
+  const { onOpen, setRequestURL } = useContext(FeedbackContext)
+  const router = useRouter()
+  const currentPath = router.asPath
+  const onContact = () => {
+    setRequestURL(`${BASE_URL}${currentPath}`)
+    onOpen()
+  }
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
@@ -45,7 +52,7 @@ export default function Custom404({ activePage }: ErrorPageProps) {
           </Text>
           <Text noSpace>
             Try a <RCLink href="/">new search</RCLink> or{" "}
-            <Link onClick={onOpen} id="feedback-link">
+            <Link onClick={onContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -1,6 +1,6 @@
 import { Heading, Text, Flex, Link } from "@nypl/design-system-react-components"
 import Layout from "../../src/components/Layout/Layout"
-import { BASE_URL, SITE_NAME } from "../../src/config/constants"
+import { SITE_NAME } from "../../src/config/constants"
 import RCHead from "../../src/components/Head/RCHead"
 import type { RCPage } from "../../src/types/pageTypes"
 import Image from "next/image"
@@ -8,7 +8,6 @@ import errorImage from "../../src/assets/errorImage.png"
 import { useContext } from "react"
 import { FeedbackContext } from "../../src/context/FeedbackContext"
 import RCLink from "../../src/components/Links/RCLink/RCLink"
-import { useRouter } from "next/router"
 
 type ErrorPageProps = {
   activePage: RCPage
@@ -16,13 +15,7 @@ type ErrorPageProps = {
 
 export default function Custom404({ activePage }: ErrorPageProps) {
   const metadataTitle = `404 | ${SITE_NAME}`
-  const { onOpen, setRequestedURL } = useContext(FeedbackContext)
-  const router = useRouter()
-  const currentPath = router.asPath
-  const onContact = () => {
-    setRequestedURL(`${BASE_URL}${currentPath}`)
-    onOpen()
-  }
+  const { onContact } = useContext(FeedbackContext)
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,13 +1,12 @@
 import { Heading, Text, Flex, Link } from "@nypl/design-system-react-components"
 import Layout from "../src/components/Layout/Layout"
-import { BASE_URL, SITE_NAME } from "../src/config/constants"
+import { SITE_NAME } from "../src/config/constants"
 import RCHead from "../src/components/Head/RCHead"
 import type { RCPage } from "../src/types/pageTypes"
 import Image from "next/image"
 import errorImage from "../src/assets/errorImage.png"
 import { useContext } from "react"
 import { FeedbackContext } from "../src/context/FeedbackContext"
-import { useRouter } from "next/router"
 
 type ErrorPageProps = {
   activePage: RCPage
@@ -15,13 +14,8 @@ type ErrorPageProps = {
 
 function Error({ activePage }: ErrorPageProps) {
   const metadataTitle = `500 | ${SITE_NAME}`
-  const { onOpen, setRequestedURL } = useContext(FeedbackContext)
-  const router = useRouter()
-  const currentPath = router.asPath
-  const onContact = () => {
-    setRequestedURL(`${BASE_URL}${currentPath}`)
-    onOpen()
-  }
+  const { onContact } = useContext(FeedbackContext)
+
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,12 +1,13 @@
 import { Heading, Text, Flex, Link } from "@nypl/design-system-react-components"
 import Layout from "../src/components/Layout/Layout"
-import { SITE_NAME } from "../src/config/constants"
+import { BASE_URL, SITE_NAME } from "../src/config/constants"
 import RCHead from "../src/components/Head/RCHead"
 import type { RCPage } from "../src/types/pageTypes"
 import Image from "next/image"
 import errorImage from "../src/assets/errorImage.png"
 import { useContext } from "react"
 import { FeedbackContext } from "../src/context/FeedbackContext"
+import { useRouter } from "next/router"
 
 type ErrorPageProps = {
   activePage: RCPage
@@ -14,7 +15,13 @@ type ErrorPageProps = {
 
 function Error({ activePage }: ErrorPageProps) {
   const metadataTitle = `500 | ${SITE_NAME}`
-  const { onOpen } = useContext(FeedbackContext)
+  const { onOpen, setRequestedURL } = useContext(FeedbackContext)
+  const router = useRouter()
+  const currentPath = router.asPath
+  const onContact = () => {
+    setRequestedURL(`${BASE_URL}${currentPath}`)
+    onOpen()
+  }
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
@@ -42,7 +49,7 @@ function Error({ activePage }: ErrorPageProps) {
           </Text>
           <Text marginBottom="0">
             Try refreshing the page or{" "}
-            <Link onClick={onOpen} id="feedback-link">
+            <Link onClick={onContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -14,7 +14,7 @@ type ErrorPageProps = {
 
 function Error({ activePage }: ErrorPageProps) {
   const metadataTitle = `500 | ${SITE_NAME}`
-  const { onErrorContact } = useContext(FeedbackContext)
+  const { openFeedbackFormWithError } = useContext(FeedbackContext)
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
@@ -42,7 +42,7 @@ function Error({ activePage }: ErrorPageProps) {
           </Text>
           <Text marginBottom="0">
             Try refreshing the page or{" "}
-            <Link onClick={onErrorContact} id="feedback-link">
+            <Link onClick={openFeedbackFormWithError} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -14,8 +14,7 @@ type ErrorPageProps = {
 
 function Error({ activePage }: ErrorPageProps) {
   const metadataTitle = `500 | ${SITE_NAME}`
-  const { onContact } = useContext(FeedbackContext)
-
+  const { onErrorContact } = useContext(FeedbackContext)
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
@@ -43,7 +42,7 @@ function Error({ activePage }: ErrorPageProps) {
           </Text>
           <Text marginBottom="0">
             Try refreshing the page or{" "}
-            <Link onClick={onContact} id="feedback-link">
+            <Link onClick={onErrorContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/pages/api/feedback-rc.ts
+++ b/pages/api/feedback-rc.ts
@@ -14,6 +14,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       appConfig.libAnswersEmail,
       appConfig.sourceEmail
     )
+    console.log(emailParams)
     // Create the promise and SES service object
     const sendPromise = new aws.SES({ apiVersion: "2010-12-01" })
       .sendEmail(emailParams)

--- a/pages/api/feedback-rc.ts
+++ b/pages/api/feedback-rc.ts
@@ -14,7 +14,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       appConfig.libAnswersEmail,
       appConfig.sourceEmail
     )
-    console.log(emailParams)
     // Create the promise and SES service object
     const sendPromise = new aws.SES({ apiVersion: "2010-12-01" })
       .sendEmail(emailParams)

--- a/src/components/FeedbackForm/FeedbackForm.test.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.test.tsx
@@ -3,8 +3,9 @@ import userEvent from "@testing-library/user-event"
 
 import { render, screen } from "../../utils/testUtils"
 import FeedbackForm from "./FeedbackForm"
+import { FeedbackContext } from "../../context/FeedbackContext"
 
-describe("FeedbackForm", () => {
+describe("rendering FeedbackForm", () => {
   it("renders a feedback button, expands the form on click, and closes it on cancel button click", async () => {
     render(<FeedbackForm></FeedbackForm>)
 
@@ -42,5 +43,83 @@ describe("FeedbackForm", () => {
         "Oops! Something went wrong. An error occured while processing your feedback."
       )
     ).toBeInTheDocument()
+  })
+})
+
+describe("FeedbackForm props in context", () => {
+  const baseContext = {
+    FeedbackBox: (props: any) => {
+      return (
+        <div>
+          <div data-testid="notificationText">{props.notificationText}</div>
+        </div>
+      )
+    },
+    isOpen: true,
+    onClose: jest.fn(),
+    onOpen: jest.fn(),
+    itemMetadata: null,
+    setItemMetadata: jest.fn(),
+    requestedURL: null,
+    setRequestedURL: jest.fn(),
+    onContact: jest.fn(),
+  }
+
+  it("renders notification text for requestedURL", () => {
+    render(
+      <FeedbackContext.Provider
+        value={{ ...baseContext, requestedURL: "https://example.com/error" }}
+      >
+        <FeedbackForm />
+      </FeedbackContext.Provider>
+    )
+
+    expect(screen.getByTestId("notificationText")).toHaveTextContent(
+      "You are asking for help or information about a page error"
+    )
+  })
+
+  it("renders notification text from itemMetadata.notificationText", () => {
+    render(
+      <FeedbackContext.Provider
+        value={{
+          ...baseContext,
+          itemMetadata: { notificationText: "Item metadata notification" },
+        }}
+      >
+        <FeedbackForm />
+      </FeedbackContext.Provider>
+    )
+
+    expect(screen.getByTestId("notificationText")).toHaveTextContent(
+      "Item metadata notification"
+    )
+  })
+
+  it("renders notification text from itemMetadata.callNumber", () => {
+    render(
+      <FeedbackContext.Provider
+        value={{
+          ...baseContext,
+          itemMetadata: { callNumber: "QA 1234 .B56" },
+        }}
+      >
+        <FeedbackForm />
+      </FeedbackContext.Provider>
+    )
+
+    expect(screen.getByTestId("notificationText")).toHaveTextContent(
+      "You are asking for help or information about QA 1234 .B56 in this record."
+    )
+  })
+
+  it("renders no notification text when itemMetadata and requestedURL are null", () => {
+    render(
+      <FeedbackContext.Provider value={baseContext}>
+        <FeedbackForm />
+      </FeedbackContext.Provider>
+    )
+
+    expect(screen.getByTestId("notificationText")).toBeEmptyDOMElement()
   })
 })

--- a/src/components/FeedbackForm/FeedbackForm.test.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.test.tsx
@@ -62,14 +62,14 @@ describe("FeedbackForm props in context", () => {
     setItemMetadata: jest.fn(),
     requestedURL: null,
     setRequestedURL: jest.fn(),
-    onContact: jest.fn(),
+    isError: false,
+    setError: jest.fn(),
+    onErrorContact: jest.fn(),
   }
 
-  it("renders notification text for requestedURL", () => {
+  it("renders notification text for error state", () => {
     render(
-      <FeedbackContext.Provider
-        value={{ ...baseContext, requestedURL: "https://example.com/error" }}
-      >
+      <FeedbackContext.Provider value={{ ...baseContext, isError: true }}>
         <FeedbackForm />
       </FeedbackContext.Provider>
     )

--- a/src/components/FeedbackForm/FeedbackForm.test.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.test.tsx
@@ -64,7 +64,7 @@ describe("FeedbackForm props in context", () => {
     setRequestedURL: jest.fn(),
     isError: false,
     setError: jest.fn(),
-    onErrorContact: jest.fn(),
+    openFeedbackFormWithError: jest.fn(),
   }
 
   it("renders notification text for error state", () => {

--- a/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useState } from "react"
 import { FeedbackContext } from "../../context/FeedbackContext"
 import type { FeedbackMetadataAndComment } from "../../types/feedbackTypes"
 import type { ItemMetadata } from "../../types/itemTypes"
+import { BASE_URL } from "../../config/constants"
 
 /**
  * Component that wraps the DS Feedback box. Can be opened by clicking the button rendered
@@ -41,29 +42,29 @@ const FeedbackForm = () => {
     metadataAndComment: FeedbackMetadataAndComment
   ) => {
     console.log(metadataAndComment)
-    // try {
-    //   // Changed this route to /feedback-rc to avoid conflicts with DFE with 2AD reverse proxy config
-    //   // TODO: Change this route name back to /feedback when all routes point to research catalog
-    //   // const response = await fetch(`${BASE_URL}/api/feedback-rc`, {
-    //   //   method: "POST",
-    //   //   body: JSON.stringify(metadataAndComment),
-    //   // })
-    //   //const responseJson = await response.json()
-    //   if (responseJson.error) {
-    //     console.error("Error in feedback api response", responseJson.error)
-    //     setFeedbackFormScreen("error")
-    //   } else {
-    //     setFeedbackFormScreen("confirmation")
-    //   }
-    // } catch (error) {
-    //   console.error("Error posting feedback", error)
-    //   setFeedbackFormScreen("error")
-    // }
+    try {
+      // Changed this route to /feedback-rc to avoid conflicts with DFE with 2AD reverse proxy config
+      // TODO: Change this route name back to /feedback when all routes point to research catalog
+      const response = await fetch(`${BASE_URL}/api/feedback-rc`, {
+        method: "POST",
+        body: JSON.stringify(metadataAndComment),
+      })
+      const responseJson = await response.json()
+      if (responseJson.error) {
+        console.error("Error in feedback api response", responseJson.error)
+        setFeedbackFormScreen("error")
+      } else {
+        setFeedbackFormScreen("confirmation")
+      }
+    } catch (error) {
+      console.error("Error posting feedback", error)
+      setFeedbackFormScreen("error")
+    }
   }
 
   const notificationText = (
-    itemMetadata: ItemMetadata,
-    requestedURL: string | null
+    itemMetadata?: ItemMetadata,
+    requestedURL?: string | null
   ) => {
     if (requestedURL) {
       return "You are asking for help or information about a page error"

--- a/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useState } from "react"
 
 import { FeedbackContext } from "../../context/FeedbackContext"
 import type { FeedbackMetadataAndComment } from "../../types/feedbackTypes"
-import type { ItemMetadata } from "../../types/itemTypes"
 import { BASE_URL } from "../../config/constants"
 
 /**
@@ -22,13 +21,13 @@ const FeedbackForm = () => {
     setRequestedURL,
     isError,
     setError,
-    onErrorContact,
+    openFeedbackFormWithError,
   } = useContext(FeedbackContext)
 
   const closeAndResetFeedbackData = () => {
-    if (itemMetadata) setItemMetadata(null)
-    if (requestedURL) setRequestedURL(null)
-    if (isError) setError(false)
+    setItemMetadata(null)
+    setRequestedURL(null)
+    setError(false)
     onClose()
     setFeedbackFormScreen("form")
 
@@ -45,7 +44,6 @@ const FeedbackForm = () => {
   const submitFeedback = async (
     metadataAndComment: FeedbackMetadataAndComment
   ) => {
-    console.log(metadataAndComment)
     try {
       // Changed this route to /feedback-rc to avoid conflicts with DFE with 2AD reverse proxy config
       // TODO: Change this route name back to /feedback when all routes point to research catalog
@@ -66,16 +64,13 @@ const FeedbackForm = () => {
     }
   }
 
-  const notificationText = (itemMetadata?: ItemMetadata) => {
-    if (isError) {
-      return "You are asking for help or information about a page error"
-    }
-    if (itemMetadata?.notificationText) {
-      return itemMetadata.notificationText
-    } else if (itemMetadata?.callNumber) {
-      return `You are asking for help or information about ${itemMetadata.callNumber} in this record.`
-    } else return null
-  }
+  const notificationText = isError
+    ? "You are asking for help or information about a page error"
+    : itemMetadata?.notificationText
+    ? itemMetadata.notificationText
+    : itemMetadata?.callNumber
+    ? `You are asking for help or information about ${itemMetadata.callNumber} in this record.`
+    : null
 
   return (
     <FeedbackBox
@@ -90,7 +85,7 @@ const FeedbackForm = () => {
         ...itemMetadata,
         requestedURL,
       }}
-      notificationText={notificationText(itemMetadata)}
+      notificationText={notificationText}
       view={feedbackFormScreen}
       className="no-print"
     />

--- a/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.tsx
@@ -20,11 +20,15 @@ const FeedbackForm = () => {
     setItemMetadata,
     requestedURL,
     setRequestedURL,
+    isError,
+    setError,
+    onErrorContact,
   } = useContext(FeedbackContext)
 
   const closeAndResetFeedbackData = () => {
     if (itemMetadata) setItemMetadata(null)
     if (requestedURL) setRequestedURL(null)
+    if (isError) setError(false)
     onClose()
     setFeedbackFormScreen("form")
 
@@ -62,11 +66,8 @@ const FeedbackForm = () => {
     }
   }
 
-  const notificationText = (
-    itemMetadata?: ItemMetadata,
-    requestedURL?: string | null
-  ) => {
-    if (requestedURL) {
+  const notificationText = (itemMetadata?: ItemMetadata) => {
+    if (isError) {
       return "You are asking for help or information about a page error"
     }
     if (itemMetadata?.notificationText) {
@@ -87,9 +88,9 @@ const FeedbackForm = () => {
       showEmailField
       hiddenFields={{
         ...itemMetadata,
-        ...(requestedURL ? { requestedURL } : {}),
+        requestedURL,
       }}
-      notificationText={notificationText(itemMetadata, requestedURL)}
+      notificationText={notificationText(itemMetadata)}
       view={feedbackFormScreen}
       className="no-print"
     />

--- a/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.tsx
@@ -17,9 +17,13 @@ const FeedbackForm = () => {
     onOpen,
     itemMetadata,
     setItemMetadata,
+    requestURL,
+    setRequestURL,
   } = useContext(FeedbackContext)
-  const closeAndResetItemMetadata = () => {
+
+  const closeAndResetFeedbackData = () => {
     if (itemMetadata) setItemMetadata(null)
+    if (requestURL) setRequestURL(null)
     onClose()
     setFeedbackFormScreen("form")
 
@@ -32,45 +36,53 @@ const FeedbackForm = () => {
       }
     }, 250)
   }
+
   const submitFeedback = async (
     metadataAndComment: FeedbackMetadataAndComment
   ) => {
-    try {
-      // Changed this route to /feedback-rc to avoid conflicts with DFE with 2AD reverse proxy config
-      // TODO: Change this route name back to /feedback when all routes point to research catalog
-      const response = await fetch(`${BASE_URL}/api/feedback-rc`, {
-        method: "POST",
-        body: JSON.stringify(metadataAndComment),
-      })
-      const responseJson = await response.json()
-      if (responseJson.error) {
-        console.error("Error in feedback api response", responseJson.error)
-        setFeedbackFormScreen("error")
-      } else {
-        setFeedbackFormScreen("confirmation")
-      }
-    } catch (error) {
-      console.error("Error posting feedback", error)
-      setFeedbackFormScreen("error")
-    }
+    console.log(metadataAndComment)
+    // try {
+    //   // Changed this route to /feedback-rc to avoid conflicts with DFE with 2AD reverse proxy config
+    //   // TODO: Change this route name back to /feedback when all routes point to research catalog
+    //   // const response = await fetch(`${BASE_URL}/api/feedback-rc`, {
+    //   //   method: "POST",
+    //   //   body: JSON.stringify(metadataAndComment),
+    //   // })
+    //   //const responseJson = await response.json()
+    //   if (responseJson.error) {
+    //     console.error("Error in feedback api response", responseJson.error)
+    //     setFeedbackFormScreen("error")
+    //   } else {
+    //     setFeedbackFormScreen("confirmation")
+    //   }
+    // } catch (error) {
+    //   console.error("Error posting feedback", error)
+    //   setFeedbackFormScreen("error")
+    // }
   }
+
+  const notificationText = (itemMetadata, requestURL) => {
+    if (requestURL) {
+      return "You are asking for help or information about a page error"
+    }
+    if (itemMetadata?.notificationText) {
+      return itemMetadata.notificationText
+    } else if (itemMetadata?.callNumber) {
+      return `You are asking for help or information about ${itemMetadata.callNumber} in this record.`
+    } else return null
+  }
+
   return (
     <FeedbackBox
       onSubmit={submitFeedback}
       isOpen={isOpen}
-      onClose={closeAndResetItemMetadata}
+      onClose={closeAndResetFeedbackData}
       onOpen={onOpen}
       descriptionText="We are here to help!"
       title="Help and Feedback"
       showEmailField
-      hiddenFields={itemMetadata}
-      notificationText={
-        itemMetadata?.notificationText
-          ? itemMetadata.notificationText
-          : itemMetadata?.callNumber
-          ? `You are asking for help or information about ${itemMetadata.callNumber} in this record.`
-          : null
-      }
+      hiddenFields={{ ...itemMetadata, requestURL }}
+      notificationText={notificationText(itemMetadata, requestURL)}
       view={feedbackFormScreen}
       className="no-print"
     />

--- a/src/components/FeedbackForm/FeedbackForm.tsx
+++ b/src/components/FeedbackForm/FeedbackForm.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from "react"
 
 import { FeedbackContext } from "../../context/FeedbackContext"
 import type { FeedbackMetadataAndComment } from "../../types/feedbackTypes"
-import { BASE_URL } from "../../config/constants"
+import type { ItemMetadata } from "../../types/itemTypes"
 
 /**
  * Component that wraps the DS Feedback box. Can be opened by clicking the button rendered
@@ -17,13 +17,13 @@ const FeedbackForm = () => {
     onOpen,
     itemMetadata,
     setItemMetadata,
-    requestURL,
-    setRequestURL,
+    requestedURL,
+    setRequestedURL,
   } = useContext(FeedbackContext)
 
   const closeAndResetFeedbackData = () => {
     if (itemMetadata) setItemMetadata(null)
-    if (requestURL) setRequestURL(null)
+    if (requestedURL) setRequestedURL(null)
     onClose()
     setFeedbackFormScreen("form")
 
@@ -61,8 +61,11 @@ const FeedbackForm = () => {
     // }
   }
 
-  const notificationText = (itemMetadata, requestURL) => {
-    if (requestURL) {
+  const notificationText = (
+    itemMetadata: ItemMetadata,
+    requestedURL: string | null
+  ) => {
+    if (requestedURL) {
       return "You are asking for help or information about a page error"
     }
     if (itemMetadata?.notificationText) {
@@ -81,8 +84,11 @@ const FeedbackForm = () => {
       descriptionText="We are here to help!"
       title="Help and Feedback"
       showEmailField
-      hiddenFields={{ ...itemMetadata, requestURL }}
-      notificationText={notificationText(itemMetadata, requestURL)}
+      hiddenFields={{
+        ...itemMetadata,
+        ...(requestedURL ? { requestedURL } : {}),
+      }}
+      notificationText={notificationText(itemMetadata, requestedURL)}
       view={feedbackFormScreen}
       className="no-print"
     />

--- a/src/components/SearchResults/SearchError.tsx
+++ b/src/components/SearchResults/SearchError.tsx
@@ -16,7 +16,7 @@ type SearchErrorProps = {
 
 export default function SearchError({ errorStatus }: SearchErrorProps) {
   const metadataTitle = `${errorStatus} | ${SITE_NAME}`
-  const { onErrorContact } = useContext(FeedbackContext)
+  const { openFeedbackFormWithError } = useContext(FeedbackContext)
 
   let errorContent
 
@@ -41,7 +41,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
               Legacy Catalog
             </ExternalLink>{" "}
             for more materials, or{" "}
-            <Link onClick={onErrorContact} id="feedback-link">
+            <Link onClick={openFeedbackFormWithError} id="feedback-link">
               contact us
             </Link>{" "}
             for assistance.
@@ -61,7 +61,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
           </Text>
           <Text marginBottom="0">
             Try refreshing the page or{" "}
-            <Link onClick={onErrorContact} id="feedback-link">
+            <Link onClick={openFeedbackFormWithError} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.
@@ -81,7 +81,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
           </Text>
           <Text marginBottom="0">
             Try again later or{" "}
-            <Link onClick={onErrorContact} id="feedback-link">
+            <Link onClick={openFeedbackFormWithError} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/src/components/SearchResults/SearchError.tsx
+++ b/src/components/SearchResults/SearchError.tsx
@@ -16,7 +16,7 @@ type SearchErrorProps = {
 
 export default function SearchError({ errorStatus }: SearchErrorProps) {
   const metadataTitle = `${errorStatus} | ${SITE_NAME}`
-  const { onContact } = useContext(FeedbackContext)
+  const { onErrorContact } = useContext(FeedbackContext)
 
   let errorContent
 
@@ -41,7 +41,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
               Legacy Catalog
             </ExternalLink>{" "}
             for more materials, or{" "}
-            <Link onClick={onContact} id="feedback-link">
+            <Link onClick={onErrorContact} id="feedback-link">
               contact us
             </Link>{" "}
             for assistance.
@@ -61,7 +61,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
           </Text>
           <Text marginBottom="0">
             Try refreshing the page or{" "}
-            <Link onClick={onContact} id="feedback-link">
+            <Link onClick={onErrorContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.
@@ -81,7 +81,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
           </Text>
           <Text marginBottom="0">
             Try again later or{" "}
-            <Link onClick={onContact} id="feedback-link">
+            <Link onClick={onErrorContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/src/components/SearchResults/SearchError.tsx
+++ b/src/components/SearchResults/SearchError.tsx
@@ -1,7 +1,7 @@
 import { Heading, Flex, Link, Text } from "@nypl/design-system-react-components"
 import type { HTTPStatusCode } from "../../types/appTypes"
 import { appConfig } from "../../config/config"
-import { BASE_URL, SITE_NAME } from "../../config/constants"
+import { SITE_NAME } from "../../config/constants"
 import RCHead from "../Head/RCHead"
 import Layout from "../Layout/Layout"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
@@ -9,7 +9,6 @@ import { useContext } from "react"
 import { FeedbackContext } from "../../context/FeedbackContext"
 import Image from "next/image"
 import errorImage from "../../assets/errorImage.png"
-import { useRouter } from "next/router"
 
 type SearchErrorProps = {
   errorStatus: HTTPStatusCode
@@ -17,13 +16,7 @@ type SearchErrorProps = {
 
 export default function SearchError({ errorStatus }: SearchErrorProps) {
   const metadataTitle = `${errorStatus} | ${SITE_NAME}`
-  const { onOpen, setRequestedURL } = useContext(FeedbackContext)
-  const router = useRouter()
-  const currentPath = router.asPath
-  const onContact = () => {
-    setRequestedURL(`${BASE_URL}${currentPath}`)
-    onOpen()
-  }
+  const { onContact } = useContext(FeedbackContext)
 
   let errorContent
 

--- a/src/components/SearchResults/SearchError.tsx
+++ b/src/components/SearchResults/SearchError.tsx
@@ -1,7 +1,7 @@
 import { Heading, Flex, Link, Text } from "@nypl/design-system-react-components"
 import type { HTTPStatusCode } from "../../types/appTypes"
 import { appConfig } from "../../config/config"
-import { SITE_NAME } from "../../config/constants"
+import { BASE_URL, SITE_NAME } from "../../config/constants"
 import RCHead from "../Head/RCHead"
 import Layout from "../Layout/Layout"
 import ExternalLink from "../Links/ExternalLink/ExternalLink"
@@ -9,6 +9,7 @@ import { useContext } from "react"
 import { FeedbackContext } from "../../context/FeedbackContext"
 import Image from "next/image"
 import errorImage from "../../assets/errorImage.png"
+import { useRouter } from "next/router"
 
 type SearchErrorProps = {
   errorStatus: HTTPStatusCode
@@ -16,7 +17,13 @@ type SearchErrorProps = {
 
 export default function SearchError({ errorStatus }: SearchErrorProps) {
   const metadataTitle = `${errorStatus} | ${SITE_NAME}`
-  const { onOpen } = useContext(FeedbackContext)
+  const { onOpen, setRequestedURL } = useContext(FeedbackContext)
+  const router = useRouter()
+  const currentPath = router.asPath
+  const onContact = () => {
+    setRequestedURL(`${BASE_URL}${currentPath}`)
+    onOpen()
+  }
 
   let errorContent
 
@@ -41,7 +48,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
               Legacy Catalog
             </ExternalLink>{" "}
             for more materials, or{" "}
-            <Link onClick={onOpen} id="feedback-link">
+            <Link onClick={onContact} id="feedback-link">
               contact us
             </Link>{" "}
             for assistance.
@@ -61,7 +68,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
           </Text>
           <Text marginBottom="0">
             Try refreshing the page or{" "}
-            <Link onClick={onOpen} id="feedback-link">
+            <Link onClick={onContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.
@@ -81,7 +88,7 @@ export default function SearchError({ errorStatus }: SearchErrorProps) {
           </Text>
           <Text marginBottom="0">
             Try again later or{" "}
-            <Link onClick={onOpen} id="feedback-link">
+            <Link onClick={onContact} id="feedback-link">
               contact us
             </Link>{" "}
             if the error persists.

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -14,6 +14,8 @@ export const FeedbackProvider = ({ children, value }) => {
   const [itemMetadata, setItemMetadata] = useState(value?.itemMetadata || null)
   const [requestedURL, setRequestedURL] = useState(value?.requestURL || null)
   const { FeedbackBox, isOpen, onOpen, onClose } = useFeedbackBox()
+
+  // If user opens feedback box from an error page "contact us" link, add their URL to email data
   const onContact = () => {
     const currentPath = router.asPath
     const fullURL = `${BASE_URL}${currentPath}`

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -28,7 +28,7 @@ export const FeedbackProvider = ({ children, value }) => {
 
   // When user opens feedback box from an error page "contact us" link,
   // set error flag on feedback box
-  const onErrorContact = () => {
+  const openFeedbackFormWithError = () => {
     setError(true)
     onOpen()
   }
@@ -46,7 +46,7 @@ export const FeedbackProvider = ({ children, value }) => {
         setRequestedURL,
         isError,
         setError,
-        onErrorContact,
+        openFeedbackFormWithError,
       }}
     >
       {children}

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -10,7 +10,7 @@ export const FeedbackContext = createContext<FeedbackContextType | null>(null)
 
 export const FeedbackProvider = ({ children, value }) => {
   const [itemMetadata, setItemMetadata] = useState(value?.itemMetadata || null)
-  const [requestURL, setRequestURL] = useState(value?.requestURL || null)
+  const [requestedURL, setRequestedURL] = useState(value?.requestURL || null)
   const { FeedbackBox, isOpen, onOpen, onClose } = useFeedbackBox()
 
   return (
@@ -22,8 +22,8 @@ export const FeedbackProvider = ({ children, value }) => {
         onClose,
         itemMetadata,
         setItemMetadata,
-        requestURL,
-        setRequestURL,
+        requestedURL,
+        setRequestedURL,
       }}
     >
       {children}

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -2,6 +2,8 @@ import React, { useState, createContext } from "react"
 
 import { useFeedbackBox } from "@nypl/design-system-react-components"
 import type { FeedbackContextType } from "../types/feedbackTypes"
+import { BASE_URL } from "../config/constants"
+import router from "next/router"
 
 /**
  * Wrapper context component that controls state for the Feedback component
@@ -12,6 +14,12 @@ export const FeedbackProvider = ({ children, value }) => {
   const [itemMetadata, setItemMetadata] = useState(value?.itemMetadata || null)
   const [requestedURL, setRequestedURL] = useState(value?.requestURL || null)
   const { FeedbackBox, isOpen, onOpen, onClose } = useFeedbackBox()
+  const onContact = () => {
+    const currentPath = router.asPath
+    const fullURL = `${BASE_URL}${currentPath}`
+    setRequestedURL(fullURL)
+    onOpen()
+  }
 
   return (
     <FeedbackContext.Provider
@@ -24,6 +32,7 @@ export const FeedbackProvider = ({ children, value }) => {
         setItemMetadata,
         requestedURL,
         setRequestedURL,
+        onContact,
       }}
     >
       {children}

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -3,7 +3,7 @@ import React, { useState, createContext } from "react"
 import { useFeedbackBox } from "@nypl/design-system-react-components"
 import type { FeedbackContextType } from "../types/feedbackTypes"
 import { BASE_URL } from "../config/constants"
-import router from "next/router"
+import { useRouter } from "next/router"
 
 /**
  * Wrapper context component that controls state for the Feedback component
@@ -17,10 +17,12 @@ export const FeedbackProvider = ({ children, value }) => {
   const { FeedbackBox, isOpen, onOpen: boxOpen, onClose } = useFeedbackBox()
 
   // When user opens feedback box, get their URL and add to email data
+  const router = useRouter()
   const onOpen = () => {
-    const currentPath = router.asPath
-    const fullURL = `${BASE_URL}${currentPath}`
-    setRequestedURL(fullURL)
+    if (router && router.asPath) {
+      const fullURL = `${BASE_URL}${router.asPath}`
+      setRequestedURL(fullURL)
+    }
     boxOpen()
   }
 

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -13,13 +13,21 @@ export const FeedbackContext = createContext<FeedbackContextType | null>(null)
 export const FeedbackProvider = ({ children, value }) => {
   const [itemMetadata, setItemMetadata] = useState(value?.itemMetadata || null)
   const [requestedURL, setRequestedURL] = useState(value?.requestURL || null)
-  const { FeedbackBox, isOpen, onOpen, onClose } = useFeedbackBox()
+  const [isError, setError] = useState(value?.error || false)
+  const { FeedbackBox, isOpen, onOpen: boxOpen, onClose } = useFeedbackBox()
 
-  // If user opens feedback box from an error page "contact us" link, add their URL to email data
-  const onContact = () => {
+  // When user opens feedback box, get their URL and add to email data
+  const onOpen = () => {
     const currentPath = router.asPath
     const fullURL = `${BASE_URL}${currentPath}`
     setRequestedURL(fullURL)
+    boxOpen()
+  }
+
+  // When user opens feedback box from an error page "contact us" link,
+  // set error flag on feedback box
+  const onErrorContact = () => {
+    setError(true)
     onOpen()
   }
 
@@ -34,7 +42,9 @@ export const FeedbackProvider = ({ children, value }) => {
         setItemMetadata,
         requestedURL,
         setRequestedURL,
-        onContact,
+        isError,
+        setError,
+        onErrorContact,
       }}
     >
       {children}

--- a/src/context/FeedbackContext.tsx
+++ b/src/context/FeedbackContext.tsx
@@ -10,6 +10,7 @@ export const FeedbackContext = createContext<FeedbackContextType | null>(null)
 
 export const FeedbackProvider = ({ children, value }) => {
   const [itemMetadata, setItemMetadata] = useState(value?.itemMetadata || null)
+  const [requestURL, setRequestURL] = useState(value?.requestURL || null)
   const { FeedbackBox, isOpen, onOpen, onClose } = useFeedbackBox()
 
   return (
@@ -21,6 +22,8 @@ export const FeedbackProvider = ({ children, value }) => {
         onClose,
         itemMetadata,
         setItemMetadata,
+        requestURL,
+        setRequestURL,
       }}
     >
       {children}

--- a/src/types/feedbackTypes.ts
+++ b/src/types/feedbackTypes.ts
@@ -21,5 +21,5 @@ export type FeedbackContextType = {
   setRequestedURL: (value: string) => void
   isError?: boolean
   setError: (value: boolean) => void
-  onErrorContact: () => void
+  openFeedbackFormWithError: () => void
 }

--- a/src/types/feedbackTypes.ts
+++ b/src/types/feedbackTypes.ts
@@ -19,5 +19,7 @@ export type FeedbackContextType = {
   setItemMetadata: (value: ItemMetadata) => void
   requestedURL?: string
   setRequestedURL: (value: string) => void
-  onContact: () => void
+  isError?: boolean
+  setError: (value: boolean) => void
+  onErrorContact: () => void
 }

--- a/src/types/feedbackTypes.ts
+++ b/src/types/feedbackTypes.ts
@@ -19,4 +19,5 @@ export type FeedbackContextType = {
   setItemMetadata: (value: ItemMetadata) => void
   requestedURL?: string
   setRequestedURL: (value: string) => void
+  onContact: () => void
 }

--- a/src/types/feedbackTypes.ts
+++ b/src/types/feedbackTypes.ts
@@ -17,4 +17,6 @@ export type FeedbackContextType = {
   isOpen?: boolean
   itemMetadata: ItemMetadata
   setItemMetadata: (value: ItemMetadata) => void
+  requestURL: string
+  setRequestURL: (value: string) => void
 }

--- a/src/types/feedbackTypes.ts
+++ b/src/types/feedbackTypes.ts
@@ -17,6 +17,6 @@ export type FeedbackContextType = {
   isOpen?: boolean
   itemMetadata: ItemMetadata
   setItemMetadata: (value: ItemMetadata) => void
-  requestURL: string
-  setRequestURL: (value: string) => void
+  requestedURL?: string
+  setRequestedURL: (value: string) => void
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4776](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4776)

## This PR does the following:

- Adds `requestedURL` to the `FeedbackContext` and updates `onOpen` to get the current URL before opening the feedback box
- Adds `openFeedbackFormWithError` to all error pages "contact us" links which just sets the error to true before opening the feedback box --> adds notification text to the feedback box if "contact us" from an error page is what opened it

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4776]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ