### PR TITLE
SCC 4855/playwright call number search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+## Added
+
+- Added Playwright test for call number search. [SCC-4855](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4855)
+
 ### Updated
 
 - Fixed search result card children width [SCC-4939](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4939)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 4,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -38,9 +38,6 @@ export class SearchPage {
     this.searchResultsTitle = page
       .locator("#search-results-list")
       .getByRole("link", { name: new RegExp(this.searchterm) })
-    this.searchResultsCallNumber = page.locator(
-      '#search-results-list table td:has-text("CALL NUMBER") td p span'
-    )
   }
 
   async searchFor(searchterm: string, searchType = "Keyword") {

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -9,6 +9,7 @@ export class SearchPage {
   readonly searchterm: string
   readonly search_dropdown: Locator
   readonly searchType: string
+  readonly searchResults: Locator
   readonly searchResultsTitle: Locator
   readonly searchResultsCallNumber: Locator
 
@@ -33,7 +34,8 @@ export class SearchPage {
         "i"
       ),
     })
-    this.searchResult = page
+    this.searchResults = page.locator("#search-results-list h3 a")
+    this.searchResultsTitle = page
       .locator("#search-results-list")
       .getByRole("link", { name: new RegExp(this.searchterm) })
     this.searchResultsCallNumber = page.locator(

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -10,6 +10,7 @@ export class SearchPage {
   readonly search_dropdown: Locator
   readonly searchType: string
   readonly searchResultsTitle: Locator
+  readonly searchResultsCallNumber: Locator
 
   constructor(page: Page, searchterm: string, searchType = "Keyword") {
     this.page = page
@@ -28,12 +29,16 @@ export class SearchPage {
       .getByRole("link", { name: new RegExp(this.searchterm) })
     this.resultsHeading = this.page.getByRole("heading", {
       name: new RegExp(
-        `^Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for ${this.searchType}(s)? "${this.searchterm}"$`
+        `^Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for ${this.searchType}s? "${this.searchterm}"$`,
+        "i"
       ),
     })
     this.searchResult = page
       .locator("#search-results-list")
       .getByRole("link", { name: new RegExp(this.searchterm) })
+    this.searchResultsCallNumber = page.locator(
+      '#search-results-list table td:has-text("CALL NUMBER") td p span'
+    )
   }
 
   async searchFor(searchterm: string, searchType = "Keyword") {

--- a/playwright/tests/Search/search_call_number.spec.ts
+++ b/playwright/tests/Search/search_call_number.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test"
+import { SearchPage } from "../../pages/search_page"
+
+let searchPage: SearchPage
+const searchterm = "JFD 93-1962"
+
+test.beforeEach(async ({ page }) => {
+  searchPage = new SearchPage(page, searchterm, "Call number")
+  await page.goto("")
+})
+
+test.describe("Call Number Search", () => {
+  test("Do a call number search and assert that at the item returned contains the supplied call number", async ({
+    page,
+  }) => {
+    await searchPage.searchFor(searchterm, "Call number")
+    await expect(searchPage.resultsHeading).toBeVisible()
+    await expect(
+      searchPage.page.getByTestId("card-content").getByText("JFD 93-1962")
+    ).toBeVisible()
+  })
+})

--- a/playwright/tests/Search/search_journal_title.spec.ts
+++ b/playwright/tests/Search/search_journal_title.spec.ts
@@ -13,6 +13,6 @@ test.describe("Journal Title Search", () => {
   test("Do a journal title search and assert that at least 5 returned titles contain the supplied journal title", async () => {
     await searchPage.searchFor(searchterm, "Journal title")
     await expect(searchPage.resultsHeading).toBeVisible()
-    await expect(await searchPage.searchResult.count()).toBeGreaterThan(5)
+    await expect(await searchPage.searchResultsTitle.count()).toBeGreaterThan(5)
   })
 })

--- a/playwright/tests/Search/search_keyword.spec.ts
+++ b/playwright/tests/Search/search_keyword.spec.ts
@@ -13,6 +13,8 @@ test.describe("Keyword Search", () => {
   test("Do a keyword search and assert that at least 10 returned titles contain the supplied keyword", async () => {
     await searchPage.searchFor(searchterm, "Keyword")
     await expect(searchPage.resultsHeading).toBeVisible()
-    await expect(await searchPage.searchResult.count()).toBeGreaterThan(10)
+    await expect(await searchPage.searchResultsTitle.count()).toBeGreaterThan(
+      10
+    )
   })
 })

--- a/playwright/tests/Search/search_title.spec.ts
+++ b/playwright/tests/Search/search_title.spec.ts
@@ -17,6 +17,8 @@ test.describe("Title Search", () => {
     // sleep for 5 seconds to allow results to load
     // await page.waitForTimeout(5000)
     await expect(searchPage.resultsHeading).toBeVisible()
-    await expect(await searchPage.searchResult.count()).toBeGreaterThan(10)
+    await expect(await searchPage.searchResultsTitle.count()).toBeGreaterThan(
+      10
+    )
   })
 })

--- a/playwright/tests/Search/search_title.spec.ts
+++ b/playwright/tests/Search/search_title.spec.ts
@@ -10,8 +10,12 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe("Title Search", () => {
-  test("Do a title search and assert that at least 10 returned titles contain the supplied keyword", async () => {
+  test("Do a title search and assert that at least 10 returned titles contain the supplied keyword", async ({
+    page,
+  }) => {
     await searchPage.searchFor(searchterm, "Title")
+    // sleep for 5 seconds to allow results to load
+    // await page.waitForTimeout(5000)
     await expect(searchPage.resultsHeading).toBeVisible()
     await expect(await searchPage.searchResult.count()).toBeGreaterThan(10)
   })

--- a/playwright/tests/Search/search_unique_identifier.spec.ts
+++ b/playwright/tests/Search/search_unique_identifier.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test"
+import { SearchPage } from "../../pages/search_page"
+
+let searchPage: SearchPage
+const searchterm = "82048999"
+
+test.beforeEach(async ({ page }) => {
+  searchPage = new SearchPage(page, searchterm, "Unique identifier")
+  await page.goto("")
+})
+
+test.describe("Unique Identifier Search", () => {
+  test("Do a unique identifier search and assert that the item returned contains the supplied unique identifier", async ({
+    page,
+  }) => {
+    await searchPage.searchFor(searchterm, "Unique identifier")
+    await expect(searchPage.resultsHeading).toBeVisible()
+    // click on the title of the first search result
+    await searchPage.searchResults.first().click()
+    // assert that the unique identifier is present on the item detail page
+    await expect(page.getByText(new RegExp(searchterm))).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Ticket:

- JIRA ticket [4855](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4855)

## This PR does the following:

- Adds Playwright test for call number search. 

## How has this been tested?

all tests pass locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
