### PR TITLE
SCC-4805: updated homepage.spec.ts to include footer assertions.  changed timeo…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
-- Updated playwright homepage.spec.ts and related page objects to include assertions for footer elements. Also added before hook to that test file.
+- Updated playwright homepage.spec.ts and related page objects to include assertions for footer elements. Also added before hook to that test file. JIRA ticket [SCC-4805](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4805)
 
 - Updated finding aid copy and link [SCC-4803](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4803)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
+- Updated playwright homepage.spec.ts and related page objects to include assertions for footer elements. Also added before hook to that test file.
+
 - Updated finding aid copy and link [SCC-4803](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4803)
 
 ### Added

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ import { defineConfig, devices } from "@playwright/test"
  */
 export default defineConfig({
   timeout: 30 * 1000,
-  globalTimeout: 20 * 60 * 1000,
+  globalTimeout: 20 * 30 * 1000,
   testDir: "./playwright",
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -28,7 +28,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://local.nypl.org:8080",
+    baseURL: "http://local.nypl.org:8080/research/research-catalog",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/playwright/pages/base_page.ts
+++ b/playwright/pages/base_page.ts
@@ -28,6 +28,25 @@ export class BasePage {
   readonly search_the_catalog: Locator
   readonly shep: Locator
   readonly my_account: Locator
+  // global footer
+  readonly footer_library_text_image: Locator
+  readonly footer_building_image: Locator
+  readonly footer_copyright_text: Locator
+  readonly footer_legal_text: Locator
+  readonly footer_accessibility: Locator
+  readonly footer_press: Locator
+  readonly footer_careers: Locator
+  readonly footer_space_rental: Locator
+  readonly footer_privacy_policy: Locator
+  readonly footer_other_policies: Locator
+  readonly footer_terms: Locator
+  readonly footer_governance: Locator
+  readonly footer_rules_regulations: Locator
+  readonly footer_about: Locator
+  readonly footer_language: Locator
+
+  readonly footer_container: Locator
+  readonly help_and_feedback: Locator
 
   constructor(page: Page) {
     this.page = page
@@ -88,6 +107,45 @@ export class BasePage {
     this.shep = page.getByRole("link", { name: "Subject Heading Explorer" })
     this.my_account = page.getByRole("link", {
       name: "My account for NYPL.org",
+    })
+    // Footer
+    this.footer_library_text_image = page.getByRole("img", {
+      name: "The New York Public Library",
+    })
+    this.footer_building_image = page.getByRole("img", {
+      name: "NYPL Main Building Facade",
+    })
+    this.footer_copyright_text = page.getByText(
+      "© The New York Public Library,"
+    )
+    this.footer_legal_text = page.getByText(
+      "The New York Public Library is a 501(c)(3) | EIN 13-"
+    )
+    this.footer_accessibility = page
+      .locator("footer")
+      .getByRole("link", { name: "Accessibility" })
+    this.footer_press = page.getByRole("link", { name: "Press" })
+    this.footer_careers = page.getByRole("link", { name: "Careers" })
+    this.footer_space_rental = page.getByRole("link", {
+      name: "Space Rental",
+    })
+    this.footer_privacy_policy = page.getByRole("link", {
+      name: "Privacy Policy",
+    })
+    this.footer_other_policies = page.getByRole("link", {
+      name: "Other Policies",
+    })
+    this.footer_terms = page.getByRole("link", { name: "Terms & Conditions" })
+    this.footer_governance = page.getByRole("link", { name: "Governance" })
+    this.footer_rules_regulations = page.getByRole("link", {
+      name: "Rules & Regulations",
+    })
+    this.footer_about = page.getByRole("link", { name: "About NYPL" })
+    this.footer_language = page.getByRole("link", { name: "Language" })
+
+    this.footer_container = page.locator("footer#footer")
+    this.help_and_feedback = page.getByRole("button", {
+      name: "Help and Feedback",
     })
   }
 }

--- a/playwright/pages/rc_home_page.ts
+++ b/playwright/pages/rc_home_page.ts
@@ -27,8 +27,6 @@ export class RC_Home_Page extends BasePage {
   readonly services_heading: Locator
   readonly services_heading_image: Locator
   readonly services_heading_blurb: Locator
-  readonly footer_container: Locator
-  readonly help_and_feedback: Locator
 
   constructor(page: Page) {
     super(page)
@@ -92,14 +90,5 @@ export class RC_Home_Page extends BasePage {
       name: "Man wheeling cart in NYPL",
     })
     this.services_heading_blurb = page.getByText("Explore services for online")
-    // Footer
-    this.footer_container = page.locator("footer#footer")
-    this.help_and_feedback = page.getByRole("button", {
-      name: "Help and Feedback",
-    })
-  }
-
-  async goto() {
-    await this.page.goto("/research/research-catalog")
   }
 }

--- a/playwright/tests/Homepage/homepage.spec.ts
+++ b/playwright/tests/Homepage/homepage.spec.ts
@@ -1,12 +1,15 @@
 import { test, expect } from "@playwright/test"
 import { RC_Home_Page } from "../../pages/rc_home_page"
 
+let rcHomePage: RC_Home_Page
+
+test.beforeEach(async ({ page }) => {
+  rcHomePage = new RC_Home_Page(page)
+  await page.goto("")
+})
+
 test.describe("Global Header", () => {
-  test("Verify global header elements appear on the Research Catalog home page", async ({
-    page,
-  }) => {
-    const rcHomePage = new RC_Home_Page(page)
-    await rcHomePage.goto()
+  test("Verify global header elements appear on the Research Catalog home page", async () => {
     await expect(rcHomePage.nypl_logo).toBeVisible()
     await expect(rcHomePage.nypl_logo_img).toBeVisible()
     await expect(rcHomePage.header_my_account).toBeVisible()
@@ -30,8 +33,6 @@ test.describe("Research Catalog Home Page", () => {
   test("Verify elements on the Research Catalog home page", async ({
     page,
   }) => {
-    const rcHomePage = new RC_Home_Page(page)
-    await rcHomePage.goto()
     await expect(rcHomePage.header_my_account).toBeVisible()
     await expect(rcHomePage.researchCatalogHeading).toHaveText(
       "Research Catalog"
@@ -81,12 +82,25 @@ test.describe("Research Catalog Home Page", () => {
 })
 
 test.describe("Global Footer", () => {
-  test("Verify global footer elements appear on the Research Catalog home page", async ({
-    page,
-  }) => {
-    const rcHomePage = new RC_Home_Page(page)
-    await rcHomePage.goto()
+  test("Verify global footer elements appear on the Research Catalog home page", async () => {
+    const links = await rcHomePage.page.locator("footer a").allTextContents()
+    console.log(links)
     await expect(rcHomePage.footer_container).toBeVisible()
+    await expect(rcHomePage.footer_library_text_image).toBeVisible()
+    await expect(rcHomePage.footer_building_image).toBeVisible()
+    await expect(rcHomePage.footer_copyright_text).toBeVisible()
+    await expect(rcHomePage.footer_legal_text).toBeVisible()
+    await expect(rcHomePage.footer_accessibility).toBeVisible()
+    await expect(rcHomePage.footer_press).toBeVisible()
+    await expect(rcHomePage.footer_careers).toBeVisible()
+    await expect(rcHomePage.footer_space_rental).toBeVisible()
+    await expect(rcHomePage.footer_privacy_policy).toBeVisible()
+    await expect(rcHomePage.footer_other_policies).toBeVisible()
+    await expect(rcHomePage.footer_terms).toBeVisible()
+    await expect(rcHomePage.footer_governance).toBeVisible()
+    await expect(rcHomePage.footer_rules_regulations).toBeVisible()
+    await expect(rcHomePage.footer_about).toBeVisible()
+    await expect(rcHomePage.footer_language).toBeVisible()
     await expect(rcHomePage.help_and_feedback).toBeVisible()
   })
 })

--- a/playwright/tests/Homepage/homepage.spec.ts
+++ b/playwright/tests/Homepage/homepage.spec.ts
@@ -8,27 +8,6 @@ test.beforeEach(async ({ page }) => {
   await page.goto("")
 })
 
-test.describe("Global Header", () => {
-  test("Verify global header elements appear on the Research Catalog home page", async () => {
-    await expect(rcHomePage.nypl_logo).toBeVisible()
-    await expect(rcHomePage.nypl_logo_img).toBeVisible()
-    await expect(rcHomePage.header_my_account).toBeVisible()
-    await expect(rcHomePage.header_locations).toBeVisible()
-    await expect(rcHomePage.header_library_card).toBeVisible()
-    await expect(rcHomePage.header_newsletter).toBeVisible()
-    await expect(rcHomePage.header_donate).toBeVisible()
-    await expect(rcHomePage.header_shop).toBeVisible()
-    await expect(rcHomePage.header_books).toBeVisible()
-    await expect(rcHomePage.header_research).toBeVisible()
-    await expect(rcHomePage.header_education).toBeVisible()
-    await expect(rcHomePage.header_events).toBeVisible()
-    await expect(rcHomePage.header_connect).toBeVisible()
-    await expect(rcHomePage.header_give).toBeVisible()
-    await expect(rcHomePage.header_get_help).toBeVisible()
-    await expect(rcHomePage.header_search).toBeVisible()
-  })
-})
-
 test.describe("Research Catalog Home Page", () => {
   test("Verify elements on the Research Catalog home page", async ({
     page,
@@ -78,29 +57,5 @@ test.describe("Research Catalog Home Page", () => {
     await expect(rcHomePage.services_heading_blurb).toContainText(
       "Explore services"
     )
-  })
-})
-
-test.describe("Global Footer", () => {
-  test("Verify global footer elements appear on the Research Catalog home page", async () => {
-    const links = await rcHomePage.page.locator("footer a").allTextContents()
-    console.log(links)
-    await expect(rcHomePage.footer_container).toBeVisible()
-    await expect(rcHomePage.footer_library_text_image).toBeVisible()
-    await expect(rcHomePage.footer_building_image).toBeVisible()
-    await expect(rcHomePage.footer_copyright_text).toBeVisible()
-    await expect(rcHomePage.footer_legal_text).toBeVisible()
-    await expect(rcHomePage.footer_accessibility).toBeVisible()
-    await expect(rcHomePage.footer_press).toBeVisible()
-    await expect(rcHomePage.footer_careers).toBeVisible()
-    await expect(rcHomePage.footer_space_rental).toBeVisible()
-    await expect(rcHomePage.footer_privacy_policy).toBeVisible()
-    await expect(rcHomePage.footer_other_policies).toBeVisible()
-    await expect(rcHomePage.footer_terms).toBeVisible()
-    await expect(rcHomePage.footer_governance).toBeVisible()
-    await expect(rcHomePage.footer_rules_regulations).toBeVisible()
-    await expect(rcHomePage.footer_about).toBeVisible()
-    await expect(rcHomePage.footer_language).toBeVisible()
-    await expect(rcHomePage.help_and_feedback).toBeVisible()
   })
 })

--- a/playwright/tests/base_page.spec.ts
+++ b/playwright/tests/base_page.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test"
+import { BasePage } from "../pages/base_page"
+
+let basePage: BasePage
+
+test.beforeEach(async ({ page }) => {
+  basePage = new BasePage(page)
+  await page.goto("")
+})
+
+test.describe("Global Header", () => {
+  test("Verify global header elements appear", async () => {
+    await expect(basePage.nypl_logo).toBeVisible()
+    await expect(basePage.nypl_logo_img).toBeVisible()
+    await expect(basePage.header_my_account).toBeVisible()
+    await expect(basePage.header_locations).toBeVisible()
+    await expect(basePage.header_library_card).toBeVisible()
+    await expect(basePage.header_newsletter).toBeVisible()
+    await expect(basePage.header_donate).toBeVisible()
+    await expect(basePage.header_shop).toBeVisible()
+    await expect(basePage.header_books).toBeVisible()
+    await expect(basePage.header_research).toBeVisible()
+    await expect(basePage.header_education).toBeVisible()
+    await expect(basePage.header_events).toBeVisible()
+    await expect(basePage.header_connect).toBeVisible()
+    await expect(basePage.header_give).toBeVisible()
+    await expect(basePage.header_get_help).toBeVisible()
+    await expect(basePage.header_search).toBeVisible()
+  })
+})
+test.describe("Global Footer", () => {
+  test("Verify global footer elements appear", async () => {
+    await expect(basePage.footer_library_text_image).toBeVisible()
+    await expect(basePage.footer_building_image).toBeVisible()
+    await expect(basePage.footer_copyright_text).toBeVisible()
+    await expect(basePage.footer_legal_text).toBeVisible()
+    await expect(basePage.footer_accessibility).toBeVisible()
+    await expect(basePage.footer_press).toBeVisible()
+    await expect(basePage.footer_careers).toBeVisible()
+    await expect(basePage.footer_space_rental).toBeVisible()
+    await expect(basePage.footer_privacy_policy).toBeVisible()
+    await expect(basePage.footer_other_policies).toBeVisible()
+    await expect(basePage.footer_terms).toBeVisible()
+    await expect(basePage.footer_governance).toBeVisible()
+    await expect(basePage.footer_rules_regulations).toBeVisible()
+    await expect(basePage.footer_about).toBeVisible()
+    await expect(basePage.footer_language).toBeVisible()
+    await expect(basePage.footer_space_rental).toBeVisible()
+    await expect(basePage.footer_space_rental).toBeVisible()
+    await expect(basePage.footer_container).toBeVisible()
+    await expect(basePage.help_and_feedback).toBeVisible()
+  })
+})


### PR DESCRIPTION
…ut back to 30 seconds.

## Ticket:

- JIRA ticket [4805](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4805)

## This PR does the following:

- Updated playwright homepage.spec.ts and related page objects to include assertions for footer elements. Also added before hook to that test file.

## How has this been tested?

tests pass locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x ] All new and existing tests passed.
