### PR TITLE
SCC-4868: Scan and delivery banner

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+## [1.5.4] 2025-08-22
+
+### Added
+
+- Scan and delivery delay banner [SCC-4868] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4868)
+
 ## [1.5.3] 2025-08-06
 
 ### Added

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -181,7 +181,9 @@ export default function Home({
 }
 
 export async function getServerSideProps({ req }) {
-  const bannerNotification = process.env.SEARCH_RESULTS_NOTIFICATION || ""
+  const bannerNotification =
+    process.env.SEARCH_RESULTS_NOTIFICATION ||
+    "Due to network connectivity issues, there may be delays in the Scan and Deliver service."
   // Every page that needs patron data must call initializePatronTokenAuth
   // to find if the token is valid and what the patron id is.
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -235,7 +235,9 @@ export default function Search({
 }
 
 export async function getServerSideProps({ req, query }) {
-  const bannerNotification = process.env.SEARCH_RESULTS_NOTIFICATION || ""
+  const bannerNotification =
+    process.env.SEARCH_RESULTS_NOTIFICATION ||
+    "Due to network connectivity issues, there may be delays in the Scan and Deliver service."
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
 
   const results = await fetchResults(mapQueryToSearchParams(query))

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -118,7 +118,7 @@ const Layout = ({
                 {showNotification && bannerNotification && (
                   <Banner
                     className={`${styles.banner} no-print`}
-                    heading="New Service Announcement"
+                    heading="Service Announcement"
                     content={bannerNotification}
                   />
                 )}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4868](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4868)

## This PR does the following:

- Adds the scan and delivery message and changes banner heading to "Service announcement"

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
