### PR TITLE
SCC-4876: Update redirect 404 page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Updated
+
+- Updated copy/layout of redirected 404s [SCC-4876] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-4876)
+
 ## [1.5.5] 2025-08-28
 
 ### Removed

--- a/__test__/pages/404/404.test.tsx
+++ b/__test__/pages/404/404.test.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import { render, screen, within } from "../../../src/utils/testUtils"
 import Custom404 from "../../../pages/404/index"
+import Redirect404 from "../../../pages/404/redirect"
+import { appConfig } from "../../../src/config/config"
 
 describe("404", () => {
   it("should display 404 text", () => {
@@ -15,5 +17,30 @@ describe("404", () => {
 
     const homeLink = within(container).getByText("new search")
     expect(homeLink).toHaveAttribute("href", "/research/research-catalog/")
+  })
+})
+
+describe("redirect 404", () => {
+  it("should display 404 text", () => {
+    render(<Redirect404 />)
+    const container = screen.getByRole("main")
+    const heading = within(container).getByRole("heading")
+    expect(heading).toHaveTextContent("We couldn't find that page")
+  })
+  it("should have links to circulating and legacy catalogs", () => {
+    render(<Redirect404 />)
+    const container = screen.getByRole("main")
+
+    const circulatingLink = within(container).getByText("Branch Catalog")
+    expect(circulatingLink).toHaveAttribute(
+      "href",
+      `${appConfig.urls.circulatingCatalog}`
+    )
+
+    const legacyLink = within(container).getByText("Legacy Catalog")
+    expect(legacyLink).toHaveAttribute(
+      "href",
+      `${appConfig.urls.legacyCatalog}`
+    )
   })
 })

--- a/pages/404/redirect.tsx
+++ b/pages/404/redirect.tsx
@@ -1,34 +1,59 @@
-import { Heading } from "@nypl/design-system-react-components"
-
-import { appConfig } from "../../src/config/config"
+import { Flex, Heading, Link, Text } from "@nypl/design-system-react-components"
 import { SITE_NAME } from "../../src/config/constants"
 import Layout from "../../src/components/Layout/Layout"
-import RCLink from "../../src/components/Links/RCLink/RCLink"
-import ExternalLink from "../../src/components/Links/ExternalLink/ExternalLink"
 import RCHead from "../../src/components/Head/RCHead"
+import { useContext } from "react"
+import { FeedbackContext } from "../../src/context/FeedbackContext"
+import Image from "next/image"
+import errorImage from "../../src/assets/errorImage.png"
+import ExternalLink from "../../src/components/Links/ExternalLink/ExternalLink"
+import { appConfig } from "../../src/config/config"
 
 export default function Redirect404() {
   const metadataTitle = `404 Redirect | ${SITE_NAME}`
+  const { openFeedbackFormWithError } = useContext(FeedbackContext)
   return (
     <>
       <RCHead metadataTitle={metadataTitle} />
       <Layout activePage="404">
-        <Heading level="h1">We&apos;re sorry...</Heading>
-        <p>You&apos;ve followed an out-of-date link to our research catalog.</p>
-        <p>
-          You may be able to find what you&apos;re looking for in the{" "}
-          <RCLink>Research Catalog</RCLink> or the{" "}
-          <ExternalLink href={appConfig.urls.circulatingCatalog}>
-            Circulating Catalog
-          </ExternalLink>
-          . for research materials.
-        </p>
-        <p>
-          You can also try the{" "}
-          <ExternalLink href={appConfig.urls.legacyCatalog}>
-            Legacy Catalog
-          </ExternalLink>
-        </p>
+        <Flex
+          flexDir="column"
+          marginTop="xxl"
+          marginBottom="xxl"
+          marginLeft="l"
+          marginRight="l"
+          alignItems="center"
+          justifyContent="center"
+          textAlign="center"
+        >
+          <Image
+            src={errorImage}
+            alt="Error image"
+            width={98}
+            height={68}
+            style={{ marginBottom: "48px" }}
+          />
+
+          <Heading level="h3">We couldn&apos;t find that page</Heading>
+          <Text noSpace>
+            You&apos;ve followed an out-of-date link to our research catalog.
+          </Text>
+          <Text noSpace>
+            Try our{" "}
+            <ExternalLink href={appConfig.urls.circulatingCatalog}>
+              Branch Catalog
+            </ExternalLink>{" "}
+            or{" "}
+            <ExternalLink href={appConfig.urls.legacyCatalog}>
+              Legacy Catalog
+            </ExternalLink>{" "}
+            for more materials, or{" "}
+            <Link onClick={openFeedbackFormWithError} id="feedback-link">
+              contact us
+            </Link>{" "}
+            for assistance.
+          </Text>
+        </Flex>
       </Layout>
     </>
   )


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4876](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4876)

## This PR does the following:

- Updates the `404/redirect` page to also use our new error layout, and correct copy

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Hit `/research/research-catalog/404/redirect` and confirm it looks like our other 404 page, only with links back to circulating and legacy

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4876]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ