### PR TITLE
SCC-4774: Browse API handler

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- Added `fetchSubjects` API handler for `browse` index page [SCC-4774](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4774)
 - Added `browse` and `browse/subjects/[...slug]` pages and page types, set up deployment of EB work to `train` [SCC-4554](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4554)
 
 ## [1.5.1] 2025-07-17

--- a/__test__/pages/browse/index.test.tsx
+++ b/__test__/pages/browse/index.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "../../../src/utils/testUtils"
 
 describe("Browse index page", () => {
   render(
-    <Browse subjects={{ status: 200, subjects: [] }} isAuthenticated={false} />
+    <Browse results={{ status: 200, subjects: [] }} isAuthenticated={false} />
   )
   it("renders the subnav", () => {
     expect(screen.queryByText("Browse the Catalog")).toBeInTheDocument()

--- a/__test__/pages/browse/index.test.tsx
+++ b/__test__/pages/browse/index.test.tsx
@@ -1,8 +1,10 @@
-import BrowseIndex from "../../../pages/browse"
+import Browse from "../../../pages/browse"
 import { render, screen } from "../../../src/utils/testUtils"
 
 describe("Browse index page", () => {
-  render(<BrowseIndex />)
+  render(
+    <Browse subjects={{ status: 200, subjects: [] }} isAuthenticated={false} />
+  )
   it("renders the subnav", () => {
     expect(screen.queryByText("Browse the Catalog")).toBeInTheDocument()
   })

--- a/pages/api/browse.ts
+++ b/pages/api/browse.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import { fetchSubjects } from "../../src/server/api/browse"
+import { mapQueryToBrowseParams } from "../../src/utils/browseUtils"
+
+/**
+ * Default API route handler for Browse
+ * Calls a helper function that maps the query params object to a BrowseParams object
+ * It is then passed to fetchSubjects, which fetches the subjects and returns a JSON response
+ * via its onSuccess callback on a successful fetch
+ */
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "GET") {
+    const browseParams = mapQueryToBrowseParams(req.query)
+    const response = await fetchSubjects(browseParams)
+    res.status(200).json(response)
+  }
+}
+
+export default handler

--- a/pages/api/browse.ts
+++ b/pages/api/browse.ts
@@ -3,15 +3,29 @@ import { fetchSubjects } from "../../src/server/api/browse"
 import { mapQueryToBrowseParams } from "../../src/utils/browseUtils"
 
 /**
- * Default API route handler for Browse
- * Calls a helper function that maps the query params object to a BrowseParams object
- * It is then passed to fetchSubjects, which fetches the subjects and returns a JSON response
- * via its onSuccess callback on a successful fetch
+ * API route handler for Browse
+ * Determines which fetcher to use based on the `browse_type` query parameter.
+ * Supported types: "subjects" (default), "authors".
+ * Calls a helper function that maps the query params object to a BrowseParams object,
+ * returns a JSON response.
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "GET") {
+    const { browse_type: browseType } = req.query
     const browseParams = mapQueryToBrowseParams(req.query)
-    const response = await fetchSubjects(browseParams)
+
+    let response
+
+    switch (browseType) {
+      case "authors":
+        //response = await fetchAuthors(browseParams)
+        break
+      case "subjects":
+      default:
+        response = await fetchSubjects(browseParams)
+        break
+    }
+
     res.status(200).json(response)
   }
 }

--- a/pages/browse/index.tsx
+++ b/pages/browse/index.tsx
@@ -38,24 +38,17 @@ export async function getServerSideProps({ req, query }) {
   let response
 
   switch (browseType) {
-    case "subjects":
-      response = await fetchSubjects({ q: "" })
-      break
     case "authors":
       //response = await fetchAuthors({ q: "" })
       break
+    case "subjects":
     default:
-      return {
-        props: {
-          errorStatus: 400,
-          isAuthenticated: patronTokenResponse.isTokenValid,
-          subjects: [],
-        },
-      }
+      response = await fetchSubjects({ q: "" })
+      break
   }
 
   // Handle API errors
-  if (response.status !== 200) {
+  if (response?.status !== 200) {
     return { props: { errorStatus: response.status } }
   }
 

--- a/pages/browse/index.tsx
+++ b/pages/browse/index.tsx
@@ -1,18 +1,56 @@
 import RCHead from "../../src/components/Head/RCHead"
 import Layout from "../../src/components/Layout/Layout"
 import { SITE_NAME } from "../../src/config/constants"
+import { fetchSubjects } from "../../src/server/api/browse"
+import initializePatronTokenAuth from "../../src/server/auth"
+import type { HTTPStatusCode } from "../../src/types/appTypes"
+import type { DiscoverySubjectsResponse } from "../../src/types/browseTypes"
+
+interface BrowseProps {
+  subjects: DiscoverySubjectsResponse
+  isAuthenticated: boolean
+  errorStatus?: HTTPStatusCode | null
+}
 
 /**
  * The Browse index page is responsible for fetching and displaying subject headings,
  * as well as displaying and controlling pagination and sort.
  */
-export default function BrowseIndex() {
+export default function Browse({
+  subjects,
+  isAuthenticated,
+  errorStatus = null,
+}: BrowseProps) {
   const metadataTitle = `Browse Research Catalog | ${SITE_NAME}`
 
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
-      <Layout activePage="browse"></Layout>
+      <Layout activePage="browse" isAuthenticated={isAuthenticated}></Layout>
     </>
   )
+}
+
+export async function getServerSideProps({ req, query }) {
+  const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+
+  const subjectsResponse = await fetchSubjects({
+    q: "F",
+    page: 6,
+    sort: "count",
+  })
+
+  // Handle API errors
+  if (subjectsResponse.status !== 200) {
+    return { props: { errorStatus: subjectsResponse.status } }
+  }
+
+  const isAuthenticated = patronTokenResponse.isTokenValid
+
+  return {
+    props: {
+      isAuthenticated,
+      subjects: subjectsResponse,
+    },
+  }
 }

--- a/pages/browse/index.tsx
+++ b/pages/browse/index.tsx
@@ -35,9 +35,7 @@ export async function getServerSideProps({ req, query }) {
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
 
   const subjectsResponse = await fetchSubjects({
-    q: "F",
-    page: 6,
-    sort: "count",
+    q: "",
   })
 
   // Handle API errors

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,8 +1,7 @@
-import { appConfig } from "./config"
-
 export const BASE_URL = "/research/research-catalog"
 export const SITE_NAME = "Research Catalog | NYPL"
 export const RESULTS_PER_PAGE = 50
+export const SUBJECTS_PER_PAGE = 50
 export const ITEMS_PER_SEARCH_RESULT = 3
 export const ITEM_PAGINATION_BATCH_SIZE = 20
 // TODO: Remove this when view_all endpoint in discovery supports query params
@@ -29,6 +28,7 @@ export const PATHS = {
 
 // API Routes
 export const DISCOVERY_API_SEARCH_ROUTE = "/discovery/resources"
+export const DISCOVERY_API_BROWSE_ROUTE = "/discovery/browse/subjects"
 
 // Query params
 export const SOURCE_PARAM = "?source=catalog"

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,7 @@
 export const BASE_URL = "/research/research-catalog"
 export const SITE_NAME = "Research Catalog | NYPL"
 export const RESULTS_PER_PAGE = 50
-export const SUBJECTS_PER_PAGE = 50
+export const SUBJECTS_PER_PAGE = 30
 export const ITEMS_PER_SEARCH_RESULT = 3
 export const ITEM_PAGINATION_BATCH_SIZE = 20
 // TODO: Remove this when view_all endpoint in discovery supports query params

--- a/src/server/api/browse.ts
+++ b/src/server/api/browse.ts
@@ -1,0 +1,47 @@
+import {
+  DISCOVERY_API_BROWSE_ROUTE,
+  SUBJECTS_PER_PAGE,
+} from "../../config/constants"
+import { logServerError } from "../../utils/appUtils"
+import nyplApiClient from "../nyplApiClient"
+import type {
+  BrowseParams,
+  DiscoverySubjectsResponse,
+} from "../../types/browseTypes"
+import { getBrowseQuery } from "../../utils/browseUtils"
+
+export async function fetchSubjects(
+  browseParams?: BrowseParams
+): Promise<DiscoverySubjectsResponse | { status: number; message?: string }> {
+  const browseQuery = getBrowseQuery(browseParams)
+
+  try {
+    // Failure to build client will throw from this:
+    const client = await nyplApiClient()
+    const res = await client.get(
+      `${DISCOVERY_API_BROWSE_ROUTE}${browseQuery}&per_page=${SUBJECTS_PER_PAGE.toString()}`
+    )
+
+    // Handle invalid parameter rejection or empty results (422, 404)
+    if (res.status === 422 || res.status === 404 || res.subjects.length === 0) {
+      logServerError(
+        "fetchSubjects",
+        `${
+          res.message ? res.message : "No subjects found"
+        } Request: ${DISCOVERY_API_BROWSE_ROUTE}${browseQuery}`
+      )
+      return {
+        status: res.status ?? 404,
+        message: res.message ?? "No subjects found",
+      }
+    }
+
+    return {
+      status: 200,
+      subjects: res.subjects,
+    }
+  } catch (error: any) {
+    logServerError("fetchSubjects", error.message)
+    return { status: 500, message: error.message }
+  }
+}

--- a/src/server/api/browse.ts
+++ b/src/server/api/browse.ts
@@ -22,8 +22,8 @@ export async function fetchSubjects(
       `${DISCOVERY_API_BROWSE_ROUTE}${browseQuery}&per_page=${SUBJECTS_PER_PAGE.toString()}`
     )
 
-    // Handle invalid parameter rejection or empty results (422, 404)
-    if (res.status === 422 || res.status === 404 || res.subjects.length === 0) {
+    // Handle empty results (404)
+    if (res.status === 404 || res.subjects.length === 0) {
       logServerError(
         "fetchSubjects",
         `${

--- a/src/server/api/tests/browse.test.ts
+++ b/src/server/api/tests/browse.test.ts
@@ -1,0 +1,66 @@
+import { fetchSubjects } from "../browse"
+import type { DiscoverySubjectsResponse } from "../../../types/browseTypes"
+
+jest.mock("../../nyplApiClient")
+import nyplApiClient from "../../nyplApiClient"
+
+const mockClient = {
+  get: jest.fn(),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(nyplApiClient as jest.Mock).mockResolvedValue(mockClient)
+})
+
+describe("fetchSubjects", () => {
+  it("fetches valid subject heading results", async () => {
+    mockClient.get.mockResolvedValue({
+      subjects: [{}, {}, {}, {}],
+    })
+
+    const response = (await fetchSubjects({
+      q: "cat",
+    })) as DiscoverySubjectsResponse
+
+    expect(response.subjects.length).toBe(4)
+  })
+
+  it("returns 500 if the client fails to initialize", async () => {
+    ;(nyplApiClient as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("Bad API URL")
+    })
+
+    const response = await fetchSubjects({ q: "cat" })
+    expect(response).toEqual({ status: 500, message: "Bad API URL" })
+  })
+
+  it("returns 500 if API call fails", async () => {
+    mockClient.get.mockRejectedValueOnce(new Error("Results error"))
+
+    const response = await fetchSubjects({ q: "cat" })
+    expect(response).toEqual({
+      status: 500,
+      message: expect.stringContaining("Results error"),
+    })
+  })
+
+  it("handles 404 response", async () => {
+    mockClient.get.mockResolvedValueOnce({
+      status: 404,
+      message: "Not found",
+    })
+
+    const response = await fetchSubjects({ q: "unknown" })
+    expect(response).toEqual({ status: 404, message: "Not found" })
+  })
+
+  it("handles valid response but no results", async () => {
+    mockClient.get.mockResolvedValueOnce({
+      subjects: [],
+    })
+
+    const response = await fetchSubjects({ q: "empty" })
+    expect(response).toEqual({ status: 404, message: "No subjects found" })
+  })
+})

--- a/src/types/browseTypes.ts
+++ b/src/types/browseTypes.ts
@@ -1,0 +1,35 @@
+import type { HTTPStatusCode } from "./appTypes"
+
+export type SortDirection = "asc" | "desc"
+export type BrowseSort = "relevance" | "preffedTerm" | "count"
+export type BrowseScope = "has" | "starts_with"
+
+export interface BrowseParams {
+  q?: string
+  page?: number
+  sort?: BrowseSort
+  sortDirection?: SortDirection
+  searchScope?: BrowseScope
+}
+
+export interface DiscoverySubjectsResponse {
+  status: HTTPStatusCode
+  subjects: DiscoverySubjectResult[]
+}
+
+export interface BrowseQueryParams {
+  q?: string
+  sort?: BrowseSort
+  sort_direction?: SortDirection
+  search_scope?: BrowseScope
+  page?: string
+}
+
+export type DiscoverySubjectResult = {
+  preferredTerm: string
+  count: number
+  uri: string
+  variants: string[]
+  narrowerTerms: string[]
+  broaderTerms: string[]
+}

--- a/src/types/browseTypes.ts
+++ b/src/types/browseTypes.ts
@@ -29,7 +29,7 @@ export type DiscoverySubjectResult = {
   preferredTerm: string
   count: number
   uri: string
-  variants: string[]
-  narrowerTerms: string[]
-  broaderTerms: string[]
+  variants?: string[]
+  narrowerTerms?: string[]
+  broaderTerms?: string[]
 }

--- a/src/utils/browseUtils.ts
+++ b/src/utils/browseUtils.ts
@@ -1,0 +1,45 @@
+import type { BrowseParams, BrowseQueryParams } from "../types/browseTypes"
+
+/**
+ * mapQueryToBrowseParams
+ * Maps the BrowseQueryParams structure from the request to a BrowseParams object,
+ * which is expected by fetchSubjects
+ * It also parses the results page number from a string, defaulting to 1 if absent
+ */
+export function mapQueryToBrowseParams({
+  q = "",
+  search_scope,
+  sort_direction,
+  page,
+  sort,
+}: BrowseQueryParams): BrowseParams {
+  return {
+    q: q,
+    page: page ? parseInt(page) : 1,
+    searchScope: search_scope,
+    sort: sort,
+    sortDirection: sort_direction,
+  }
+}
+
+/**
+ * getBrowseQuery
+ * Builds a query string from a BrowseParams object
+ */
+export function getBrowseQuery(params: BrowseParams): string {
+  const {
+    sort = "relevance",
+    q,
+    page = 1,
+    sortDirection = "desc",
+    searchScope = "has",
+  } = params
+  const browseKeywordsQuery = encodeURIComponent(q)
+  // TO DO: exclude default sort directions
+  const sortQuery = `&sort=${sort}&sort_direction=${sortDirection}`
+  const scopeQuery = `&search_scope=${searchScope}`
+  const pageQuery = page !== 1 ? `&page=${page}` : ""
+
+  const completeQuery = `${browseKeywordsQuery}${scopeQuery}${sortQuery}${pageQuery}`
+  return completeQuery?.length ? `?q=${completeQuery}` : ""
+}

--- a/src/utils/browseUtils.ts
+++ b/src/utils/browseUtils.ts
@@ -35,7 +35,7 @@ export function getBrowseQuery(params: BrowseParams): string {
     searchScope = "has",
   } = params
   const browseKeywordsQuery = encodeURIComponent(q)
-  // TO DO: exclude default sort directions
+  // TO DO: confirm if this should enforce the respective default sorts
   const sortQuery = `&sort=${sort}&sort_direction=${sortDirection}`
   const scopeQuery = `&search_scope=${searchScope}`
   const pageQuery = page !== 1 ? `&page=${page}` : ""


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4774](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4774)

## This PR does the following:

- Adds the serverside fetcher `fetchSubjects`– used in `getServerSideProps` on the browse index page
    - For POC, this currently calls `fetchSubjects({ q: "" })` on `browse/index`, you can log it to see the output
- Also adds the clientside browse route handler (`api/browse`) which just passes params to `fetchSubjects`
- Adds a bunch of types and helper functions for the parsing of browse params
     - There are separate tickets for sort and pagination, so those will be refined and tested further once they have their corresponding page controls
- Noting again for posterity that the `DISCOVERY_BROWSE_ROUTE` = `/discovery/browse/subjects` for now, and all "browse"-named things really just refer to subject headings. Goal here is not to close any naming/typing doors to when we add `discovery/browse/authors`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Added unit tests for `fetchSubjects` and then, if you add `console.log(subjects)` to `browse/index` you can play around with various params and confirm it spits out what you'd expect. Not expecting to see the URL update yet, that'll come with `BrowseForm`

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4774]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ