### PR TITLE
SCC-4763: Duplicate AM fields formatting edition

### DIFF
--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -345,18 +345,24 @@ export async function getServerSideProps({ params, query, req }) {
   const { id } = params
   const { discoveryBibResult, annotatedMarc, status, redirectUrl } =
     await fetchBib(id, query)
-
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
   const isAuthenticated = patronTokenResponse.isTokenValid
 
   switch (status) {
     case 307:
       return {
-        redirect: { destination: redirectUrl, permanent: false },
+        redirect: {
+          destination: redirectUrl,
+          permanent: false,
+        },
       }
     case 404:
-      return { props: { notFound: true } }
-    default: {
+      return {
+        props: {
+          notFound: true,
+        },
+      }
+    default:
       return {
         props: {
           discoveryBibResult,
@@ -365,6 +371,5 @@ export async function getServerSideProps({ params, query, req }) {
           itemPage: query.item_page ? parseInt(query.item_page) : 1,
         },
       }
-    }
   }
 }

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -55,7 +55,6 @@ interface BibPropsType {
   itemPage?: number
   viewAllItems?: boolean
   notFound?: boolean
-  prebuiltBibDetails?: BibDetailsModel
 }
 
 /**
@@ -64,7 +63,6 @@ interface BibPropsType {
 export default function BibPage({
   discoveryBibResult,
   annotatedMarc,
-  prebuiltBibDetails,
   isAuthenticated,
   itemPage = 1,
   viewAllItems = false,
@@ -99,7 +97,7 @@ export default function BibPage({
   }
 
   const { topDetails, bottomDetails, holdingsDetails, findingAid } =
-    prebuiltBibDetails || new BibDetailsModel(discoveryBibResult, annotatedMarc)
+    new BibDetailsModel(discoveryBibResult, annotatedMarc)
   const displayLegacyCatalogLink = isNyplBibID(bib.id)
 
   const filtersAreApplied = areFiltersApplied(appliedFilters)
@@ -359,20 +357,12 @@ export async function getServerSideProps({ params, query, req }) {
     case 404:
       return { props: { notFound: true } }
     default: {
-      // Build bib details serverside, allows us to log our kept annotated MARC fields.
-      const bibDetails = new BibDetailsModel(discoveryBibResult, annotatedMarc)
       return {
         props: {
           discoveryBibResult,
           annotatedMarc,
           isAuthenticated,
           itemPage: query.item_page ? parseInt(query.item_page) : 1,
-          prebuiltBibDetails: {
-            topDetails: bibDetails.topDetails,
-            bottomDetails: bibDetails.bottomDetails,
-            holdingsDetails: bibDetails.holdingsDetails,
-            findingAid: bibDetails.findingAid,
-          },
         },
       }
     }

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -7,6 +7,9 @@ import type {
   BibDetailURL,
   AnnotatedMarc,
   AnyBibDetail,
+  MarcLinkedDetail,
+  MarcDetail,
+  AnyMarcDetail,
 } from "../types/bibDetailsTypes"
 import { convertToSentenceCase } from "../utils/appUtils"
 import { getFindingAidFromSupplementaryContent } from "../utils/bibUtils"
@@ -14,7 +17,7 @@ import logger from "../../logger"
 
 export default class BibDetails {
   bib: DiscoveryBibResult
-  annotatedMarcDetails: AnyBibDetail[]
+  annotatedMarcDetails: AnyMarcDetail[]
   holdingsDetails: AnyBibDetail[]
   topDetails: AnyBibDetail[]
   bottomDetails: AnyBibDetail[]
@@ -59,20 +62,53 @@ export default class BibDetails {
 
   buildAnnotatedMarcDetails(
     annotatedMarc: AnnotatedMarcField[]
-  ): AnyBibDetail[] {
+  ): AnyMarcDetail[] {
     if (!annotatedMarc) return []
     return annotatedMarc.map(({ label, values }: AnnotatedMarcField) => {
+      const fieldMarcTags = values.map((val) => val.source?.marcTag)
       if (label === "Connect to:") {
         const urlValues = values.map(({ label, content }) => ({
           url: content,
           urlLabel: label,
         }))
-        return this.buildExternalLinkedDetail("Connect to:", urlValues)
+        const detail = this.buildExternalLinkedDetail(
+          "Connect to:",
+          urlValues,
+          fieldMarcTags
+        )
+        return detail as MarcLinkedDetail
       } else {
         const fieldValues = values.map((val) => val.content)
-        return this.buildDetail(label, fieldValues)
+        return this.buildDetail(label, fieldValues, fieldMarcTags) as MarcDetail
       }
     })
+  }
+
+  buildDetail(
+    label: string,
+    value: string[],
+    fieldMarcTags?: string[]
+  ): BibDetail | MarcDetail {
+    if (!value?.length) return null
+
+    const base = { label: convertToSentenceCase(label), value }
+
+    return fieldMarcTags ? { ...base, marcTags: fieldMarcTags } : base
+  }
+
+  buildExternalLinkedDetail(
+    label: string,
+    value: BibDetailURL[],
+    fieldMarcTags?: string[]
+  ): LinkedBibDetail | MarcLinkedDetail {
+    if (!value.length) return null
+
+    const base: LinkedBibDetail = {
+      label: convertToSentenceCase(label),
+      value,
+      link: "external",
+    }
+    return fieldMarcTags ? { ...base, marcTags: fieldMarcTags } : base
   }
 
   buildHoldingsDetails(holdings): BibDetail[] {
@@ -113,6 +149,7 @@ export default class BibDetails {
       })
       .filter((f) => f)
   }
+
   buildBottomDetails(): AnyBibDetail[] {
     const resourceFields = [
       { field: "contributorLiteral", label: "Additional authors" },
@@ -152,62 +189,64 @@ export default class BibDetails {
     return combinedFields.filter((f) => f)
   }
 
-  combineBibDetailsData = (
+  combineBibDetailsData(
     resourceEndpointDetails: AnyBibDetail[],
-    annotatedMarcDetails: AnyBibDetail[]
-  ) => {
-    // Flatten values
+    annotatedMarcDetails: AnyMarcDetail[]
+  ): AnyBibDetail[] {
     const normalizeValues = (val: any) => {
       if (!val) return []
-      return Array.isArray(val)
-        ? val
-            .flat()
-            .map((v) =>
-              typeof v === "string" ? v.trim() : v?.urlLabel?.trim()
-            )
-        : [typeof val === "string" ? val.trim() : val?.urlLabel?.trim()]
+      if (Array.isArray(val)) {
+        return val
+          .flat()
+          .map((v) =>
+            typeof v === "string"
+              ? v.trim()
+              : v?.content?.trim() || v?.urlLabel?.trim()
+          )
+      }
+      if (typeof val === "string") return [val.trim()]
+      if (val?.content) return [val.content.trim()]
+      return [val?.urlLabel?.trim()]
     }
 
-    // Label set
-    const resourceEndpointDetailsLabels = new Set(
-      resourceEndpointDetails.map((detail) => detail.label)
-    )
-
-    // Value set
+    const labelsSet = new Set(resourceEndpointDetails.map((d) => d.label))
     const resourceValuesSet = new Set<string>()
-    const allBibDetails = [
-      ...resourceEndpointDetails,
-      ...(this.topDetails || []),
-    ]
-    allBibDetails.forEach((detail) => {
-      normalizeValues(detail.value).forEach((v) => {
-        if (v) resourceValuesSet.add(v)
-      })
+    const allDetails = [...resourceEndpointDetails, ...(this.topDetails || [])]
+
+    allDetails.forEach((detail) => {
+      normalizeValues(detail.value).forEach(
+        (v) => v && resourceValuesSet.add(v)
+      )
     })
 
-    const filteredAnnotatedMarcDetails: AnyBibDetail[] = []
-    const keptByLabel: Record<string, string[]> = {}
+    const filteredMarc: AnyBibDetail[] = []
+    const keptByLabel = {}
 
     annotatedMarcDetails.forEach((detail) => {
-      if (resourceEndpointDetailsLabels.has(detail.label)) return
-
-      const marcValues = normalizeValues(detail.value)
-      const hasOverlap = marcValues.some((v) => resourceValuesSet.has(v))
-      if (!hasOverlap) {
-        filteredAnnotatedMarcDetails.push(detail)
-        keptByLabel[detail.label] = marcValues.filter(Boolean)
+      if (labelsSet.has(detail.label)) return
+      const detailValues = normalizeValues(detail.value)
+      const detailMarcTags = detail.marcTags
+      const overlap = detailValues.some((v) => resourceValuesSet.has(v))
+      if (!overlap) {
+        filteredMarc.push(detail)
+        // store both values and marc tags in one object per AM label
+        keptByLabel[detail.label] = {
+          values: detailValues.filter(Boolean),
+          marcTags: detailMarcTags,
+        }
       }
     })
 
     if (Object.keys(keptByLabel).length > 0) {
       logger.info(
-        `Bib details: Keeping annotated MARC fields on ${
-          this.bib["@id"]
-        }:\n${JSON.stringify(keptByLabel, null, 2)}`
+        `Bib details: Keeping annotated MARC fields on ${this.bib["@id"]}`,
+        {
+          keptMarcFields: keptByLabel,
+        }
       )
     }
 
-    return resourceEndpointDetails.concat(filteredAnnotatedMarcDetails)
+    return resourceEndpointDetails.concat(filteredMarc)
   }
 
   buildHoldingDetail(holding, fieldMapping: FieldMapping) {
@@ -238,15 +277,6 @@ export default class BibDetails {
     )
   }
 
-  buildDetail(label: string, value: string[]): BibDetail {
-    if (!value?.length) return null
-
-    return {
-      label: convertToSentenceCase(label),
-      value,
-    }
-  }
-
   buildSearchFilterUrl(fieldMapping: {
     label: string
     field: string
@@ -262,21 +292,6 @@ export default class BibDetails {
         }][0]=${encodeURI(v)}`
         return { url: internalUrl, urlLabel: v }
       }),
-    }
-  }
-
-  buildExternalLinkedDetail(
-    label: string,
-    values: BibDetailURL[]
-  ): LinkedBibDetail {
-    if (!values.length) return null
-    return {
-      link: "external",
-      value: values.map((v) => ({
-        url: v.url,
-        urlLabel: v.urlLabel ?? null,
-      })),
-      label: convertToSentenceCase(label),
     }
   }
 

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -272,7 +272,10 @@ export default class BibDetails {
     if (!values.length) return null
     return {
       link: "external",
-      value: values,
+      value: values.map((v) => ({
+        url: v.url,
+        urlLabel: v.urlLabel ?? null,
+      })),
       label: convertToSentenceCase(label),
     }
   }

--- a/src/types/bibDetailsTypes.ts
+++ b/src/types/bibDetailsTypes.ts
@@ -1,5 +1,7 @@
 export type AnyBibDetail = BibDetail | LinkedBibDetail | SubjectHeadingDetail
 
+export type AnyMarcDetail = MarcDetail | MarcLinkedDetail
+
 export interface SubjectHeadingDetail {
   value: BibDetailURL[][]
   label: string
@@ -12,6 +14,15 @@ export interface BibDetail {
   value: string[]
 }
 
+export interface MarcDetail {
+  // label is the formatted name of the field, such as "Author"
+  label: string
+  // value is the array of metadata, such as "["Author One", "Author Two"]"
+  value: string[]
+  // associated marc tags on this field– since this detail comes from the annotated MARC
+  marcTags: string[]
+}
+
 export interface LinkedBibDetail {
   value: BibDetailURL[]
   // label is the formatted name of the field, such as "Author"
@@ -19,6 +30,17 @@ export interface LinkedBibDetail {
   // indicates if a linked bib detail is internal, like a link to a creator
   // literal search, or external, like supplementary content
   link?: "internal" | "external"
+}
+
+export interface MarcLinkedDetail {
+  value: BibDetailURL[]
+  // label is the formatted name of the field, such as "Author"
+  label: string
+  // indicates if a linked bib detail is internal, like a link to a creator
+  // literal search, or external, like supplementary content
+  link?: "internal" | "external"
+  // associated marc tags on this field– since this detail comes from the annotated MARC
+  marcTags: string[]
 }
 
 export interface BibDetailURL {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4763](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763)

## This PR does the following:

- Updates the workings of the `BibDetails` model so that the MARC tags are passed through, and adds all MARC tags to the log of a given annotated MARC field that's being kept
   - Involves adding `MarcDetail` and `MarcLinkedDetail` types just to keep everything all lined up
- Reformats log, and now includes recent updates to the logger

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4763]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ