### PR TITLE
SCC-4905: Remove item format display

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Playwright test for author search. [SCC-4853](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4853)
 - Added Playwright test for title search. [SCC-4852](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4852)
 
+### Removed
+
+- Removed item format from bib page item table, moving it to bib-level detail, and search result cards [SCC-4905](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4905)
+
 ## [1.5.5] 2025-08-28
 
 ### Removed

--- a/__test__/pages/bib/bibPage.test.tsx
+++ b/__test__/pages/bib/bibPage.test.tsx
@@ -110,7 +110,140 @@ describe("Bib Page no electronic resources", () => {
   })
 })
 
-describe("Bib Page Item Table", () => {
+describe("Bib Page Item Table general", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({ success: true }),
+      })
+    )
+
+    render(
+      <BibPage
+        discoveryBibResult={bibWithItems.resource}
+        annotatedMarc={bibWithItems.annotatedMarc}
+        isAuthenticated={false}
+      />
+    )
+  })
+
+  it("renders the filters container and populates the checkboxes", async () => {
+    expect(screen.getByTestId("item-filters-container")).toBeInTheDocument()
+    const checkboxGroups = screen.getAllByTestId("checkbox-group")
+    expect(checkboxGroups).toHaveLength(2)
+
+    expect(checkboxGroups[0].querySelectorAll("input")).toHaveLength(2)
+    expect(checkboxGroups[1].querySelectorAll("input")).toHaveLength(1)
+  })
+
+  it("updates the router when filter checkboxes are clicked", async () => {
+    const checkboxGroups = screen.getAllByTestId("checkbox-group")
+
+    await userEvent.click(checkboxGroups[0].querySelector("input"))
+    expect(mockRouter.asPath).toBe("/bib/b15080796?item_location=loc%3Amak32")
+
+    await userEvent.click(
+      screen.getByLabelText("remove 1 item selected from Location")
+    )
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+  })
+
+  it("updates the router when year filter is submitted", async () => {
+    const yearFilter = screen.queryByTestId("year-filter")
+    const yearField = screen.queryByPlaceholderText("YYYY")
+    await userEvent.type(yearField, "2005")
+
+    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
+
+    expect(mockRouter.asPath).toBe("/bib/b15080796?item_date=2005")
+  })
+
+  it("clears the year filter when the year tag is clicked", async () => {
+    const yearTag = screen.queryByText("Year > 2005").closest("button")
+    await userEvent.click(yearTag)
+
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+  })
+
+  it("shows an error and doesn't update router when an invalid year is submitted", async () => {
+    const yearFilter = screen.queryByTestId("year-filter")
+    const yearField = screen.queryByPlaceholderText("YYYY")
+
+    // blank year
+    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+    expect(
+      screen.queryByText("There was a problem. Please enter a valid year.")
+    ).toBeInTheDocument()
+
+    // non-numeric
+    await userEvent.type(yearField, "ABCD")
+    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+    expect(
+      screen.queryByText("There was a problem. Please enter a valid year.")
+    ).toBeInTheDocument()
+
+    // not of length 4
+    await userEvent.type(yearField, "1")
+    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+    expect(
+      screen.queryByText("There was a problem. Please enter a valid year.")
+    ).toBeInTheDocument()
+  })
+
+  it("clears a filter group when the MultiSelect clear button is clicked", async () => {
+    const checkboxGroups = screen.getAllByTestId("checkbox-group")
+
+    await userEvent.click(checkboxGroups[1].querySelector("input"))
+
+    expect(mockRouter.asPath).toBe("/bib/b15080796?item_status=status%3Aa")
+
+    await userEvent.click(
+      screen.getByLabelText("remove 1 item selected from Status")
+    )
+
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+  })
+
+  it("renders TagSet for applied filters and clears filters via tag click", async () => {
+    await userEvent.click(
+      screen.getAllByTestId("checkbox-group")[1].querySelector("input")
+    )
+
+    const tagButton = screen.queryByTestId("ds-tagSetFilter-tags")
+    expect(tagButton).toHaveTextContent("Status > Available")
+    expect(mockRouter.asPath).toBe("/bib/b15080796?item_status=status%3Aa")
+
+    await userEvent.click(tagButton)
+    expect(screen.queryByTestId("ds-tagSetFilter-tags")).not.toBeInTheDocument()
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+  })
+
+  it("TagSet should display a clear all button that clears all filters on click", async () => {
+    await userEvent.click(
+      screen.getAllByTestId("checkbox-group")[0].querySelector("input")
+    )
+    await userEvent.type(screen.queryByPlaceholderText("YYYY"), "2005")
+
+    await userEvent.click(
+      screen.queryByTestId("year-filter").querySelector("button[type='submit']")
+    )
+
+    expect(mockRouter.asPath).toBe(
+      "/bib/b15080796?item_location=loc%3Amak32&item_date=2005"
+    )
+    await userEvent.click(screen.getByText("Clear filters"))
+
+    expect(mockRouter.asPath).toBe("/bib/b15080796")
+    expect(screen.queryByTestId("ds-tagSetFilter-tags")).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText("YYYY")).toHaveValue("")
+  })
+})
+
+describe("Bib Page Item Table many items", () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockImplementationOnce(() =>
       Promise.resolve({
@@ -126,118 +259,6 @@ describe("Bib Page Item Table", () => {
         isAuthenticated={false}
       />
     )
-  })
-
-  it("renders the filters container and populates the checkboxes", async () => {
-    expect(screen.getByTestId("item-filters-container")).toBeInTheDocument()
-    const checkboxGroups = screen.getAllByTestId("checkbox-group")
-    expect(checkboxGroups).toHaveLength(2)
-
-    expect(checkboxGroups[0].querySelectorAll("input")).toHaveLength(1)
-    expect(checkboxGroups[1].querySelectorAll("input")).toHaveLength(1)
-  })
-
-  it("updates the router when filter checkboxes are clicked", async () => {
-    const checkboxGroups = screen.getAllByTestId("checkbox-group")
-
-    await userEvent.click(checkboxGroups[0].querySelector("input"))
-    expect(mockRouter.asPath).toBe("/bib/pb5579193?item_format=Text")
-
-    await userEvent.click(checkboxGroups[0].querySelector("input"))
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-  })
-
-  it("updates the router when year filter is submitted", async () => {
-    const yearFilter = screen.queryByTestId("year-filter")
-    const yearField = screen.queryByPlaceholderText("YYYY")
-    await userEvent.type(yearField, "2005")
-
-    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
-
-    expect(mockRouter.asPath).toBe("/bib/pb5579193?item_date=2005")
-  })
-
-  it("clears the year filter when the year tag is clicked", async () => {
-    const yearTag = screen.queryByText("Year > 2005").closest("button")
-    await userEvent.click(yearTag)
-
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-  })
-
-  it("shows an error and doesn't update router when an invalid year is submitted", async () => {
-    const yearFilter = screen.queryByTestId("year-filter")
-    const yearField = screen.queryByPlaceholderText("YYYY")
-
-    // blank year
-    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-    expect(
-      screen.queryByText("There was a problem. Please enter a valid year.")
-    ).toBeInTheDocument()
-
-    // non-numeric
-    await userEvent.type(yearField, "ABCD")
-    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-    expect(
-      screen.queryByText("There was a problem. Please enter a valid year.")
-    ).toBeInTheDocument()
-
-    // not of length 4
-    await userEvent.type(yearField, "1")
-    await userEvent.click(yearFilter.querySelector("button[type='submit']"))
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-    expect(
-      screen.queryByText("There was a problem. Please enter a valid year.")
-    ).toBeInTheDocument()
-  })
-
-  it("clears a filter group when the MultiSelect clear button is clicked", async () => {
-    const checkboxGroups = screen.getAllByTestId("checkbox-group")
-
-    await userEvent.click(checkboxGroups[0].querySelector("input"))
-
-    expect(mockRouter.asPath).toBe("/bib/pb5579193?item_status=status%3Aa")
-
-    await userEvent.click(
-      screen.getByLabelText("remove 1 item selected from Status")
-    )
-
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-  })
-
-  it("renders TagSet for applied filters and clears filters via tag click", async () => {
-    await userEvent.click(
-      screen.getAllByTestId("checkbox-group")[0].querySelector("input")
-    )
-
-    const tagButton = screen.queryByTestId("ds-tagSetFilter-tags")
-    expect(tagButton).toHaveTextContent("Text")
-    expect(mockRouter.asPath).toBe("/bib/pb5579193?item_status=status")
-
-    await userEvent.click(tagButton)
-    expect(screen.queryByTestId("ds-tagSetFilter-tags")).not.toBeInTheDocument()
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-  })
-
-  it("TagSet should display a clear all button that clears all filters on click", async () => {
-    await userEvent.click(
-      screen.getAllByTestId("checkbox-group")[0].querySelector("input")
-    )
-    await userEvent.type(screen.queryByPlaceholderText("YYYY"), "2005")
-
-    await userEvent.click(
-      screen.queryByTestId("year-filter").querySelector("button[type='submit']")
-    )
-
-    expect(mockRouter.asPath).toBe(
-      "/bib/pb5579193?item_status=status%3Aa&item_date=2005"
-    )
-    await userEvent.click(screen.getByText("Clear filters"))
-
-    expect(mockRouter.asPath).toBe("/bib/pb5579193")
-    expect(screen.queryByTestId("ds-tagSetFilter-tags")).not.toBeInTheDocument()
-    expect(screen.queryByPlaceholderText("YYYY")).toHaveValue("")
   })
 
   it("renders pagination when there are more than 20 items and updates the router on page button clicks", async () => {

--- a/__test__/pages/bib/bibPage.test.tsx
+++ b/__test__/pages/bib/bibPage.test.tsx
@@ -196,14 +196,6 @@ describe("Bib Page Item Table", () => {
     const checkboxGroups = screen.getAllByTestId("checkbox-group")
 
     await userEvent.click(checkboxGroups[0].querySelector("input"))
-    await userEvent.click(checkboxGroups[1].querySelector("input"))
-    expect(mockRouter.asPath).toBe(
-      "/bib/pb5579193?item_format=Text&item_status=status%3Aa"
-    )
-
-    await userEvent.click(
-      screen.getByLabelText("remove 1 item selected from Format")
-    )
 
     expect(mockRouter.asPath).toBe("/bib/pb5579193?item_status=status%3Aa")
 
@@ -221,7 +213,7 @@ describe("Bib Page Item Table", () => {
 
     const tagButton = screen.queryByTestId("ds-tagSetFilter-tags")
     expect(tagButton).toHaveTextContent("Text")
-    expect(mockRouter.asPath).toBe("/bib/pb5579193?item_format=Text")
+    expect(mockRouter.asPath).toBe("/bib/pb5579193?item_status=status")
 
     await userEvent.click(tagButton)
     expect(screen.queryByTestId("ds-tagSetFilter-tags")).not.toBeInTheDocument()
@@ -232,9 +224,6 @@ describe("Bib Page Item Table", () => {
     await userEvent.click(
       screen.getAllByTestId("checkbox-group")[0].querySelector("input")
     )
-    await userEvent.click(
-      screen.getAllByTestId("checkbox-group")[1].querySelector("input")
-    )
     await userEvent.type(screen.queryByPlaceholderText("YYYY"), "2005")
 
     await userEvent.click(
@@ -242,7 +231,7 @@ describe("Bib Page Item Table", () => {
     )
 
     expect(mockRouter.asPath).toBe(
-      "/bib/pb5579193?item_format=Text&item_status=status%3Aa&item_date=2005"
+      "/bib/pb5579193?item_status=status%3Aa&item_date=2005"
     )
     await userEvent.click(screen.getByText("Clear filters"))
 

--- a/src/components/BibPage/BibDetail.test.tsx
+++ b/src/components/BibPage/BibDetail.test.tsx
@@ -70,7 +70,7 @@ describe("BibDetail component", () => {
     })
   })
   describe("text only details", () => {
-    it("single value", () => {
+    it("single value: title", () => {
       render(<BibDetails details={noParallelsBibModel.topDetails} />, {
         wrapper: MemoryRouterProvider,
       })
@@ -78,6 +78,15 @@ describe("BibDetail component", () => {
       const title = screen.getByText("Spaghetti! / Gérard de Cortanze.")
       expect(titleLabel).toBeInTheDocument()
       expect(title).toBeInTheDocument()
+    })
+    it("single value: format", () => {
+      render(<BibDetails details={noParallelsBibModel.topDetails} />, {
+        wrapper: MemoryRouterProvider,
+      })
+      const formatLabel = screen.getByText("Format")
+      const format = screen.getByText("Text")
+      expect(formatLabel).toBeInTheDocument()
+      expect(format).toBeInTheDocument()
     })
     it("renders multiple values, primaries and orphaned parallels", () => {
       render(<BibDetails details={parallelsBibModel.topDetails} />)

--- a/src/components/BibPage/FindingAid.tsx
+++ b/src/components/BibPage/FindingAid.tsx
@@ -25,6 +25,7 @@ const FindingAid = ({
       sx={{
         borderBottom: hasElectronicResources ? "0px" : "1px ui.gray solid",
       }}
+      marginBottom="s"
     >
       <CardHeading level="four" size="body1" mb="xs">
         Collection information

--- a/src/components/ItemFilters/ItemFilters.test.tsx
+++ b/src/components/ItemFilters/ItemFilters.test.tsx
@@ -20,7 +20,6 @@ describe("ItemFilters", () => {
           handleFiltersChange={filtersChangeMock}
           appliedFilters={{
             location: ["Offsite"],
-            format: ["Text"],
             status: ["Available"],
             year: [],
           }}
@@ -36,7 +35,6 @@ describe("ItemFilters", () => {
 
     it("renders filters container with one MultiSelect per populated checkbox group", async () => {
       expect(screen.getByTestId("item-filters-container")).toBeInTheDocument()
-      expect(screen.getByTestId("format-multi-select")).toBeInTheDocument()
       expect(screen.getByTestId("status-multi-select")).toBeInTheDocument()
     })
 
@@ -68,7 +66,6 @@ describe("ItemFilters", () => {
       )
       expect(filtersChangeMock).toHaveBeenCalledWith(
         {
-          item_format: "Text",
           item_status: "Available",
         },
         false
@@ -85,7 +82,6 @@ describe("ItemFilters", () => {
           handleFiltersChange={filtersChangeMock}
           appliedFilters={{
             location: ["Offsite"],
-            format: ["Text"],
             status: ["Available"],
             year: [],
           }}

--- a/src/components/ItemFilters/ItemFilters.tsx
+++ b/src/components/ItemFilters/ItemFilters.tsx
@@ -47,11 +47,15 @@ const ItemFilters = ({
   const [invalidYear, setInvalidYear] = useState(false)
 
   const filterData = useRef<ItemFilterData[]>(
-    itemAggregations.map((aggregation: Aggregation) => {
-      if (aggregation.field === "location")
-        return new LocationFilterData(aggregation)
-      else return new ItemFilterData(aggregation)
-    })
+    itemAggregations
+      .filter((aggregation: Aggregation) => aggregation.field !== "format")
+      .map((aggregation: Aggregation) => {
+        if (aggregation.field === "location") {
+          return new LocationFilterData(aggregation)
+        } else {
+          return new ItemFilterData(aggregation)
+        }
+      })
   ).current
 
   const appliedFiltersTagSetData = buildAppliedFiltersTagSetData(
@@ -184,6 +188,7 @@ const ItemFilters = ({
           onClear={() => handleClearFilterGroup(checkboxGroup.id)}
           width={multiSelectWidth}
           closeOnBlur
+          mt={{ base: "0", md: "6px" }}
         />
       ) : null
     })

--- a/src/components/ItemFilters/ItemFilters.tsx
+++ b/src/components/ItemFilters/ItemFilters.tsx
@@ -36,7 +36,7 @@ interface ItemFilterContainerProps {
 const ItemFilters = ({
   itemAggregations,
   handleFiltersChange,
-  appliedFilters = { location: [], format: [], status: [], year: [] },
+  appliedFilters = { location: [], status: [], year: [] },
   filtersAreApplied = false,
   showDateFilter = false,
 }: ItemFilterContainerProps) => {

--- a/src/components/ItemTable/ItemTable.tsx
+++ b/src/components/ItemTable/ItemTable.tsx
@@ -28,11 +28,9 @@ const ItemTable = ({ itemTableData }: ItemTableProps) => {
             ? [
                 { width: 272, minWidth: 85 },
                 { width: 272, minWidth: 85 },
-                { width: 272, minWidth: 85 },
               ]
             : [
                 { width: "auto", minWidth: 250 },
-                { width: "14%", minWidth: 100 },
                 { width: "14%", minWidth: 100 },
                 { width: "14%", minWidth: 100 },
                 { width: "14%", minWidth: 100 },

--- a/src/components/ItemTable/ItemTable.tsx
+++ b/src/components/ItemTable/ItemTable.tsx
@@ -1,7 +1,5 @@
 import { Box, Table } from "@nypl/design-system-react-components"
-
 import type ItemTableData from "../../models/ItemTableData"
-import StatusLinks from "./StatusLinks"
 import styles from "../../../styles/components/ItemTable.module.scss"
 
 interface ItemTableProps {
@@ -9,18 +7,16 @@ interface ItemTableProps {
 }
 
 /**
- * The ItemTable displays item details, the RequestButtons
+ * The ItemTable displays item details and the request buttons
  */
 const ItemTable = ({ itemTableData }: ItemTableProps) => {
-  const { tableHeadings, tableData, items, inSearchResult } = itemTableData
+  const { tableHeadings, tableData, inSearchResult } = itemTableData
 
   return (
     // Display as grid to prevent bug where the outer container stretches to the Table's width on mobile
     <Box display="grid">
       <Table
-        className={`${styles.itemTable}${
-          inSearchResult ? " " + styles.inSearchResult : ""
-        } itemTable`}
+        className={`${styles.itemTable} itemTable`}
         columnHeaders={tableHeadings}
         fontSize="body2"
         columnStyles={
@@ -31,23 +27,18 @@ const ItemTable = ({ itemTableData }: ItemTableProps) => {
               ]
             : [
                 { width: "auto", minWidth: 250 },
-                { width: "14%", minWidth: 100 },
-                { width: "14%", minWidth: 100 },
-                { width: "14%", minWidth: 100 },
-                { width: "14%", minWidth: 100 },
+                { width: "17%", minWidth: 100 },
+                { width: "17%", minWidth: 100 },
+                { width: "17%", minWidth: 100 },
+                { width: "17%", minWidth: 100 },
               ]
         }
         tableData={tableData}
         isScrollable
-        showRowDividers={!inSearchResult}
-        my={{ base: inSearchResult ? "s" : 0, md: "s" }}
-        data-testid={
-          !inSearchResult
-            ? "bib-details-item-table"
-            : "search-results-item-table"
-        }
+        showRowDividers
+        my={{ base: 0, md: "s" }}
+        data-testid="bib-details-item-table"
       />
-      {inSearchResult && <StatusLinks item={items[0]} />}
     </Box>
   )
 }

--- a/src/components/SearchResults/ElectronicResourcesLink.tsx
+++ b/src/components/SearchResults/ElectronicResourcesLink.tsx
@@ -17,7 +17,7 @@ const ElectronicResourcesLink = ({
   electronicResources,
 }: ElectronicResourcesLinkProps) => {
   return (
-    <Card isBordered data-testid="electronic-resources-link">
+    <Card isBordered data-testid="electronic-resources-link" marginBottom="s">
       <CardHeading level="four" size="body1" mb="xs">
         Available online
       </CardHeading>

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -14,6 +14,7 @@ import ItemTable from "../ItemTable/ItemTable"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import { PATHS } from "../../config/constants"
 import FindingAid from "../BibPage/FindingAid"
+import SearchResultItems from "./SearchResultItems"
 
 interface SearchResultProps {
   bib: SearchResultsBib
@@ -68,11 +69,11 @@ const SearchResult = ({ bib }: SearchResultProps) => {
             electronicResources={bib.electronicResources}
           />
         ) : null}
-        <SimpleGrid columns={1} mt="l" gap="grid.l">
+        <SimpleGrid columns={1} gap="grid.m">
           {bib.itemTables && (
             <>
               {bib.itemTables.map((itemTableData) => (
-                <ItemTable
+                <SearchResultItems
                   itemTableData={itemTableData}
                   key={`search-results-item-${itemTableData.items[0].id}`}
                 />

--- a/src/components/SearchResults/SearchResultItems.tsx
+++ b/src/components/SearchResults/SearchResultItems.tsx
@@ -1,0 +1,55 @@
+import { Box, Text } from "@nypl/design-system-react-components"
+import type ItemTableData from "../../models/ItemTableData"
+import StatusLinks from "../ItemTable/StatusLinks"
+
+interface ItemTableProps {
+  itemTableData: ItemTableData
+}
+
+/**
+ * Displays item format and
+ */
+const SearchResultItems = ({ itemTableData }: ItemTableProps) => {
+  const { tableHeadings, tableData, items } = itemTableData
+  return (
+    <Box display="grid">
+      <table
+        style={{
+          marginBottom: "20px",
+          width: "100%",
+          borderCollapse: "separate",
+          borderSpacing: "0 4px",
+        }}
+      >
+        <tbody>
+          {tableHeadings.map((heading, index) => (
+            <tr key={heading}>
+              <td
+                style={{
+                  width: "181px",
+                  minWidth: "85px",
+                }}
+              >
+                <Text
+                  textTransform="uppercase"
+                  fontWeight="bold"
+                  fontSize="small"
+                  mt="xxs"
+                >
+                  {heading}
+                </Text>
+              </td>
+              <td>
+                <Text fontSize="small">{tableData[0][index]}</Text>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <StatusLinks item={items[0]} />
+    </Box>
+  )
+}
+
+export default SearchResultItems

--- a/src/components/SearchResults/SearchResultItems.tsx
+++ b/src/components/SearchResults/SearchResultItems.tsx
@@ -2,14 +2,14 @@ import { Box, Text } from "@nypl/design-system-react-components"
 import type ItemTableData from "../../models/ItemTableData"
 import StatusLinks from "../ItemTable/StatusLinks"
 
-interface ItemTableProps {
+interface SearchResultItemsProps {
   itemTableData: ItemTableData
 }
 
 /**
- * Displays item format and
+ * Displays item information for search result card.
  */
-const SearchResultItems = ({ itemTableData }: ItemTableProps) => {
+const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
   const { tableHeadings, tableData, items } = itemTableData
   return (
     <Box display="grid">
@@ -27,7 +27,7 @@ const SearchResultItems = ({ itemTableData }: ItemTableProps) => {
               <td
                 style={{
                   width: "181px",
-                  minWidth: "85px",
+                  minWidth: "60px",
                 }}
               >
                 <Text

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -33,12 +33,7 @@ export const DISCOVERY_API_SEARCH_ROUTE = "/discovery/resources"
 // Query params
 export const SOURCE_PARAM = "?source=catalog"
 
-export const ITEM_FILTER_PARAMS = [
-  "item_location",
-  "item_format",
-  "item_status",
-  "item_date",
-]
+export const ITEM_FILTER_PARAMS = ["item_location", "item_status", "item_date"]
 
 // String used to namespace Research Catalog events in Adobe Analytics
 export const ADOBE_ANALYTICS_SITE_SECTION = "Research Catalog"

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -132,6 +132,7 @@ export default class BibDetails {
     return [
       { field: "titleDisplay", label: "Title" },
       { field: "publicationStatement", label: "Published by" },
+      { field: "format", label: "Format" },
       // external link
       { field: "supplementaryContent", label: "Supplementary content" },
       // internal link
@@ -267,8 +268,8 @@ export default class BibDetails {
   buildStandardDetail(fieldMapping: FieldMapping) {
     let bibFieldValue = this[fieldMapping.field] || this.bib[fieldMapping.field]
     if (!bibFieldValue) return
-    // "language" is the only resource field with JSON-LD format
-    if (fieldMapping.field === "language") {
+    // "language" and "format" use JSON-LD format
+    if (fieldMapping.field === "language" || fieldMapping.field === "format") {
       bibFieldValue = [bibFieldValue[0]?.prefLabel]
     }
     return this.buildDetail(

--- a/src/models/ItemTableData.ts
+++ b/src/models/ItemTableData.ts
@@ -34,7 +34,6 @@ export default class ItemTableData {
     return [
       ...(this.showStatusColumn() ? ["Status"] : []),
       ...(this.showVolumeColumn() ? [this.volumeColumnHeading()] : []),
-      "Format",
       ...(this.showAccessColumn() ? ["Access"] : []),
       "Call number",
       "Item location",
@@ -48,7 +47,6 @@ export default class ItemTableData {
         ...(this.showVolumeColumn()
           ? [ItemTableCell({ children: item.volume })]
           : []),
-        ItemTableCell({ children: item.format }),
         ...(this.showAccessColumn()
           ? [ItemTableCell({ children: item.accessMessage })]
           : []),

--- a/src/types/filterTypes.ts
+++ b/src/types/filterTypes.ts
@@ -12,7 +12,6 @@ export type FilterCheckbox = { id: string; name: string }
 
 export type AppliedItemFilters = {
   location: string[]
-  format: string[]
   status: string[]
   year: string[]
 }
@@ -26,7 +25,6 @@ export interface AggregationOption {
 /* eslint-disable @typescript-eslint/naming-convention */
 export type ItemFilterQueryParams = {
   item_location?: string
-  item_format?: string
   item_status?: string
   item_date?: string
 }

--- a/src/utils/itemFilterUtils.ts
+++ b/src/utils/itemFilterUtils.ts
@@ -22,7 +22,7 @@ export const areFiltersApplied = (appliedFilters: AppliedItemFilters) =>
   Object.entries(appliedFilters).some(([, value]) => value.length > 0)
 
 export const buildItemFilterQuery = (
-  { location, format, status, year }: AppliedItemFilters,
+  { location, status, year }: AppliedItemFilters,
   recapLocations: string
 ) => {
   const locs = location.map((loc) => {
@@ -32,7 +32,6 @@ export const buildItemFilterQuery = (
 
   return {
     ...(locs.length && { item_location: locs.join(",") }),
-    ...(format.length && { item_format: format.join(",") }),
     ...(status.length && { item_status: status.join(",") }),
     ...(year.length && { item_date: year.join(",") }),
   }
@@ -88,7 +87,6 @@ export const removeValueFromFilters = (
 /* eslint-disable @typescript-eslint/naming-convention */
 export const parseItemFilterQueryParams = ({
   item_status,
-  item_format,
   item_location,
   item_date,
 }: ItemFilterQueryParams) => {
@@ -96,7 +94,6 @@ export const parseItemFilterQueryParams = ({
     location: item_location
       ? combineRecapLocations(item_location.split(","))
       : [],
-    format: item_format?.split(",") || [],
     status: item_status?.split(",") || [],
     year: item_date?.split(",") || [],
   }

--- a/src/utils/utilsTests/bibUtils.test.ts
+++ b/src/utils/utilsTests/bibUtils.test.ts
@@ -46,7 +46,6 @@ describe("bibUtils", () => {
   describe("itemFiltersActive", () => {
     it("returns true when any of the filter params are populated in the bib query string", () => {
       expect(itemFiltersActive({ item_location: "location" })).toBe(true)
-      expect(itemFiltersActive({ item_format: "format" })).toBe(true)
       expect(itemFiltersActive({ item_status: "status" })).toBe(true)
       expect(itemFiltersActive({ item_date: "date" })).toBe(true)
     })
@@ -61,7 +60,6 @@ describe("bibUtils", () => {
         itemFiltersActive({
           item_location: "",
           item_status: "",
-          item_format: "",
           item_date: "",
         })
       ).toBe(false)

--- a/src/utils/utilsTests/itemFilterUtils.test.tsx
+++ b/src/utils/utilsTests/itemFilterUtils.test.tsx
@@ -43,11 +43,9 @@ describe("Item Filter Utils", () => {
     it("parses locations including recap locations", () => {
       const query = {
         item_location: "loc:rc2ma,loc:mal",
-        item_format: "Text",
         item_status: "status:a,status:na",
       }
       expect(parseItemFilterQueryParams(query)).toEqual({
-        format: ["Text"],
         location: ["loc:mal", "Offsite"],
         status: ["status:a", "status:na"],
         year: [],
@@ -56,11 +54,9 @@ describe("Item Filter Utils", () => {
     it("parses locations including multiple recap locations", () => {
       const query = {
         item_location: "loc:rc2ma,loc:rc3ma,loc:rc4ma,loc:abc",
-        item_format: "Text",
         item_status: "status:a,status:na",
       }
       expect(parseItemFilterQueryParams(query)).toEqual({
-        format: ["Text"],
         location: ["loc:abc", "Offsite"],
         status: ["status:a", "status:na"],
         year: [],
@@ -70,7 +66,6 @@ describe("Item Filter Utils", () => {
   describe("buildItemFilterQuery", () => {
     it("maps offsite back to the recap locations", () => {
       const query = {
-        format: ["Text"],
         location: ["loc:abc", "Offsite"],
         status: ["status:a", "status:na"],
         year: [],
@@ -78,13 +73,11 @@ describe("Item Filter Utils", () => {
       const recapLocations = "loc:rc2ma,loc:rc3ma,loc:rc4ma"
       expect(buildItemFilterQuery(query, recapLocations)).toStrictEqual({
         item_location: "loc:abc,loc:rc2ma,loc:rc3ma,loc:rc4ma",
-        item_format: "Text",
         item_status: "status:a,status:na",
       })
     })
     it("can handle only one param", () => {
       const query = {
-        format: [],
         location: ["loc:abc", "Offsite"],
         status: [],
         year: [],
@@ -100,7 +93,6 @@ describe("Item Filter Utils", () => {
     const query = parseItemFilterQueryParams({
       item_location: "loc:rc2ma,loc:rcma2",
       item_status: "status:a",
-      item_format: "Text",
       item_date: "2005",
     })
     const emptyQuery = parseItemFilterQueryParams({})
@@ -118,7 +110,6 @@ describe("Item Filter Utils", () => {
           id: "Offsite",
           label: "Location > Offsite",
         },
-        { id: "Text", label: "Format > Text" },
         {
           id: "status:a",
           label: "Status > Available",

--- a/styles/components/ItemTable.module.scss
+++ b/styles/components/ItemTable.module.scss
@@ -22,20 +22,4 @@
       vertical-align: top;
     }
   }
-
-  &.inSearchResult {
-    margin-top: 0;
-    width: fit-content;
-
-    tr {
-      border: 0 !important;
-
-      th,
-      td {
-        padding-top: 0;
-        padding-left: 0;
-        box-sizing: border-box;
-      }
-    }
-  }
 }


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4905](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4905)

## This PR does the following:

- Removes format column from item table on bib page, moves it to bib-level top details
- Removes format from search result card and replaces the item table component with a custom table (departs from DS since rows were required)
- Removes item format from tests and types relating to bib page

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-4905]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ