### PR TITLE
SCC-4572: Browse index pagination

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- Added `ResultsSort` to browse page [SCC-4571](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4571)
 - Added `SubjectHeadingBanner` to browse page [SCC-4569](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4569)
 - Added `BrowseForm` and updated `Layout` and `RCSubNav` to use it [SCC-4568](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4568)
 - Added `SubjectTable` and table cells [SCC-4570](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4570)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Added `ResultsSort` to browse page [SCC-4571](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4571)
+- Added pagination to browse index [SCC-4572](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4572)
+- Added `ResultsSort` to browse index [SCC-4571](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4571)
 - Added `SubjectHeadingBanner` to browse page [SCC-4569](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4569)
 - Added `BrowseForm` and updated `Layout` and `RCSubNav` to use it [SCC-4568](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4568)
 - Added `SubjectTable` and table cells [SCC-4570](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4570)

--- a/pages/browse/index.tsx
+++ b/pages/browse/index.tsx
@@ -3,11 +3,12 @@ import {
   Flex,
   SkeletonLoader,
   Icon,
+  Pagination,
 } from "@nypl/design-system-react-components"
 import RCHead from "../../src/components/Head/RCHead"
 import Layout from "../../src/components/Layout/Layout"
 import SubjectTable from "../../src/components/SubjectTable/SubjectTable"
-import { SITE_NAME } from "../../src/config/constants"
+import { SITE_NAME, SUBJECTS_PER_PAGE } from "../../src/config/constants"
 import { fetchSubjects } from "../../src/server/api/browse"
 import initializePatronTokenAuth from "../../src/server/auth"
 import type { HTTPStatusCode } from "../../src/types/appTypes"
@@ -61,6 +62,12 @@ export default function Browse({
 
   if (errorStatus) {
     return <ResultsError errorStatus={errorStatus} page="browse" />
+  }
+
+  const handlePageChange = async (page: number) => {
+    const newQuery = getBrowseQuery({ ...browseParams, page })
+    setPersistentFocus(idConstants.browseResultsHeading)
+    await push(newQuery)
   }
 
   const handleSortChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -168,6 +175,16 @@ export default function Browse({
         ) : (
           <SubjectTable subjectTableData={results.subjects} />
         )}
+        <Pagination
+          id="results-pagination"
+          mt="xxl"
+          mb="xxl"
+          className="no-print"
+          initialPage={browseParams.page}
+          currentPage={browseParams.page}
+          pageCount={Math.ceil(results.totalResults / SUBJECTS_PER_PAGE)}
+          onPageChange={handlePageChange}
+        />
       </>
     )
   }

--- a/pages/browse/index.tsx
+++ b/pages/browse/index.tsx
@@ -4,6 +4,7 @@ import {
   SkeletonLoader,
   Icon,
   Pagination,
+  Box,
 } from "@nypl/design-system-react-components"
 import RCHead from "../../src/components/Head/RCHead"
 import Layout from "../../src/components/Layout/Layout"
@@ -145,7 +146,7 @@ export default function Browse({
 
   const renderResults = () => {
     return (
-      <>
+      <Box mb="xxl">
         <Flex
           direction={{ base: "column", md: "row" }}
           justifyContent="space-between"
@@ -178,14 +179,13 @@ export default function Browse({
         <Pagination
           id="results-pagination"
           mt="xxl"
-          mb="xxl"
           className="no-print"
           initialPage={browseParams.page}
           currentPage={browseParams.page}
           pageCount={Math.ceil(results.totalResults / SUBJECTS_PER_PAGE)}
           onPageChange={handlePageChange}
         />
-      </>
+      </Box>
     )
   }
 

--- a/src/components/Banners/SubjectHeadingBanner.tsx
+++ b/src/components/Banners/SubjectHeadingBanner.tsx
@@ -1,4 +1,4 @@
-import { Banner } from "@nypl/design-system-react-components"
+import { Banner, Flex } from "@nypl/design-system-react-components"
 import React from "react"
 import RCLink from "../Links/RCLink/RCLink"
 import styles from "../../../styles/components/Layout.module.scss"
@@ -8,23 +8,27 @@ import styles from "../../../styles/components/Layout.module.scss"
  */
 const SubjectHeadingBanner = () => {
   return (
-    <Banner
-      className={`${styles.banner} no-print`}
-      type="recommendation"
-      isDismissible
-      content={
-        <>
-          <span style={{ fontWeight: "bold" }}>Subject Headings</span> are the
-          most effective strategy for browsing the{" "}
-          <RCLink href="/">NYPL Research Catalog</RCLink>. These descriptive
-          authorities, created by the Library of Congress, are used to group
-          similar materials together. Each item in the catalog is typically
-          assigned at least one relevant Subject Heading, and clicking through
-          the hyperlinked Subject Headings is the best way to gain a
-          comprehensive sense of NYPL collections.
-        </>
-      }
-    />
+    <Flex align="center" direction="column">
+      <Banner
+        className={`${styles.banner} no-print`}
+        type="recommendation"
+        mt="l"
+        mb="l"
+        isDismissible
+        content={
+          <>
+            <span style={{ fontWeight: "bold" }}>Subject Headings</span> are the
+            most effective strategy for browsing the{" "}
+            <RCLink href="/">NYPL Research Catalog</RCLink>. These descriptive
+            authorities, created by the Library of Congress, are used to group
+            similar materials together. Each item in the catalog is typically
+            assigned at least one relevant Subject Heading, and clicking through
+            the hyperlinked Subject Headings is the best way to gain a
+            comprehensive sense of NYPL collections.
+          </>
+        }
+      />
+    </Flex>
   )
 }
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -111,11 +111,7 @@ const Layout = ({
             {showBrowse && (
               <>
                 <BrowseForm />
-                {showBrowseBanner && (
-                  <Flex gap="s" align="center" direction="column" pb="l" pt="l">
-                    <SubjectHeadingBanner />
-                  </Flex>
-                )}
+                {showBrowseBanner && <SubjectHeadingBanner />}
               </>
             )}
 

--- a/src/components/SearchResults/ResultsSort.tsx
+++ b/src/components/SearchResults/ResultsSort.tsx
@@ -36,6 +36,7 @@ const ResultsSort = ({
       value={value}
       display={display}
       className="no-print"
+      mt={{ base: "s", md: 0 }}
     >
       {Object.entries(sortOptions).map(([key, label]) => (
         <option value={key} key={`sort-by-${key}`}>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,7 +1,7 @@
 export const BASE_URL = "/research/research-catalog"
 export const SITE_NAME = "Research Catalog | NYPL"
 export const RESULTS_PER_PAGE = 50
-export const SUBJECTS_PER_PAGE = 30
+export const SUBJECTS_PER_PAGE = 25
 export const ITEMS_PER_SEARCH_RESULT = 3
 export const ITEM_PAGINATION_BATCH_SIZE = 20
 // TODO: Remove this when view_all endpoint in discovery supports query params

--- a/src/utils/utilsTests/browseUtils.test.ts
+++ b/src/utils/utilsTests/browseUtils.test.ts
@@ -21,155 +21,156 @@ describe("browseUtils", () => {
         "/browse/subjects/X%2C%20Malcolm%2C%201925-1965%20--%20Political%20and%20social%20views."
       )
     })
-    describe("mapQueryToBrowseParams", () => {
-      it("uses defaults if no values passed", () => {
-        expect(mapQueryToBrowseParams({})).toEqual({
-          q: "",
-          page: 1,
-          searchScope: "has",
-          sortBy: "count",
-          order: "desc",
+  })
+
+  describe("mapQueryToBrowseParams", () => {
+    it("uses defaults if no values passed", () => {
+      expect(mapQueryToBrowseParams({})).toEqual({
+        q: "",
+        page: 1,
+        searchScope: "has",
+        sortBy: "count",
+        order: "desc",
+      })
+    })
+
+    it("parses page as number", () => {
+      expect(
+        mapQueryToBrowseParams({
+          page: "3",
         })
-      })
-
-      it("parses page as number", () => {
-        expect(
-          mapQueryToBrowseParams({
-            page: "3",
-          })
-        ).toHaveProperty("page", 3)
-      })
-
-      it("falls back invalid sort and order", () => {
-        const result = mapQueryToBrowseParams({
-          //@ts-ignore
-          sort: "invalidSort",
-          //@ts-ignore
-          sort_direction: "invalidOrder",
-        })
-        expect(result.sortBy).toBe("count")
-        expect(result.order).toBe("desc")
-      })
-
-      it("accepts valid sort and order", () => {
-        const result = mapQueryToBrowseParams({
-          sort: "count",
-          sort_direction: "desc",
-          search_scope: "starts_with",
-        })
-        expect(result.sortBy).toBe("count")
-        expect(result.order).toBe("desc")
-        expect(result.searchScope).toBe("starts_with")
-      })
+      ).toHaveProperty("page", 3)
     })
 
-    describe("getBrowseQuery", () => {
-      it("returns correct query string with defaults not included", () => {
-        const params = {
-          q: "cats",
-          page: 1,
-          searchScope: "has",
-        }
-        expect(getBrowseQuery(params)).toBe("?q=cats&search_scope=has")
+    it("falls back invalid sort and order", () => {
+      const result = mapQueryToBrowseParams({
+        //@ts-ignore
+        sort: "invalidSort",
+        //@ts-ignore
+        sort_direction: "invalidOrder",
       })
-
-      it("includes sort params if not default", () => {
-        const params = {
-          q: "dogs",
-          page: 2,
-          searchScope: "has",
-          sortBy: "count",
-          order: "asc",
-        }
-        expect(getBrowseQuery(params)).toBe(
-          "?q=dogs&search_scope=has&sort=count&sort_direction=asc&page=2"
-        )
-      })
-
-      it("encodes query correctly", () => {
-        const params = {
-          q: "cats & dogs",
-          page: 1,
-          searchScope: "starts_with",
-          sortBy: "termLabel",
-          order: "asc",
-        }
-        expect(getBrowseQuery(params)).toBe(
-          "?q=cats%20%26%20dogs&search_scope=starts_with"
-        )
-      })
-
-      it("applies default sort if missing", () => {
-        const params = {
-          q: "fish",
-          page: 1,
-          searchScope: "has",
-          sortBy: "",
-          order: "",
-        }
-        expect(getBrowseQuery(params)).toBe("?q=fish&search_scope=has")
-      })
+      expect(result.sortBy).toBe("count")
+      expect(result.order).toBe("desc")
     })
 
-    describe("isPreferredSubject", () => {
-      it("returns true if object has @type preferredTerm", () => {
-        const subj = { "@type": "preferredTerm", termLabel: "foo", count: 3 }
-        expect(isPreferredSubject(subj)).toBe(true)
+    it("accepts valid sort and order", () => {
+      const result = mapQueryToBrowseParams({
+        sort: "count",
+        sort_direction: "desc",
+        search_scope: "starts_with",
       })
+      expect(result.sortBy).toBe("count")
+      expect(result.order).toBe("desc")
+      expect(result.searchScope).toBe("starts_with")
+    })
+  })
 
-      it("returns false if object has @type variant", () => {
-        const subj = { "@type": "variant", termLabel: "foo" }
-        expect(isPreferredSubject(subj)).toBe(false)
-      })
+  describe("getBrowseQuery", () => {
+    it("returns correct query string with defaults not included", () => {
+      const params = {
+        q: "cats",
+        page: 1,
+        searchScope: "has",
+      }
+      expect(getBrowseQuery(params)).toBe("?q=cats&search_scope=has")
     })
 
-    describe("getBrowseResultsHeading", () => {
-      it("returns correct heading with totalResults less than SUBJECTS_PER_PAGE", () => {
-        const params = { q: "cats", page: 1, searchScope: "has" }
-        const heading = getBrowseResultsHeading(params, 20)
-        expect(heading).toContain("20")
-        expect(heading).toContain('containing "cats"')
-      })
-
-      it("returns correct heading with totalResults more than SUBJECTS_PER_PAGE", () => {
-        const params = { q: "dogs", page: 2, searchScope: "starts_with" }
-        const heading = getBrowseResultsHeading(params, 200)
-        expect(heading).toContain("31-60")
-        expect(heading).toContain('beginning with "dogs"')
-      })
-
-      it("adds 'over' for 10000 totalResults", () => {
-        const params = { q: "", page: 1, searchScope: "has" }
-        const heading = getBrowseResultsHeading(params, 10000)
-        expect(heading).toContain("over")
-      })
+    it("includes sort params if not default", () => {
+      const params = {
+        q: "dogs",
+        page: 2,
+        searchScope: "has",
+        sortBy: "count",
+        order: "asc",
+      }
+      expect(getBrowseQuery(params)).toBe(
+        "?q=dogs&search_scope=has&sort=count&sort_direction=asc&page=2"
+      )
     })
 
-    describe("browseSortOptions", () => {
-      it("has expected keys and labels", () => {
-        expect(browseSortOptions).toHaveProperty("termLabel_asc")
-        expect(browseSortOptions.termLabel_asc).toBe("Subject heading (A - Z)")
-        expect(browseSortOptions.count_desc).toBe("Count (High - Low)")
-      })
+    it("encodes query correctly", () => {
+      const params = {
+        q: "cats & dogs",
+        page: 1,
+        searchScope: "starts_with",
+        sortBy: "termLabel",
+        order: "asc",
+      }
+      expect(getBrowseQuery(params)).toBe(
+        "?q=cats%20%26%20dogs&search_scope=starts_with"
+      )
     })
 
-    describe("buildSubjectLinks", () => {
-      it("builds links with termLabel, url, and count", () => {
-        const terms = [
-          { label: "foo", count: 123 },
-          { label: "bar", count: 0 },
-          { label: "baz" },
-        ]
-        const results = buildSubjectLinks(terms)
-        expect(results).toHaveLength(3)
-        expect(results[0]).toMatchObject({
-          termLabel: "foo",
-          count: "123",
-        })
-        expect(results[0].url).toContain("/browse/subjects/foo")
+    it("applies default sort if missing", () => {
+      const params = {
+        q: "fish",
+        page: 1,
+        searchScope: "has",
+        sortBy: "",
+        order: "",
+      }
+      expect(getBrowseQuery(params)).toBe("?q=fish&search_scope=has")
+    })
+  })
 
-        expect(results[2].count).toBe("")
+  describe("isPreferredSubject", () => {
+    it("returns true if object has @type preferredTerm", () => {
+      const subj = { "@type": "preferredTerm", termLabel: "foo", count: 3 }
+      expect(isPreferredSubject(subj)).toBe(true)
+    })
+
+    it("returns false if object has @type variant", () => {
+      const subj = { "@type": "variant", termLabel: "foo" }
+      expect(isPreferredSubject(subj)).toBe(false)
+    })
+  })
+
+  describe("getBrowseResultsHeading", () => {
+    it("returns correct heading with totalResults less than SUBJECTS_PER_PAGE", () => {
+      const params = { q: "cats", page: 1, searchScope: "has" }
+      const heading = getBrowseResultsHeading(params, 20)
+      expect(heading).toContain("20")
+      expect(heading).toContain('containing "cats"')
+    })
+
+    it("returns correct heading with totalResults more than SUBJECTS_PER_PAGE", () => {
+      const params = { q: "dogs", page: 2, searchScope: "starts_with" }
+      const heading = getBrowseResultsHeading(params, 200)
+      expect(heading).toContain("26-50")
+      expect(heading).toContain('beginning with "dogs"')
+    })
+
+    it("adds 'over' for 10000 totalResults", () => {
+      const params = { q: "", page: 1, searchScope: "has" }
+      const heading = getBrowseResultsHeading(params, 10000)
+      expect(heading).toContain("over")
+    })
+  })
+
+  describe("browseSortOptions", () => {
+    it("has expected keys and labels", () => {
+      expect(browseSortOptions).toHaveProperty("termLabel_asc")
+      expect(browseSortOptions.termLabel_asc).toBe("Subject heading (A - Z)")
+      expect(browseSortOptions.count_desc).toBe("Count (High - Low)")
+    })
+  })
+
+  describe("buildSubjectLinks", () => {
+    it("builds links with termLabel, url, and count", () => {
+      const terms = [
+        { label: "foo", count: 123 },
+        { label: "bar", count: 0 },
+        { label: "baz" },
+      ]
+      const results = buildSubjectLinks(terms)
+      expect(results).toHaveLength(3)
+      expect(results[0]).toMatchObject({
+        termLabel: "foo",
+        count: "123",
       })
+      expect(results[0].url).toContain("/browse/subjects/foo")
+
+      expect(results[2].count).toBe("")
     })
   })
 })


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4572](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4572)

## This PR does the following:

- Adds `Pagination` to browse index page

## How has this been tested?

Advance through the pages . Of the browse index

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4572]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ