### PR TITLE
added playwright subject search test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- Added Playwright test for subject search. [SCC-4857](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4857)
 - Added Playwright test for unique number search. [SCC-4856](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4856)
 - Added Playwright test for call number search. [SCC-4855](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4855)
 

--- a/playwright/tests/Search/search_subject.spec.ts
+++ b/playwright/tests/Search/search_subject.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test"
+import { SearchPage } from "../../pages/search_page"
+
+let searchPage: SearchPage
+const searchterm = "Ornithology"
+
+test.beforeEach(async ({ page }) => {
+  searchPage = new SearchPage(page, searchterm, "subject")
+  await page.goto("")
+})
+
+test.describe("Subject Search", () => {
+  test("Do a subject search and assert that the first 5 returned titles contain the supplied subject", async ({
+    page,
+  }) => {
+    await searchPage.searchFor(searchterm, "Subject")
+    await expect(searchPage.searchResultsHeading).toBeVisible()
+
+    // Collect all title link URLs (limit to 5)
+    const titleLinks = await page.locator("#search-results-list h3 a").all()
+    const urls = []
+    for (const link of titleLinks.slice(0, 5)) {
+      urls.push(await link.getAttribute("href"))
+    }
+
+    expect(urls.length).toBe(5)
+
+    // Visit each URL and assert searchterm (in this case, subject) appears on the page as a link
+    for (const url of urls) {
+      await page.goto(url)
+      await expect(
+        page.getByRole("link", { name: new RegExp(`^${searchterm}$`) }).first()
+      ).toBeVisible()
+    }
+  })
+})


### PR DESCRIPTION
## Ticket:

- JIRA ticket [4857](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4857)

## This PR does the following:

-- Adds Playwright test for subject search.

## How has this been tested?

-- all tests pass locally
## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
