### PR TITLE
Remove series/author literal value fallbacks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated series links in bib details [SCC-5195](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5195)
+- Remove linked author/series literals as fallback
 
 ## [1.9.0] 2026-04-14
 

--- a/src/models/BibDetails.ts
+++ b/src/models/BibDetails.ts
@@ -73,8 +73,7 @@ export default class BibDetails {
     if (owner) return [owner]
   }
 
-  // Build a linked series or author field with link and display text,
-  // defaulting to the literal field
+  // Build a linked series or author field with link and display text
   buildLinkedDisplayFieldDetail(literalField: string): LinkedBibDetail | null {
     const {
       label: displayLabel,
@@ -91,24 +90,11 @@ export default class BibDetails {
       })
     )
 
-    // Literals (fallback)
-    const literalValues: string[] = this.bib[literalField] || []
-    const literals: BibDetailURL[] = literalValues.map((name) => ({
-      url: searchUrl(name),
-      urlText: name,
-    }))
-
     return displayValues?.length > 0
       ? {
           label: displayLabel,
           link: "internal",
           value: displayValues,
-        }
-      : literals?.length > 0
-      ? {
-          label: displayLabel,
-          link: "internal",
-          value: literals,
         }
       : null
   }


### PR DESCRIPTION
## Ticket:

- n/a

## This PR does the following:

- Removes the fallbacks that just link the literal values for series/author fields– if there's no display/value string combination, things have already gone wrong upstream, and linking the literals won't help

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
