### PR TITLE
Bug fix: Adding hold ID to hold completed check

### DIFF
--- a/__test__/pages/hold/confirmation.test.tsx
+++ b/__test__/pages/hold/confirmation.test.tsx
@@ -186,6 +186,7 @@ describe("Hold Confirmation page", () => {
         <HoldConfirmationPage
           discoveryBibResult={bibWithItems.resource}
           isEDD
+          holdId="test"
         />
       )
     })
@@ -229,8 +230,8 @@ describe("Hold Confirmation page", () => {
       const searchLink = screen.getByText("Start a new search")
       expect(searchLink).toHaveAttribute("href", "/research/research-catalog/")
     })
-    it("sets sessionStorage key 'holdCompleted' to true on mount", () => {
-      expect(sessionStorage.getItem("holdCompleted")).toBe("true")
+    it("sets sessionStorage key 'holdCompleted' with hold ID to true on mount", () => {
+      expect(sessionStorage.getItem("holdCompleted-test")).toBe("true")
     })
   })
   describe("Hold confirmation not found", () => {

--- a/__test__/pages/hold/confirmation.test.tsx
+++ b/__test__/pages/hold/confirmation.test.tsx
@@ -186,7 +186,7 @@ describe("Hold Confirmation page", () => {
         <HoldConfirmationPage
           discoveryBibResult={bibWithItems.resource}
           isEDD
-          holdId="test"
+          itemId="test"
         />
       )
     })
@@ -230,7 +230,7 @@ describe("Hold Confirmation page", () => {
       const searchLink = screen.getByText("Start a new search")
       expect(searchLink).toHaveAttribute("href", "/research/research-catalog/")
     })
-    it("sets sessionStorage key 'holdCompleted' with hold ID to true on mount", () => {
+    it("sets sessionStorage key 'holdCompleted' with item ID to true on mount", () => {
       expect(sessionStorage.getItem("holdCompleted-test")).toBe("true")
     })
   })

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -566,7 +566,8 @@ describe("EDD Request page", () => {
     })
   })
   describe("EDD request already completed renders warning banner", () => {
-    sessionStorage.setItem("holdCompleted", "true")
+    // Hold ID from bibWithItems
+    sessionStorage.setItem("holdCompleted-b15080796-i39333697", "true")
     render(
       <EDDRequestPage
         discoveryBibResult={bibWithItems.resource}

--- a/__test__/pages/hold/eddRequestPage.test.tsx
+++ b/__test__/pages/hold/eddRequestPage.test.tsx
@@ -566,8 +566,8 @@ describe("EDD Request page", () => {
     })
   })
   describe("EDD request already completed renders warning banner", () => {
-    // Hold ID from bibWithItems
-    sessionStorage.setItem("holdCompleted-b15080796-i39333697", "true")
+    // Item ID from bibWithItems
+    sessionStorage.setItem("holdCompleted-i39333697", "true")
     render(
       <EDDRequestPage
         discoveryBibResult={bibWithItems.resource}

--- a/__test__/pages/hold/holdRequestPage.test.tsx
+++ b/__test__/pages/hold/holdRequestPage.test.tsx
@@ -429,7 +429,8 @@ describe("Hold Request page", () => {
     expect(screen.getByText("We couldn't find that page")).toBeInTheDocument()
   })
   describe("Hold request already completed renders warning banner", () => {
-    sessionStorage.setItem("holdCompleted", "true")
+    // Hold ID from bibWithItems
+    sessionStorage.setItem("holdCompleted-b15080796-i39333697", "true")
     render(
       <HoldRequestPage
         discoveryBibResult={bibWithItems.resource}

--- a/__test__/pages/hold/holdRequestPage.test.tsx
+++ b/__test__/pages/hold/holdRequestPage.test.tsx
@@ -429,8 +429,8 @@ describe("Hold Request page", () => {
     expect(screen.getByText("We couldn't find that page")).toBeInTheDocument()
   })
   describe("Hold request already completed renders warning banner", () => {
-    // Hold ID from bibWithItems
-    sessionStorage.setItem("holdCompleted-b15080796-i39333697", "true")
+    // Item ID from bibWithItems
+    sessionStorage.setItem("holdCompleted-i39333697", "true")
     render(
       <HoldRequestPage
         discoveryBibResult={bibWithItems.resource}

--- a/pages/hold/confirmation/[id].tsx
+++ b/pages/hold/confirmation/[id].tsx
@@ -38,6 +38,7 @@ interface HoldConfirmationPageProps {
   pickupLocationLabel?: string
   discoveryBibResult: DiscoveryBibResult
   notFound?: boolean
+  holdId?: string
 }
 
 /**
@@ -49,18 +50,22 @@ export default function HoldConfirmationPage({
   pickupLocationLabel,
   discoveryBibResult,
   notFound = false,
+  holdId,
 }: HoldConfirmationPageProps) {
   useEffect(() => {
     // Set flag to show hold already happened, if user goes back to form page
-    sessionStorage.setItem("holdCompleted", "true")
+    if (holdId) {
+      sessionStorage.setItem(`holdCompleted-${holdId}`, "true")
+    }
   }, [])
 
   if (notFound) {
     return <Custom404 activePage="hold" />
   }
-  const metadataTitle = `Request Confirmation | ${SITE_NAME}`
+
   const bib = new Bib(discoveryBibResult)
   const item = bib?.items[0]
+  const metadataTitle = `Request Confirmation | ${SITE_NAME}`
 
   return (
     <>
@@ -189,6 +194,7 @@ export async function getServerSideProps({ params, req, res, query }) {
         isEDD: pickupLocation === "edd",
         pickupLocationLabel: pickupLocationLabel || null,
         discoveryBibResult,
+        holdId: id,
       },
     }
   } catch (error) {

--- a/pages/hold/confirmation/[id].tsx
+++ b/pages/hold/confirmation/[id].tsx
@@ -38,7 +38,7 @@ interface HoldConfirmationPageProps {
   pickupLocationLabel?: string
   discoveryBibResult: DiscoveryBibResult
   notFound?: boolean
-  holdId?: string
+  itemId?: string
 }
 
 /**
@@ -50,12 +50,12 @@ export default function HoldConfirmationPage({
   pickupLocationLabel,
   discoveryBibResult,
   notFound = false,
-  holdId,
+  itemId,
 }: HoldConfirmationPageProps) {
   useEffect(() => {
     // Set flag to show hold already happened, if user goes back to form page
-    if (holdId) {
-      sessionStorage.setItem(`holdCompleted-${holdId}`, "true")
+    if (itemId) {
+      sessionStorage.setItem(`holdCompleted-${itemId}`, "true")
     }
   }, [])
 
@@ -194,7 +194,7 @@ export async function getServerSideProps({ params, req, res, query }) {
         isEDD: pickupLocation === "edd",
         pickupLocationLabel: pickupLocationLabel || null,
         discoveryBibResult,
-        holdId: id,
+        itemId: item.id,
       },
     }
   } catch (error) {

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -113,10 +113,10 @@ export default function EDDRequestPage({
 
   // Check if hold request was completed already.
   useEffect(() => {
-    const bannerFlag = sessionStorage.getItem(`holdCompleted-${holdId}`)
+    const bannerFlag = sessionStorage.getItem(`holdCompleted-${item?.id}`)
     if (bannerFlag === "true") {
       setHoldCompleted(true)
-      sessionStorage.removeItem(`holdCompleted-${holdId}`)
+      sessionStorage.removeItem(`holdCompleted-${item?.id}`)
       if (bannerContainerRef.current) {
         bannerContainerRef.current.focus()
       }

--- a/pages/hold/request/[id]/edd.tsx
+++ b/pages/hold/request/[id]/edd.tsx
@@ -113,10 +113,10 @@ export default function EDDRequestPage({
 
   // Check if hold request was completed already.
   useEffect(() => {
-    const bannerFlag = sessionStorage.getItem("holdCompleted")
+    const bannerFlag = sessionStorage.getItem(`holdCompleted-${holdId}`)
     if (bannerFlag === "true") {
       setHoldCompleted(true)
-      sessionStorage.removeItem("holdCompleted")
+      sessionStorage.removeItem(`holdCompleted-${holdId}`)
       if (bannerContainerRef.current) {
         bannerContainerRef.current.focus()
       }

--- a/pages/hold/request/[id]/index.tsx
+++ b/pages/hold/request/[id]/index.tsx
@@ -92,10 +92,10 @@ export default function HoldRequestPage({
 
   // Check if hold request was completed already.
   useEffect(() => {
-    const bannerFlag = sessionStorage.getItem(`holdCompleted-${holdId}`)
+    const bannerFlag = sessionStorage.getItem(`holdCompleted-${item?.id}`)
     if (bannerFlag === "true") {
       setHoldCompleted(true)
-      sessionStorage.removeItem(`holdCompleted-${holdId}`)
+      sessionStorage.removeItem(`holdCompleted-${item?.id}`)
       setPersistentFocus(idConstants.holdCompletedBanner)
     }
   }, [])


### PR DESCRIPTION
## Ticket:

- Follows up on JIRA ticket [SCC-3360](https://newyorkpubliclibrary.atlassian.net/browse/SCC-3360)

## This PR does the following:

- Adds the item ID to the session storage item key, so that the check is specific to the hold you just made rather than just any hold 
- Updated unit tests to reflect

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

- Make a hold. Then go immediately make another hold on a different item, go back, you should not see the banner

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-3360]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-3360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ