### PR TITLE
SCC-4837: Fix location link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
-### Added
+### Fixed
 
-- Logs on hold cancel button [SCC-4807] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4807)
+- Fixed broken homepage "Locations" link [SCC-4837](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4837)
 
 ## [1.5.2] 2025-07-31
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -105,7 +105,7 @@ export default function Home({
                 }}
                 layout="row"
               >
-                <CardHeading level="h4" url="/locations/map?libraries=research">
+                <CardHeading level="h4" url="/locations">
                   Locations
                 </CardHeading>
                 <CardContent>


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4837](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4837)

## This PR does the following:

- Updates the now broken link on the homepage from `/locations/map?libraries=research` to `/locations`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4837]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ