### PR TITLE
finished writing global header tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Playwright tests for global header, as it appears on the Research Catalog. [SCC-4793] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4793). Also increased the playwright timeout to 60 seconds to accomodate the global header tests.
+
 - Added Playwright tests for RC home page elements. found in /playwright. Deleted dummy test file that was created for initial Playwright install. [SCC-4792] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4792)
 
 - Added Playwright, the end-to-end testing framework for automating and verifying browser interactions across Chromium, Firefox, and WebKit. [SCC-4772] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4772)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ import { defineConfig, devices } from "@playwright/test"
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  timeout: 30 * 1000,
+  timeout: 60 * 1000,
   globalTimeout: 20 * 60 * 1000,
   testDir: "./playwright",
   /* Run tests in files in parallel */
@@ -28,7 +28,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://local.nypl.org:8080",
+    baseURL: "http://local.nypl.org:8080/research/research-catalog/",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/playwright/pages/base_page.ts
+++ b/playwright/pages/base_page.ts
@@ -90,4 +90,8 @@ export class BasePage {
       name: "My account for NYPL.org",
     })
   }
+
+  async goto() {
+    await this.page.goto("")
+  }
 }

--- a/playwright/pages/rc_home_page.ts
+++ b/playwright/pages/rc_home_page.ts
@@ -98,8 +98,4 @@ export class RC_Home_Page extends BasePage {
       name: "Help and Feedback",
     })
   }
-
-  async goto() {
-    await this.page.goto("/research/research-catalog")
-  }
 }

--- a/playwright/tests/global_header.spec.ts
+++ b/playwright/tests/global_header.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test"
+import { BasePage } from "../pages/base_page"
+
+test.describe("Global Header", () => {
+  test("Verify global header elements appear and resolve to the correct landing pages", async ({
+    page,
+  }) => {
+    const basePage = new BasePage(page)
+    await basePage.goto()
+    const headerLinks = [
+      {
+        locator: basePage.nypl_logo,
+        expectedTitle: "The New York Public Library",
+      },
+      {
+        locator: basePage.header_locations,
+        expectedTitle: "Location Finder | The New York Public Library",
+      },
+      {
+        locator: basePage.header_library_card,
+        expectedTitle: "Library Card Application Form | NYPL",
+      },
+      {
+        locator: basePage.header_newsletter,
+        expectedTitle: "Subscription Center | The New York Public Library",
+      },
+      {
+        locator: basePage.header_donate,
+        expectedTitle:
+          "Make Your Tax-Deductible Gift Today - New York Public Library",
+      },
+
+      {
+        locator: basePage.header_shop,
+        expectedTitle: "The New York Public Library Shop",
+      },
+      {
+        locator: basePage.header_books,
+        expectedTitle: "Books/Music/Movies | The New York Public Library",
+      },
+      {
+        locator: basePage.header_research,
+        expectedTitle: "Research | The New York Public Library",
+      },
+      {
+        locator: basePage.header_education,
+        expectedTitle: "Education | The New York Public Library",
+      },
+      {
+        locator: basePage.header_events,
+        expectedTitle: "Events | The New York Public Library",
+      },
+      {
+        locator: basePage.header_connect,
+        expectedTitle: "Connect | The New York Public Library",
+      },
+      {
+        locator: basePage.header_give,
+        expectedTitle: "Give | The New York Public Library",
+      },
+      {
+        locator: basePage.header_get_help,
+        expectedTitle: "Get Help | The New York Public Library",
+      },
+    ]
+
+    for (const { locator, expectedTitle } of headerLinks) {
+      await locator.click()
+      await expect(page).toHaveTitle(expectedTitle)
+      await basePage.goto() // go back to home for the next link
+    }
+  })
+  // Search and My Account do not resolve to a new page.  Just test for visibility. Funcationality is tested elsewhere.
+  test("Verify Search and My Account buttons appear in header", async ({
+    page,
+  }) => {
+    const basePage = new BasePage(page)
+    await basePage.goto()
+    await expect(basePage.header_search).toBeVisible()
+    await expect(basePage.header_my_account).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Ticket:

- JIRA ticket [4793](https://newyorkpubliclibrary.atlassian.net/browse/SCC-{4793})

## This PR does the following:

- adds tests: Verify global header elements appear and resolve to the correct landing pages. 
- increased the playwright timeout to 60 seconds to accommodate the global header tests.  
- fixed base url.

## How has this been tested?

tests pass locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x ] All new and existing tests passed.
