### PR TITLE
Scc 4844/playwright keyword search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Playwright test for keyword search. [SCC-4844](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4844)
 
-### Added
-
 - Remove annotated MARC duplicate values from bib details and log unique values [SCC-4763](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763)
 - Add QA only banner [SCC-4810](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4810)
 - Updated playwright homepage.spec.ts and related page objects to include assertions for footer elements. Also added before hook to that test file. [SCC-4805](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4805)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Playwright test for keyword search. [SCC-4844](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4844)
 - Added Playwright tests for RC home page elements. found in /playwright. Deleted dummy test file that was created for initial Playwright install. [SCC-4792](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4792)
 - Added Playwright, the end-to-end testing framework for automating and verifying browser interactions across Chromium, Firefox, and WebKit. [SCC-4772](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4772)
 - Trailing period removal from subject literals [SCC-4801](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4801)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Playwright test for keyword search. [SCC-4844](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4844)
+
+### Added
+
 - Remove annotated MARC duplicate values from bib details and log unique values [SCC-4763](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763)
 - Add QA only banner [SCC-4810](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4810)
 - Updated playwright homepage.spec.ts and related page objects to include assertions for footer elements. Also added before hook to that test file. [SCC-4805](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4805)
@@ -36,9 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplify winston instantiation [SCC-4807] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4807)
 - Updated finding aid copy and link [SCC-4803](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4803)
 
-### Added
-
-- Added Playwright test for keyword search. [SCC-4844](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4844)
 - Added Playwright tests for RC home page elements. found in /playwright. Deleted dummy test file that was created for initial Playwright install. [SCC-4792](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4792)
 - Added Playwright, the end-to-end testing framework for automating and verifying browser interactions across Chromium, Firefox, and WebKit. [SCC-4772](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4772)
 - Trailing period removal from subject literals [SCC-4801](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4801)

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -2,19 +2,16 @@ import type { Page, Locator } from "@playwright/test"
 
 export class SearchPage {
   readonly page: Page
-  readonly search_input: Locator
-  readonly search_submit_button: Locator
   readonly results_count: Locator
-  readonly results_title: Locator
+  readonly keyword: string
+  readonly keywordResult: Locator
 
-  constructor(page: Page) {
+  constructor(page: Page, keyword: string) {
     this.page = page
-    this.results_count = page.getByTestId("search-results-heading")
-    this.results_title = page.locator("#search-results-list h3 a")
-  }
-
-  async searchFor(keyword: string) {
-    await this.search_input.fill(keyword)
-    await this.search_submit_button.click()
+    this.keywordResult = page
+      .locator("#search-results-list")
+      .locator("h3")
+      .getByRole("link", { name: new RegExp(keyword) })
+    this.results_count = page.locator("#search-results-heading")
   }
 }

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -20,11 +20,10 @@ export class SearchPage {
     })
     this.keywordResult = page
       .locator("#search-results-list")
-      .locator("h3")
       .getByRole("link", { name: new RegExp(keyword) })
     this.resultsHeading = this.page.getByRole("heading", {
       name: new RegExp(
-        `^Displaying (\\d+-\\d+|\\d+) of \\d+ results for keywords? "${this.keyword}"$`
+        `^Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for keywords? "${this.keyword}"$`
       ),
     })
   }

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -2,16 +2,35 @@ import type { Page, Locator } from "@playwright/test"
 
 export class SearchPage {
   readonly page: Page
-  readonly results_count: Locator
-  readonly keyword: string
   readonly keywordResult: Locator
+  readonly search_input: Locator
+  readonly search_submit_button: Locator
+  readonly resultsHeading: Locator
+  readonly keyword: string
 
   constructor(page: Page, keyword: string) {
     this.page = page
+    this.keyword = keyword
+    this.search_input = page.getByRole("textbox", {
+      name: "Enter one or more keywords.",
+    })
+    this.search_submit_button = page.getByRole("button", {
+      name: "Search",
+      exact: true,
+    })
     this.keywordResult = page
       .locator("#search-results-list")
       .locator("h3")
       .getByRole("link", { name: new RegExp(keyword) })
-    this.results_count = page.locator("#search-results-heading")
+    this.resultsHeading = this.page.getByRole("heading", {
+      name: new RegExp(
+        `^Displaying (\\d+-\\d+|\\d+) of \\d+ results for keywords? "${this.keyword}"$`
+      ),
+    })
+  }
+
+  async searchFor(keyword: string) {
+    await this.search_input.fill(keyword)
+    await this.search_submit_button.click()
   }
 }

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -1,0 +1,20 @@
+import type { Page, Locator } from "@playwright/test"
+
+export class SearchPage {
+  readonly page: Page
+  readonly search_input: Locator
+  readonly search_submit_button: Locator
+  readonly results_count: Locator
+  readonly results_title: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.results_count = page.getByTestId("search-results-heading")
+    this.results_title = page.locator("#search-results-list h3 a")
+  }
+
+  async searchFor(keyword: string) {
+    await this.search_input.fill(keyword)
+    await this.search_submit_button.click()
+  }
+}

--- a/playwright/tests/Search/search_keyword.spec.ts
+++ b/playwright/tests/Search/search_keyword.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test"
+import { RC_Home_Page } from "../../pages/rc_home_page"
+import { SearchPage } from "../../pages/search_page"
+let rcHomePage: RC_Home_Page
+let searchPage: SearchPage
+
+test.beforeEach(async ({ page }) => {
+  rcHomePage = new RC_Home_Page(page)
+  searchPage = new SearchPage(page)
+  await page.goto("")
+})
+
+test.describe("Keyword Search", () => {
+  test("Do a keyword search and verify that at least 8 of the first 10 results has the supplied keyword in the title field", async ({
+    page,
+  }) => {
+    await expect(rcHomePage.search_input).toBeVisible()
+    await rcHomePage.search_input.fill("IBM 1401")
+    await rcHomePage.search_submit_button.click()
+    // sleep 1 second
+    await page.waitForTimeout(1000)
+    await expect(searchPage.results_count).toContainText("keywords")
+    // assert that at least 8 of the first 10 results has the supplied keyword in the title field
+    const titles = await searchPage.results_title.allTextContents()
+    const matchingTitles = titles.filter((title) => title.includes("IBM 1401"))
+    expect(matchingTitles.length).toBeGreaterThanOrEqual(8)
+  })
+})

--- a/playwright/tests/Search/search_keyword.spec.ts
+++ b/playwright/tests/Search/search_keyword.spec.ts
@@ -1,27 +1,25 @@
 import { test, expect } from "@playwright/test"
 import { RC_Home_Page } from "../../pages/rc_home_page"
 import { SearchPage } from "../../pages/search_page"
+
 let rcHomePage: RC_Home_Page
 let searchPage: SearchPage
+const keyword = "IBM 1401"
 
 test.beforeEach(async ({ page }) => {
   rcHomePage = new RC_Home_Page(page)
-  searchPage = new SearchPage(page)
+  searchPage = new SearchPage(page, keyword)
   await page.goto("")
 })
 
 test.describe("Keyword Search", () => {
-  test("Do a keyword search and verify that at least 8 of the first 10 results has the supplied keyword in the title field", async ({
+  test("Do a keyword search and assert that at least 10 returned titles contain the supplied keyword", async ({
     page,
   }) => {
     await expect(rcHomePage.search_input).toBeVisible()
-    await rcHomePage.search_input.fill("IBM 1401")
+    await rcHomePage.search_input.fill(keyword)
     await rcHomePage.search_submit_button.click()
-
     await expect(searchPage.results_count).toBeVisible()
-    // assert that at least 8 of the first 10 results has the supplied keyword in the title field
-    const titles = await searchPage.results_title.allTextContents()
-    const matchingTitles = titles.filter((title) => title.includes("IBM 1401"))
-    expect(matchingTitles.length).toBeGreaterThanOrEqual(8)
+    await expect(await searchPage.keywordResult.count()).toBeGreaterThan(10)
   })
 })

--- a/playwright/tests/Search/search_keyword.spec.ts
+++ b/playwright/tests/Search/search_keyword.spec.ts
@@ -1,25 +1,18 @@
 import { test, expect } from "@playwright/test"
-import { RC_Home_Page } from "../../pages/rc_home_page"
 import { SearchPage } from "../../pages/search_page"
 
-let rcHomePage: RC_Home_Page
 let searchPage: SearchPage
 const keyword = "IBM 1401"
 
 test.beforeEach(async ({ page }) => {
-  rcHomePage = new RC_Home_Page(page)
   searchPage = new SearchPage(page, keyword)
   await page.goto("")
 })
 
 test.describe("Keyword Search", () => {
-  test("Do a keyword search and assert that at least 10 returned titles contain the supplied keyword", async ({
-    page,
-  }) => {
-    await expect(rcHomePage.search_input).toBeVisible()
-    await rcHomePage.search_input.fill(keyword)
-    await rcHomePage.search_submit_button.click()
-    await expect(searchPage.results_count).toBeVisible()
+  test("Do a keyword search and assert that at least 10 returned titles contain the supplied keyword", async () => {
+    await searchPage.searchFor(keyword)
+    await expect(searchPage.resultsHeading).toBeVisible()
     await expect(await searchPage.keywordResult.count()).toBeGreaterThan(10)
   })
 })

--- a/playwright/tests/Search/search_keyword.spec.ts
+++ b/playwright/tests/Search/search_keyword.spec.ts
@@ -17,9 +17,8 @@ test.describe("Keyword Search", () => {
     await expect(rcHomePage.search_input).toBeVisible()
     await rcHomePage.search_input.fill("IBM 1401")
     await rcHomePage.search_submit_button.click()
-    // sleep 1 second
-    await page.waitForTimeout(1000)
-    await expect(searchPage.results_count).toContainText("keywords")
+
+    await expect(searchPage.results_count).toBeVisible()
     // assert that at least 8 of the first 10 results has the supplied keyword in the title field
     const titles = await searchPage.results_title.allTextContents()
     const matchingTitles = titles.filter((title) => title.includes("IBM 1401"))


### PR DESCRIPTION
## Ticket:

- JIRA ticket [4844](https://newyorkpubliclibrary.atlassian.net/browse/SCC-{4844})

## This PR does the following:

- adds Playwright test for keyword search on RC

## How has this been tested?

tests pass locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [ x] All new and existing tests passed.
