### PR TITLE
SCC-5340: Timezone bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,8 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated series links in bib details [SCC-5195](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5195)
+- Fixed timezone shift in date formatting [SCC-5340](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5340)
 
 ## [1.9.0] 2026-04-14
+
+### Added
 
 - Added Playwright test for redirecting circ bib requests to Vega [SCC-5292](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5292)
 - Added author/contributor mode to browse landing [SCC-4966](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4966)

--- a/src/utils/myAccountUtils.ts
+++ b/src/utils/myAccountUtils.ts
@@ -33,7 +33,7 @@ export function formatPatronName(name = "") {
 }
 
 /**
- * getDueDate
+ * formatDate
  * Returns date in readable string ("Month day, year")
  */
 export function formatDate(date: string | number | Date) {

--- a/src/utils/myAccountUtils.ts
+++ b/src/utils/myAccountUtils.ts
@@ -42,9 +42,9 @@ export function formatDate(date: string | number | Date) {
   // we need to specify timezone to avoid off by one error.
   // perhaps this method needs to be two methods for the specific cases.
   const d = new Date(date)
-  const year = d.getFullYear()
+  const year = d.getUTCFullYear()
   const day = d.getUTCDate()
-  const month = d.toLocaleString("default", { month: "long" })
+  const month = d.toLocaleString("default", { month: "long", timeZone: "UTC" })
   return `${month} ${day}, ${year}`
 }
 

--- a/src/utils/myAccountUtils.ts
+++ b/src/utils/myAccountUtils.ts
@@ -38,13 +38,18 @@ export function formatPatronName(name = "") {
  */
 export function formatDate(date: string | number | Date) {
   if (!date) return null
-  // pickup location returns an iso string, but expiration date is YYYY-MM-DD.
-  // we need to specify timezone to avoid off by one error.
-  // perhaps this method needs to be two methods for the specific cases.
+  // Pickup location returns an ISO string, but expiration date is YYYY-MM-DD.
+  // If the date is a string without a time component (e.g., "YYYY-MM-DD"),
+  // treat it as UTC to avoid timezone shifting.
   const d = new Date(date)
-  const year = d.getUTCFullYear()
-  const day = d.getUTCDate()
-  const month = d.toLocaleString("default", { month: "long", timeZone: "UTC" })
+  const isDateOnly = typeof date === "string" && !date.includes("T")
+  const year = isDateOnly ? d.getUTCFullYear() : d.getFullYear()
+  const day = isDateOnly ? d.getUTCDate() : d.getDate()
+  const month = d.toLocaleString("default", {
+    month: "long",
+    timeZone: isDateOnly ? "UTC" : undefined,
+  })
+
   return `${month} ${day}, ${year}`
 }
 

--- a/src/utils/utilsTests/myAccountUtils.test.ts
+++ b/src/utils/utilsTests/myAccountUtils.test.ts
@@ -26,13 +26,23 @@ describe("myAccountUtils", () => {
       expect(formatDate("")).toBeNull()
     })
 
-    it("formats YYYY-MM-DD correctly without timezone shifting", () => {
+    it("formats YYYY-MM-DD date strings without shifting timezones", () => {
       expect(formatDate("2026-05-01")).toBe("May 1, 2026")
       expect(formatDate("2026-06-01")).toBe("June 1, 2026")
     })
 
-    it("formats full ISO strings correctly", () => {
-      expect(formatDate("2026-04-15T15:26:18.209Z")).toBe("April 15, 2026")
+    it("formats ISO strings with a time component using the local timezone", () => {
+      const isoString = "2026-04-15T15:26:18.209Z"
+      const localDate = new Date(isoString)
+      const expectedMonth = localDate.toLocaleString("default", {
+        month: "long",
+      })
+      const expectedDay = localDate.getDate()
+      const expectedYear = localDate.getFullYear()
+
+      expect(formatDate(isoString)).toBe(
+        `${expectedMonth} ${expectedDay}, ${expectedYear}`
+      )
     })
   })
 

--- a/src/utils/utilsTests/myAccountUtils.test.ts
+++ b/src/utils/utilsTests/myAccountUtils.test.ts
@@ -1,0 +1,78 @@
+import { formatPatronName, formatDate, buildPatron } from "../myAccountUtils"
+import type { SierraPatron } from "../../types/myAccountTypes"
+
+describe("myAccountUtils", () => {
+  describe("formatPatronName", () => {
+    it("returns an empty string if no name is provided", () => {
+      expect(formatPatronName()).toBe("")
+      expect(formatPatronName("")).toBe("")
+    })
+
+    it("returns the original string if no comma is present", () => {
+      expect(formatPatronName("Zendaya")).toBe("Zendaya")
+    })
+
+    it("formats 'LASTNAME, FIRSTNAME' to 'Firstname Lastname'", () => {
+      expect(formatPatronName("NONNA, STREGA")).toBe("Strega Nonna")
+    })
+
+    it("handles multiple names correctly", () => {
+      expect(formatPatronName("SMITH, JOHN DOE")).toBe("John Doe Smith")
+    })
+  })
+
+  describe("formatDate", () => {
+    it("returns null if no date is provided", () => {
+      expect(formatDate("")).toBeNull()
+    })
+
+    it("formats YYYY-MM-DD correctly without timezone shifting", () => {
+      expect(formatDate("2026-05-01")).toBe("May 1, 2026")
+      expect(formatDate("2026-06-01")).toBe("June 1, 2026")
+    })
+
+    it("formats full ISO strings correctly", () => {
+      expect(formatDate("2026-04-15T15:26:18.209Z")).toBe("April 15, 2026")
+    })
+  })
+
+  describe("buildPatron", () => {
+    it("constructs a Patron object from SierraPatron data", () => {
+      const sierraPatron: SierraPatron = {
+        id: 12345,
+        names: ["NONNA, STREGA"],
+        barcodes: ["23333121538324"],
+        expirationDate: "2025-03-28",
+        emails: ["streganonna@gmail.com", "spaghettigrandma@gmail.com"],
+        homeLibrary: { code: "sn   ", name: "SNFL (formerly Mid-Manhattan)" },
+        phones: [{ number: "123-456-7890", type: "t" }],
+        varFields: [{ fieldTag: "u", content: "pastadisciple" }],
+        fixedFields: {
+          "268": { label: "notification preference", value: "z" },
+        },
+      }
+
+      expect(buildPatron(sierraPatron)).toEqual({
+        notificationPreference: "z",
+        username: "pastadisciple",
+        name: "Strega Nonna",
+        barcode: "23333121538324",
+        formattedBarcode: "2 3333 12153 8324",
+        expirationDate: "March 28, 2025",
+        emails: ["streganonna@gmail.com", "spaghettigrandma@gmail.com"],
+        phones: [{ number: "123-456-7890", type: "t" }],
+        homeLibrary: { code: "sn   ", name: "SNFL (formerly Mid-Manhattan)" },
+        id: 12345,
+      })
+    })
+
+    it("handles missing optional fields gracefully", () => {
+      const emptySierraPatron: SierraPatron = { id: 12345 }
+
+      const result = buildPatron(emptySierraPatron)
+      expect(result.id).toBe(12345)
+      expect(result.name).toBe("")
+      expect(result.emails).toStrictEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5340](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5340)

## This PR does the following:

- Adds `timeZone:"UTC"` to our `toLocaleString` to ensure we format date strings in the same timezone that we parse them in 
- Adds some unit tests to cover this specific case (June 1 2026 getting parsed to May 1 2026) and the other utilities in `myAccountUtils`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-5340]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ