### PR TITLE
Added test for RC sends circ bib requests to Vega

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Playwright test for 'RC sends circ bib requests to Vega' [SCC-5292](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5292)
+- Added Playwright test for redirecting circ bib requests to Vega [SCC-5292](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5292)
 - Added author/contributor mode to browse landing [SCC-4966](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4966)
 - Added author/contributor models and table [SCC-4969](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4969)
 - Added author/contributor index and search results pages, with role handling [SCC-4967](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4967)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Playwright test for 'RC sends circ bib requests to Vega' [SCC-5292](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5292)
 - Added author/contributor mode to browse landing [SCC-4966](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4966)
 - Added author/contributor models and table [SCC-4969](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4969)
 - Added author/contributor index and search results pages, with role handling [SCC-4967](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4967)

--- a/playwright/tests/redirects.spec.ts
+++ b/playwright/tests/redirects.spec.ts
@@ -55,14 +55,17 @@ test("SHEP link with unknown uuid/path redirects to browse", async ({
   await expect(page).toHaveURL(`${BASE_URL}/browse`)
 })
 
-test("RC sends circ bib requests to Vega", async ({ request }) => {
-  const response = await request.get(`${BASE_URL}/bib/b17782484`, {
-    maxRedirects: 0,
+test.describe("circ bib redirects", () => {
+  test("RC sends circ bib requests to Vega", async ({ request }) => {
+    const response = await request.get(`${BASE_URL}/bib/b17782484`, {
+      maxRedirects: 0,
+    })
+
+    expect(response.status()).toEqual(307)
+
+    const location = response.headers()["location"]
+    expect(location).toBe(
+      "https://borrow.nypl.org/search/card?recordId=17782484"
+    )
   })
-
-  expect(response.status()).toBeGreaterThanOrEqual(300)
-  expect(response.status()).toBeLessThan(400)
-
-  const location = response.headers()["location"]
-  expect(location).toBe("https://borrow.nypl.org/search/card?recordId=17782484")
 })

--- a/playwright/tests/redirects.spec.ts
+++ b/playwright/tests/redirects.spec.ts
@@ -4,68 +4,74 @@ const BASE_URL =
   process.env.BASE_URL || "http://local.nypl.org:8080/research/research-catalog"
 const BASE_HOST = BASE_URL.replace("/research/research-catalog", "")
 
-test("legacy url redirects to base path", async ({ page }) => {
-  await page.goto(`${BASE_HOST}/research/collections/shared-collection-catalog`)
-  await expect(page).toHaveURL(BASE_URL)
-})
-
-test("legacy url plus path redirects to base path", async ({ page }) => {
-  await page.goto(
-    `${BASE_HOST}/research/collections/shared-collection-catalog/test`
-  )
-  await expect(page).toHaveURL(`${BASE_URL}/test`)
-})
-
-test("exact mapped SHEP link redirects to browse", async ({ page }) => {
-  await page.goto(
-    `${BASE_URL}/subject_headings/c47dda10-a6a1-49ba-81db-6e46722674af`
-  )
-  await expect(page).toHaveURL(
-    `${BASE_URL}/browse/subjects/Hebrew language -- Study and teaching.`
-  )
-})
-
-test("SHEP link with filter parameter redirects to browse index", async ({
-  page,
-}) => {
-  await page.goto(`${BASE_URL}/subject_headings?filter=Bronx River`)
-  await expect(page).toHaveURL(
-    `${BASE_URL}/browse?q=Bronx River&search_scope=starts_with`
-  )
-})
-
-test("SHEP link with label parameter redirects to browse results", async ({
-  page,
-}) => {
-  await page.goto(
-    `${BASE_URL}/subject_headings/c47dda10-a6a1-49ba-81db-6e46722674af?label=Hello`
-  )
-  await expect(page).toHaveURL(new RegExp(`${BASE_URL}/browse/subjects/Hello`))
-})
-
-test("SHEP base url redirects to browse", async ({ page }) => {
-  await page.goto(`${BASE_URL}/subject_headings`)
-  await expect(page).toHaveURL(`${BASE_URL}/browse`)
-})
-
-test("SHEP link with unknown uuid/path redirects to browse", async ({
-  page,
-}) => {
-  await page.goto(`${BASE_URL}/subject_headings/something-something`)
-  await expect(page).toHaveURL(`${BASE_URL}/browse`)
-})
-
-test.describe("circ bib redirects", () => {
-  test("RC sends circ bib requests to Vega", async ({ request }) => {
-    const response = await request.get(`${BASE_URL}/bib/b17782484`, {
-      maxRedirects: 0,
-    })
-
-    expect(response.status()).toEqual(307)
-
-    const location = response.headers()["location"]
-    expect(location).toBe(
-      "https://borrow.nypl.org/search/card?recordId=17782484"
+test.describe("middleware redirects", () => {
+  test("legacy url redirects to base path", async ({ page }) => {
+    await page.goto(
+      `${BASE_HOST}/research/collections/shared-collection-catalog`
     )
+    await expect(page).toHaveURL(BASE_URL)
+  })
+
+  test("legacy url plus path redirects to base path", async ({ page }) => {
+    await page.goto(
+      `${BASE_HOST}/research/collections/shared-collection-catalog/test`
+    )
+    await expect(page).toHaveURL(`${BASE_URL}/test`)
+  })
+
+  test("exact mapped SHEP link redirects to browse", async ({ page }) => {
+    await page.goto(
+      `${BASE_URL}/subject_headings/c47dda10-a6a1-49ba-81db-6e46722674af`
+    )
+    await expect(page).toHaveURL(
+      `${BASE_URL}/browse/subjects/Hebrew language -- Study and teaching.`
+    )
+  })
+
+  test("SHEP link with filter parameter redirects to browse index", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/subject_headings?filter=Bronx River`)
+    await expect(page).toHaveURL(
+      `${BASE_URL}/browse?q=Bronx River&search_scope=starts_with`
+    )
+  })
+
+  test("SHEP link with label parameter redirects to browse results", async ({
+    page,
+  }) => {
+    await page.goto(
+      `${BASE_URL}/subject_headings/c47dda10-a6a1-49ba-81db-6e46722674af?label=Hello`
+    )
+    await expect(page).toHaveURL(
+      new RegExp(`${BASE_URL}/browse/subjects/Hello`)
+    )
+  })
+
+  test("SHEP base url redirects to browse", async ({ page }) => {
+    await page.goto(`${BASE_URL}/subject_headings`)
+    await expect(page).toHaveURL(`${BASE_URL}/browse`)
+  })
+
+  test("SHEP link with unknown uuid/path redirects to browse", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/subject_headings/something-something`)
+    await expect(page).toHaveURL(`${BASE_URL}/browse`)
+  })
+
+  test.describe("circ bib request redirects", () => {
+    test("RC sends circ bib requests to Vega", async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/bib/b17782484`, {
+        maxRedirects: 0,
+      })
+
+      expect(response.status()).toEqual(307)
+
+      const location = response.headers()["location"]
+      expect(location).toBe(
+        "https://borrow.nypl.org/search/card?recordId=17782484"
+      )
+    })
   })
 })

--- a/playwright/tests/redirects.spec.ts
+++ b/playwright/tests/redirects.spec.ts
@@ -54,3 +54,15 @@ test("SHEP link with unknown uuid/path redirects to browse", async ({
   await page.goto(`${BASE_URL}/subject_headings/something-something`)
   await expect(page).toHaveURL(`${BASE_URL}/browse`)
 })
+
+test("RC sends circ bib requests to Vega", async ({ request }) => {
+  const response = await request.get(`${BASE_URL}/bib/b17782484`, {
+    maxRedirects: 0,
+  })
+
+  expect(response.status()).toBeGreaterThanOrEqual(300)
+  expect(response.status()).toBeLessThan(400)
+
+  const location = response.headers()["location"]
+  expect(location).toBe("https://borrow.nypl.org/search/card?recordId=17782484")
+})


### PR DESCRIPTION
## Ticket:

- JIRA ticket [5292](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5292)

## This PR does the following:

- Adds a test to redirects.spec.ts for asserting that RC sends circ bib requests to Vega

## How has this been tested?

- all test pass locally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
