### PR TITLE
SCC-5369: Language label bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated series links in bib details [SCC-5195](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5195)
+- Updated to use `searchVocabularies` language labels for filters [SCC-5369](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5369)
 
 ## [1.9.0] 2026-04-14
 

--- a/src/components/AppliedFilters/appliedFilterUtils.test.ts
+++ b/src/components/AppliedFilters/appliedFilterUtils.test.ts
@@ -98,6 +98,19 @@ describe("Applied Filter utils", () => {
         dateTo: [{ value: "2010", count: null, label: "To 2010" }],
       })
     })
+
+    it("takes applied language filter values and adds the appropriate label", () => {
+      const appliedFilterValues = {
+        language: ["lang:alb"],
+      }
+      const parsed = addLabelPropAndParseFilters(
+        aggregationsResults.itemListElement,
+        appliedFilterValues
+      )
+      expect(parsed).toStrictEqual({
+        language: [{ value: "lang:alb", count: null, label: "Albanian" }],
+      })
+    })
   })
   describe("buildAppliedFiltersValueArrayWithTagRemoved", () => {
     it("removes the provided tag", () => {

--- a/src/components/AppliedFilters/appliedFilterUtils.ts
+++ b/src/components/AppliedFilters/appliedFilterUtils.ts
@@ -4,7 +4,10 @@ import type {
   CollapsedMultiValueAppliedFilters,
   Option,
 } from "../../types/filterTypes"
-import { mapCollectionToFilterTag } from "../../utils/advancedSearchUtils"
+import {
+  mapCollectionToFilterTag,
+  mapLanguageToFilterTag,
+} from "../../utils/advancedSearchUtils"
 
 export const buildAppliedFiltersValueArrayWithTagRemoved = (
   tag: TagSetFilterDataProps,
@@ -47,6 +50,10 @@ export const addLabelPropAndParseFilters = (
         label: filterValue,
       }
 
+      const matchingOption = matchingFieldAggregation?.values.find(
+        (option) => option.value === filterValue
+      )
+
       // Date: Add "From"/"To" to filter labels
       if (appliedFilterField.includes("date")) {
         const labelPrefix = appliedFilterField.split("date")[1]
@@ -71,9 +78,14 @@ export const addLabelPropAndParseFilters = (
         }
       }
 
-      const matchingOption = matchingFieldAggregation?.values.find(
-        (option) => option.value === filterValue
-      )
+      // Language: Map language code to label from aggregations first, then fall back to searchVocabularies
+      if (appliedFilterField === "language") {
+        return {
+          count: matchingOption?.count || null,
+          value: filterValue,
+          label: matchingOption?.label || mapLanguageToFilterTag(filterValue),
+        }
+      }
 
       // If there's no matching option in the aggregations,
       // or no matching aggregations for the field, fall back to value as label

--- a/src/utils/advancedSearchUtils.ts
+++ b/src/utils/advancedSearchUtils.ts
@@ -103,3 +103,11 @@ export function mapCollectionToFilterTag(collectionValue, collectionName) {
   }
   return collectionName
 }
+
+/** Get filter string to display for language codes from searchVocabularies. **/
+export function mapLanguageToFilterTag(languageCode: string) {
+  const language = searchVocabularies.languages.find(
+    (l) => languageCode === l.value
+  )
+  return language?.label || languageCode
+}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5369](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5369)

## This PR does the following:

- Update language filter tags to use the handy `searchVocabularies` labels instead of limiting ourselves to the language aggs on any given response
- More context: this issue was exposed a couple weeks ago when [this work](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5125) went out, previously if the language didn't appear in the aggregations we just didn't display the tag!

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Try applying some obscure languages (first five listed in languages dropdown in advanced search are all good bets) and check that the filter tag in Active filters has a label rather than the code

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-5369]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ