### PR TITLE
SCC-4763: Remove duplicated MARC values from bib details

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Remove annotated MARC duplicate values from bib details and log unique values [SCC-4763] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763)
+- Remove annotated MARC duplicate values from bib details and log unique values [SCC-4763](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763)
 
 ## [1.5.3] 2025-08-06
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Added
+
+- Remove annotated MARC duplicate values from bib details and log unique values [SCC-4763] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763)
+
 ## [1.5.3] 2025-08-06
 
 ### Added

--- a/__test__/pages/bib/bibPage.test.tsx
+++ b/__test__/pages/bib/bibPage.test.tsx
@@ -66,6 +66,9 @@ describe("Bib Page with items", () => {
     )
     expect(screen.getByTestId("lccn")).toHaveTextContent("sn 98001765")
     expect(screen.getByTestId("issn")).toHaveTextContent("1521-1371")
+
+    // Research call number duplicates call number
+    expect(screen.queryByTestId("research-call-number")).not.toBeInTheDocument()
   })
 })
 

--- a/__test__/pages/bib/bibPage.test.tsx
+++ b/__test__/pages/bib/bibPage.test.tsx
@@ -44,7 +44,6 @@ describe("Bib Page with items", () => {
     expect(screen.getByTestId("bib-details-item-table")).toBeInTheDocument()
   })
 
-  // TODO: Determine if this should be rendering twice
   it("renders the bottom bib details", () => {
     expect(screen.getAllByTestId("publication-date")[0]).toHaveTextContent(
       "Vol. 1, issue 1-"
@@ -62,26 +61,11 @@ describe("Bib Page with items", () => {
     expect(screen.getAllByTestId("call-number")[0]).toHaveTextContent(
       "JFK 01-374"
     )
-    expect(screen.getAllByTestId("title")[1]).toHaveTextContent(
-      "Urban spaghetti."
-    )
-    expect(screen.getByTestId("imprint")).toHaveTextContent(
-      "Mansfield, Ohio : Urban Spaghetti, [1999?-"
-    )
     expect(screen.getByTestId("current-frequency")).toHaveTextContent(
       "Semiannual"
     )
-    expect(screen.getByTestId("abbreviated-title")).toHaveTextContent(
-      "Urban spaghetti"
-    )
-    expect(screen.getByTestId("cover-title")).toHaveTextContent(
-      "Urban spaghetti literary arts journal"
-    )
     expect(screen.getByTestId("lccn")).toHaveTextContent("sn 98001765")
     expect(screen.getByTestId("issn")).toHaveTextContent("1521-1371")
-    expect(screen.getByTestId("research-call-number")).toHaveTextContent(
-      "JFK 01-374"
-    )
   })
 })
 

--- a/src/components/BibPage/BibDetail.test.tsx
+++ b/src/components/BibPage/BibDetail.test.tsx
@@ -42,7 +42,7 @@ describe("BibDetail component", () => {
       expect(screen.getByText("Series statement")).toBeInTheDocument()
       expect(screen.queryAllByText(/Haute enfance/)[0]).toBeInTheDocument()
     })
-    it("merges annotated MARC and resource fields without duplicates", () => {
+    it("merges annotated MARC and resource fields without label duplicates", () => {
       const combinedDetails = noParallelsBibModel.bottomDetails
       const labels = combinedDetails.map((d) => d.label)
       const labelCounts = labels.reduce((acc, label) => {
@@ -51,6 +51,20 @@ describe("BibDetail component", () => {
       }, {})
 
       Object.values(labelCounts).forEach((count) => {
+        expect(count).toBeLessThanOrEqual(1)
+      })
+    })
+    it("merges annotated MARC and resource fields without value duplicates", () => {
+      const combinedDetails = noParallelsBibModel.bottomDetails
+      const allValues = combinedDetails.flatMap((d) =>
+        Array.isArray(d.value) ? d.value.map(String) : [String(d.value)]
+      )
+      const valueCounts = allValues.reduce((acc, value) => {
+        acc[value] = (acc[value] || 0) + 1
+        return acc
+      }, {} as Record<string, number>)
+
+      Object.entries(valueCounts).forEach(([value, count]) => {
         expect(count).toBeLessThanOrEqual(1)
       })
     })

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -199,15 +199,11 @@ export default class BibDetails {
       }
     })
 
-    const logEntries = Object.entries(keptByLabel).map(
-      ([label, values]) => `"${label}" — unique value(s): ${values.join(", ")}`
-    )
-
-    if (logEntries.length > 0) {
+    if (Object.keys(keptByLabel).length > 0) {
       logger.info(
         `Bib details: Keeping annotated MARC fields on ${
           this.bib["@id"]
-        }:\n${logEntries.join("\n")}`
+        }:\n${JSON.stringify(keptByLabel, null, 2)}`
       )
     }
 

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -10,6 +10,7 @@ import type {
 } from "../types/bibDetailsTypes"
 import { convertToSentenceCase } from "../utils/appUtils"
 import { getFindingAidFromSupplementaryContent } from "../utils/bibUtils"
+import logger from "../../logger"
 
 export default class BibDetails {
   bib: DiscoveryBibResult
@@ -201,8 +202,8 @@ export default class BibDetails {
         }
 
         // Keep if neither condition matched
-        console.log(
-          `[BibDetails] Keeping annotated MARC field "${
+        logger.info(
+          `Bib details: Keeping annotated MARC field "${
             detail.label
           }" — unique values: ${marcValues.join(", ")}`
         )


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4763](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763)

## This PR does the following:

- We already remove annotated MARC fields with matching labels, this also removes fields that match any *value* in the bib
- Logs when there's a unique MARC value that we keep (so we can see what bibs are missing over time)
     - This seems like it's really gonna clutter the logs but the log was specifically requested

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Check that there's no repeated labels, or repeated values, in the details of a bib page. 

For example: 
[Prod bib with duplicates](https://www.nypl.org/research/research-catalog/bib/b22811365)
[Same bib on Vercel with duplicates removed](https://research-catalog-git-scc-4763-remove-duplicate-marc-fields-nypl.vercel.app/research/research-catalog/bib/b22811365)
- The annotated MARC fields `Title`, `Provenance`, and `Research call number` are removed because `Title`, `Binding (note)`, and `Call number` are already covered by the bib

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4763]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ