### PR TITLE
SCC-4803: Update Finding aid link and copy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
-### Remove
+### Updated
+
+- Updated finding aid copy and link [SCC-4803](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4803)
+
+### Removed
 
 - Trailing period removal from subject literals [SCC-4801](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4801)
 

--- a/src/components/BibPage/FindingAid.test.tsx
+++ b/src/components/BibPage/FindingAid.test.tsx
@@ -24,11 +24,11 @@ describe("FindingAid component", () => {
 
   it("renders the appointments link", () => {
     const appointmentsLink = screen.getByRole("link", {
-      name: "require an appointment",
+      name: "may require an appointment",
     })
     expect(appointmentsLink).toHaveAttribute(
       "href",
-      "https://www.nypl.org/research/appointments"
+      "https://libguides.nypl.org/special-collections-account-tutorial"
     )
   })
 })

--- a/src/components/BibPage/FindingAid.tsx
+++ b/src/components/BibPage/FindingAid.tsx
@@ -48,9 +48,11 @@ const FindingAid = ({
             collections{" "}
             <Link
               hasVisitedState={false}
-              href={"https://www.nypl.org/research/appointments"}
+              href={
+                "https://libguides.nypl.org/special-collections-account-tutorial"
+              }
             >
-              require an appointment
+              may require an appointment
             </Link>{" "}
             to view and use on-site.
           </Text>


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4803](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4803)

## This PR does the following:

- Updates finding aid link and copy, and corresponding unit test
- It seems like LibGuides is adding GA params to the URL... will confirm with Sean/Nora

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Search something with a finding aid and click the link!

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4803]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ