### PR TITLE
SCC-4836: Remove bib `dateEndYear` from search result

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed search result card children width [SCC-4939](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4939)
 
+### Removed
+
+- Removed `dateEndYear` from display on search result [SCC-4836](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4936)
+
 ## [1.5.6] 2025-09-23
 
 ### Updated

--- a/src/models/SearchResultsBib.ts
+++ b/src/models/SearchResultsBib.ts
@@ -50,16 +50,10 @@ export default class SearchResultsBib extends Bib {
   }
 
   getYearFromResult(result: DiscoveryBibResult) {
-    const { dateStartYear, dateEndYear } = result
-
+    const { dateStartYear } = result
     const displayStartYear: string =
       dateStartYear === 999 ? "unknown" : dateStartYear?.toString()
-    const displayEndYear: string =
-      dateEndYear === 9999 ? "present" : dateEndYear?.toString()
-
-    if (dateStartYear && dateEndYear) {
-      return `${displayStartYear}-${displayEndYear}`
-    } else if (dateStartYear) {
+    if (dateStartYear) {
       return displayStartYear
     }
     return null

--- a/src/models/modelTests/SearchResultsBib.test.ts
+++ b/src/models/modelTests/SearchResultsBib.test.ts
@@ -41,8 +41,8 @@ describe("SearchResultsBib model", () => {
       expect(bibWithNoTitle.title).toBe("[Untitled]")
     })
 
-    it("initializes the yearPublished based on dateStartYear and dateEndYear", () => {
-      expect(searchResultsBib.yearPublished).toBe("1999-present")
+    it("initializes the yearPublished based on dateStartYear", () => {
+      expect(searchResultsBib.yearPublished).toBe("1999")
     })
 
     it("initializes the publicationStatement based on bib result's publicationStatement if present", () => {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-4836](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4836)

## This PR does the following:

- Removes the second date (`dateEndYear`, on the bib result) from displaying on the search result card

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
