### PR TITLE
SCC-5245: All lists display

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Playwright tests for Author Browse [SCC-5338](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5338)
 - Added series and genre to advanced search fields [SCC-5179](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5179)
 - Added lists API handlers [SCC-5243](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5243)
+- Added lists tab and all lists table [SCC-5245](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5245)
 
 ### Updated
 

--- a/__test__/fixtures/listFixtures.ts
+++ b/__test__/fixtures/listFixtures.ts
@@ -1,6 +1,6 @@
 export const listsResponse = [
   {
-    id: 12345000,
+    id: "12345000-aabb-bb",
     patronId: "12345",
     records: [],
     createdDate: "2026-04-15T15:26:18.209896",
@@ -9,7 +9,7 @@ export const listsResponse = [
     description: null,
   },
   {
-    id: 123456000,
+    id: "1234-cc-vv",
     patronId: "12345",
     records: [
       {
@@ -21,7 +21,7 @@ export const listsResponse = [
     ],
     createdDate: "2026-04-21T16:23:22.326377",
     modifiedDate: "2026-04-21T16:23:22.326378",
-    listName: "Second list",
-    description: "Description",
+    listName: "Spaghetti westerns",
+    description: "all about spaghetti",
   },
 ]

--- a/pages/account/[[...index]].tsx
+++ b/pages/account/[[...index]].tsx
@@ -99,10 +99,13 @@ export async function getServerSideProps({ req, res }) {
   const id = patronTokenResponse.decodedPatron.sub
 
   try {
-    const listsResponse = await fetchLists({ patronId: id })
+    const [listsResponse, patronData] = await Promise.all([
+      fetchLists({ patronId: id }),
+      getPatronData(id),
+    ])
     const lists = listsResponse.lists
-    const { checkouts, holds, patron, fines, pickupLocations } =
-      await getPatronData(id)
+    const { checkouts, holds, patron, fines, pickupLocations } = patronData
+
     // Redirecting invalid paths and cleaning extra parts off valid paths.
     if (tabsPath) {
       const allowedPaths = [

--- a/pages/api/account/lists.ts
+++ b/pages/api/account/lists.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import { fetchLists } from "../../../src/server/api/lists"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" })
+  }
+
+  const { patronId, sort } = req.query
+
+  if (!patronId || typeof patronId !== "string") {
+    return res.status(400).json({ error: "Missing or invalid patronId" })
+  }
+
+  const response = await fetchLists({
+    patronId,
+    sort: typeof sort === "string" ? sort : undefined,
+  })
+  res.status(200).json(response)
+}

--- a/pages/api/account/lists.ts
+++ b/pages/api/account/lists.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 import { fetchLists } from "../../../src/server/api/lists"
+import type { ListSort } from "../../../src/types/listTypes"
 
 export default async function handler(
   req: NextApiRequest,
@@ -17,7 +18,7 @@ export default async function handler(
 
   const response = await fetchLists({
     patronId,
-    sort: typeof sort === "string" ? sort : undefined,
+    sort: sort as ListSort,
   })
   res.status(200).json(response)
 }

--- a/src/components/MyAccount/ItemsTab.tsx
+++ b/src/components/MyAccount/ItemsTab.tsx
@@ -36,7 +36,7 @@ const ItemsTab = ({
       </Box>
       {data?.length > 0 && (
         <Table
-          className={styles.itemsTable}
+          className={styles.accountItemsTable}
           showRowDividers={true}
           columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
           columnHeaders={headers}

--- a/src/components/MyAccount/ListsTab/CreateListButton.tsx
+++ b/src/components/MyAccount/ListsTab/CreateListButton.tsx
@@ -1,0 +1,14 @@
+import { Button, Icon } from "@nypl/design-system-react-components"
+
+const CreateListButton = () => {
+  return (
+    <Button width={{ base: "100%", sm: "auto" }}>
+      <Icon name="plus" align="left" size="small" />
+      Create new list
+    </Button>
+  )
+}
+
+CreateListButton.displayName = "CreateListButton"
+
+export default CreateListButton

--- a/src/components/MyAccount/ListsTab/CreateListButton.tsx
+++ b/src/components/MyAccount/ListsTab/CreateListButton.tsx
@@ -9,6 +9,4 @@ const CreateListButton = () => {
   )
 }
 
-CreateListButton.displayName = "CreateListButton"
-
 export default CreateListButton

--- a/src/components/MyAccount/ListsTab/ListOptionsModal.tsx
+++ b/src/components/MyAccount/ListsTab/ListOptionsModal.tsx
@@ -1,0 +1,15 @@
+import { Button, Flex, Icon } from "@nypl/design-system-react-components"
+import type List from "../../../models/List"
+
+const ListOptionsModal = ({ list }: { list: List }) => {
+  return (
+    <Flex justifyContent="flex-end" width="100%">
+      <Button variant="text" gap="0" padding="xs">
+        <Icon name="navigationMoreVert" align="left" size="large" />
+        Options
+      </Button>
+    </Flex>
+  )
+}
+
+export default ListOptionsModal

--- a/src/components/MyAccount/ListsTab/ListsSort.tsx
+++ b/src/components/MyAccount/ListsTab/ListsSort.tsx
@@ -1,0 +1,62 @@
+import { Box, Menu } from "@nypl/design-system-react-components"
+import { forwardRef, useEffect } from "react"
+import { idConstants, useFocusContext } from "../../../context/FocusContext"
+
+interface ListsSortProps {
+  handleSortChange: (string) => Promise<void>
+  selectedValue: string
+  sortOptions: Record<string, string>
+}
+
+/**
+ * The ListsSort component renders a Menu component used for sorting a user's lists.
+ */
+const ListsSort = forwardRef<HTMLDivElement, ListsSortProps>(
+  ({ handleSortChange, sortOptions, selectedValue }, ref) => {
+    const { activeElementId } = useFocusContext()
+
+    // Uses current focus context value and wrapping ref to refocus Menu's internal button
+    useEffect(() => {
+      if (
+        ref &&
+        typeof ref !== "function" &&
+        activeElementId === idConstants.listsSort
+      ) {
+        const btn = ref.current?.querySelector("button")
+        btn?.focus()
+      }
+    }, [selectedValue, ref, activeElementId])
+
+    return (
+      // TODO: Forcing focus, remove with repaired Menu component
+      <Box
+        zIndex="9999"
+        ref={ref}
+        width={{ base: "100%", sm: "auto" }}
+        sx={{
+          button: { width: { base: "100%", sm: "auto" } },
+        }}
+      >
+        <Menu
+          zIndex="9999"
+          key={selectedValue} // TODO: Forcing remount, replace with repaired Menu component
+          id="lists-sort"
+          showLabel
+          className="no-print"
+          selectedItem={selectedValue}
+          labelText={`Sort by: ${sortOptions[selectedValue]}`}
+          listItemsData={Object.entries(sortOptions).map(([key, label]) => ({
+            id: key,
+            label,
+            onClick: () => handleSortChange(key),
+            type: "action",
+          }))}
+        />
+      </Box>
+    )
+  }
+)
+
+export default ListsSort
+
+ListsSort.displayName = "ListsSort"

--- a/src/components/MyAccount/ListsTab/ListsSort.tsx
+++ b/src/components/MyAccount/ListsTab/ListsSort.tsx
@@ -34,7 +34,7 @@ const ListsSort = forwardRef<HTMLDivElement, ListsSortProps>(
         ref={ref}
         width={{ base: "100%", sm: "auto" }}
         sx={{
-          button: { width: { base: "100%", sm: "auto" } },
+          button: { width: "100%" },
         }}
       >
         <Menu

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { render, screen, within } from "../../../utils/testUtils"
+import { processedPatron } from "../../../../__test__/fixtures/processedMyAccountData"
+import userEvent from "@testing-library/user-event"
+import ListsTab from "./ListsTab"
+import { PatronDataProvider } from "../../../context/PatronDataContext"
+import { BASE_URL } from "../../../config/constants"
+import { pickupLocations } from "../../../../__test__/fixtures/rawSierraAccountData"
+import { listsResponse } from "../../../../__test__/fixtures/listFixtures"
+import type { ListResult } from "../../../types/listTypes"
+
+jest.mock("next/router", () => jest.requireActual("next-router-mock"))
+
+const renderWithPatronDataContext = (
+  lists: ListResult[] = listsResponse as ListResult[]
+) => {
+  return render(
+    <PatronDataProvider
+      value={{
+        lists,
+        patron: processedPatron,
+        pickupLocations: pickupLocations as any,
+      }}
+    >
+      <ListsTab />
+    </PatronDataProvider>
+  )
+}
+
+describe("ListsTab", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    jest.clearAllMocks()
+  })
+
+  it("renders the create button and sort menu", () => {
+    renderWithPatronDataContext()
+    expect(screen.getByText("Create new list")).toBeInTheDocument()
+    expect(screen.getByText(/Sort by:/)).toBeInTheDocument()
+  })
+
+  it("renders each list as a row", () => {
+    renderWithPatronDataContext()
+    const table = screen.getByTestId("list-table")
+    const rows = within(table).getAllByRole("row")
+
+    // Header row and 2 lists
+    expect(rows.length).toBe(3)
+
+    expect(within(rows[1]).getByText("First list")).toBeInTheDocument()
+    expect(within(rows[1]).getByText("No description")).toBeInTheDocument()
+    expect(within(rows[1]).getByText("0")).toBeInTheDocument()
+
+    expect(within(rows[2]).getByText("Spaghetti westerns")).toBeInTheDocument()
+    expect(within(rows[2]).getByText("all about spaghetti")).toBeInTheDocument()
+    expect(within(rows[2]).getByText("1")).toBeInTheDocument()
+  })
+
+  it("renders a placeholder when a list has no description", () => {
+    const listsWithoutDescription: ListResult[] = [
+      {
+        ...listsResponse[1],
+        description: null,
+      } as unknown as ListResult,
+    ]
+    renderWithPatronDataContext(listsWithoutDescription)
+    expect(screen.getByText("No description")).toBeInTheDocument()
+  })
+
+  it("calls sort endpoint when a sort option is selected and updates lists", async () => {
+    const sortedListsResponse = [
+      listsResponse[1],
+      listsResponse[0],
+    ] as unknown as ListResult[]
+
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ lists: sortedListsResponse }),
+    } as Response)
+
+    renderWithPatronDataContext()
+
+    const sortMenu = screen.getByLabelText("Sort by:", { exact: false })
+    userEvent.click(sortMenu)
+    await userEvent.click(screen.getByText("List name (A-Z)"))
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/api/account/lists?patronId=${processedPatron.id}&sort=list_name_asc`
+    )
+
+    // Confirm rows flipped order
+    const table = await screen.findByTestId("list-table")
+    const rows = within(table).getAllByRole("row")
+
+    // Now Spaghetti westerns should be in the first row
+    expect(within(rows[1]).getByText("Spaghetti westerns")).toBeInTheDocument()
+    expect(within(rows[2]).getByText("First list")).toBeInTheDocument()
+  })
+})

--- a/src/components/MyAccount/ListsTab/ListsTab.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.tsx
@@ -9,6 +9,7 @@ import { idConstants, useFocusContext } from "../../../context/FocusContext"
 import { listSortOptions } from "../../../utils/listUtils"
 import CreateListButton from "./CreateListButton"
 import ListOptionsModal from "./ListOptionsModal"
+import { BASE_URL } from "../../../config/constants"
 
 const ListsTab = () => {
   const {
@@ -46,10 +47,12 @@ const ListsTab = () => {
   const handleSortChange = async (selectedSortOption: string) => {
     try {
       const response = await fetch(
-        `/api/account/lists?patronId=${patron.id}&sort=${selectedSortOption}`
+        `${BASE_URL}/api/account/lists?patronId=${patron.id}&sort=${selectedSortOption}`
       )
+      console.log(response)
       if (response.ok) {
         const data = await response.json()
+        console.log(data)
         setLists(data.lists.map((list: any) => new List(list)))
       }
     } catch (error) {

--- a/src/components/MyAccount/ListsTab/ListsTab.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.tsx
@@ -49,10 +49,8 @@ const ListsTab = () => {
       const response = await fetch(
         `${BASE_URL}/api/account/lists?patronId=${patron.id}&sort=${selectedSortOption}`
       )
-      console.log(response)
       if (response.ok) {
         const data = await response.json()
-        console.log(data)
         setLists(data.lists.map((list: any) => new List(list)))
       }
     } catch (error) {

--- a/src/components/MyAccount/ListsTab/ListsTab.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.tsx
@@ -1,60 +1,108 @@
-import { useContext } from "react"
-import { Box, Table } from "@nypl/design-system-react-components"
+import { useContext, useRef, useState, useEffect } from "react"
+import { Box, Button, Flex, Table } from "@nypl/design-system-react-components"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import styles from "../../../../styles/components/MyAccount.module.scss"
 import List from "../../../models/List"
 import Link from "../../Link/Link"
+import ListsSort from "./ListsSort"
+import { idConstants, useFocusContext } from "../../../context/FocusContext"
+import { listSortOptions } from "../../../utils/listUtils"
+import CreateListButton from "./CreateListButton"
 
 const ListsTab = () => {
   const {
-    updatedAccountData: { lists: listResults },
+    updatedAccountData: { lists: listResults, patron },
   } = useContext(PatronDataContext)
-  const lists = listResults.map((list: any) => new List(list))
+
+  const [lists, setLists] = useState(
+    listResults.map((list: any) => new List(list))
+  )
+
+  // Keep local lists in sync
+  useEffect(() => {
+    setLists(listResults.map((list: any) => new List(list)))
+  }, [listResults])
+
   const tableData = lists.map((list: List) => [
-    <Link href={`/account/lists/${list.id}`} key={list.id}>
+    <Link isUnderlined={false} href={`/account/lists/${list.id}`} key={list.id}>
       {list.listName}
     </Link>,
     list.description || (
-      <span style={{ color: "ui.gray.dark !important", fontStyle: "italic" }}>
+      <Box as="span" color="ui.gray.dark" fontStyle="italic">
         No description
-      </span>
+      </Box>
     ),
-    list.records?.length || 0,
-    list.createdDate ? new Date(list.createdDate).toLocaleDateString() : "",
-    list.modifiedDate ? new Date(list.modifiedDate).toLocaleDateString() : "",
+    list.recordCount,
+    list.createdDate,
+    list.modifiedDate,
     "Actions...",
   ])
 
+  const { setPersistentFocus } = useFocusContext()
+  const sortMenuRef = useRef<HTMLDivElement | null>(null)
+  const [activeSort, setActiveSort] = useState("modified_date_desc")
+
+  const handleSortChange = async (selectedSortOption: string) => {
+    try {
+      const response = await fetch(
+        `/api/account/lists?patronId=${patron.id}&sort=${selectedSortOption}`
+      )
+      if (response.ok) {
+        const data = await response.json()
+        setLists(data.lists.map((list: any) => new List(list)))
+      }
+    } catch (error) {
+      console.error("Error sorting lists:", error)
+    }
+    setActiveSort(selectedSortOption)
+    setPersistentFocus(idConstants.listsSort)
+  }
+
   return (
-    // Display as grid to prevent bug where the outer container stretches to the Table's width on mobile
-    <Box display="grid">
-      <Table
-        className={styles.listTable}
-        columnHeaders={[
-          "List name",
-          "List description",
-          "Records",
-          "Date created",
-          "Date modified",
-          "Action",
-        ]}
-        fontSize="body2"
-        columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
-        columnStyles={[
-          { width: "auto", minWidth: 250 },
-          { width: "auto", minWidth: 250 },
-          { width: "17%", minWidth: 100 },
-          { width: "17%", minWidth: 100 },
-          { width: "17%", minWidth: 100 },
-          { width: "17%", minWidth: 100 },
-        ]}
-        tableData={tableData}
-        isScrollable
-        showRowDividers
-        my={{ base: 0, md: "s" }}
-        data-testid="list-table"
-      />
-    </Box>
+    <Flex flexDir="column">
+      <Flex
+        flexDir={{ base: "column", sm: "row" }}
+        justifyContent="space-between"
+        mt="m"
+        mb="m"
+        gap="xs"
+      >
+        <CreateListButton />
+        <ListsSort
+          ref={sortMenuRef}
+          selectedValue={activeSort}
+          sortOptions={listSortOptions}
+          handleSortChange={handleSortChange}
+        />
+      </Flex>
+      <Box display="grid">
+        <Table
+          className={styles.listTable}
+          columnHeaders={[
+            "List name",
+            "List description",
+            "Records",
+            "Date created",
+            "Date modified",
+            "Action",
+          ]}
+          columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
+          columnStyles={[
+            { width: "auto", minWidth: 240 },
+            { width: "auto", minWidth: 240 },
+            { width: "17%", minWidth: 120 },
+            { width: "17%", minWidth: 120 },
+            { width: "17%", minWidth: 120 },
+            { width: "18%", minWidth: 128 },
+          ]}
+          tableData={tableData}
+          isScrollable
+          showRowDividers
+          my={{ base: 0, md: "s" }}
+          data-testid="list-table"
+        />
+      </Box>
+    </Flex>
   )
 }
 

--- a/src/components/MyAccount/ListsTab/ListsTab.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.tsx
@@ -1,13 +1,61 @@
 import { useContext } from "react"
+import { Box, Table } from "@nypl/design-system-react-components"
 import { PatronDataContext } from "../../../context/PatronDataContext"
+import styles from "../../../../styles/components/MyAccount.module.scss"
 import List from "../../../models/List"
+import Link from "../../Link/Link"
 
 const ListsTab = () => {
   const {
     updatedAccountData: { lists: listResults },
   } = useContext(PatronDataContext)
   const lists = listResults.map((list: any) => new List(list))
-  return <>{JSON.stringify(lists)}</>
+  const tableData = lists.map((list: List) => [
+    <Link href={`/account/lists/${list.id}`} key={list.id}>
+      {list.listName}
+    </Link>,
+    list.description || (
+      <span style={{ color: "ui.gray.dark !important", fontStyle: "italic" }}>
+        No description
+      </span>
+    ),
+    list.records?.length || 0,
+    list.createdDate ? new Date(list.createdDate).toLocaleDateString() : "",
+    list.modifiedDate ? new Date(list.modifiedDate).toLocaleDateString() : "",
+    "Actions...",
+  ])
+
+  return (
+    // Display as grid to prevent bug where the outer container stretches to the Table's width on mobile
+    <Box display="grid">
+      <Table
+        className={styles.listTable}
+        columnHeaders={[
+          "List name",
+          "List description",
+          "Records",
+          "Date created",
+          "Date modified",
+          "Action",
+        ]}
+        fontSize="body2"
+        columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
+        columnStyles={[
+          { width: "auto", minWidth: 250 },
+          { width: "auto", minWidth: 250 },
+          { width: "17%", minWidth: 100 },
+          { width: "17%", minWidth: 100 },
+          { width: "17%", minWidth: 100 },
+          { width: "17%", minWidth: 100 },
+        ]}
+        tableData={tableData}
+        isScrollable
+        showRowDividers
+        my={{ base: 0, md: "s" }}
+        data-testid="list-table"
+      />
+    </Box>
+  )
 }
 
 export default ListsTab

--- a/src/components/MyAccount/ListsTab/ListsTab.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.tsx
@@ -1,5 +1,5 @@
 import { useContext, useRef, useState, useEffect } from "react"
-import { Box, Button, Flex, Table } from "@nypl/design-system-react-components"
+import { Box, Flex, Table } from "@nypl/design-system-react-components"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import styles from "../../../../styles/components/MyAccount.module.scss"
 import List from "../../../models/List"
@@ -8,6 +8,7 @@ import ListsSort from "./ListsSort"
 import { idConstants, useFocusContext } from "../../../context/FocusContext"
 import { listSortOptions } from "../../../utils/listUtils"
 import CreateListButton from "./CreateListButton"
+import ListOptionsModal from "./ListOptionsModal"
 
 const ListsTab = () => {
   const {
@@ -35,7 +36,7 @@ const ListsTab = () => {
     list.recordCount,
     list.createdDate,
     list.modifiedDate,
-    "Actions...",
+    <ListOptionsModal key={list.id} list={list} />,
   ])
 
   const { setPersistentFocus } = useFocusContext()
@@ -88,12 +89,12 @@ const ListsTab = () => {
           ]}
           columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
           columnStyles={[
+            { width: 320, minWidth: 240 },
             { width: "auto", minWidth: 240 },
-            { width: "auto", minWidth: 240 },
-            { width: "17%", minWidth: 120 },
-            { width: "17%", minWidth: 120 },
-            { width: "17%", minWidth: 120 },
-            { width: "18%", minWidth: 128 },
+            { width: 160, minWidth: 120 },
+            { width: 160, minWidth: 120 },
+            { width: 160, minWidth: 120 },
+            { width: 120, minWidth: 128 },
           ]}
           tableData={tableData}
           isScrollable

--- a/src/components/MyAccount/ProfileTabs.tsx
+++ b/src/components/MyAccount/ProfileTabs.tsx
@@ -15,7 +15,7 @@ interface ProfileTabsPropsType {
 
 const ProfileTabs = ({ activePath }: ProfileTabsPropsType) => {
   const {
-    updatedAccountData: { checkouts, holds, fines },
+    updatedAccountData: { checkouts, holds, fines, lists },
   } = useContext(PatronDataContext)
   // tabsData conditionally includes fines– only when user has total fines more than $0.
   const tabsData = [
@@ -24,7 +24,7 @@ const ProfileTabs = ({ activePath }: ProfileTabsPropsType) => {
       content: checkouts ? (
         <CheckoutsTab />
       ) : (
-        <Text sx={{ mt: "s" }}>
+        <Text sx={{ mt: "m" }}>
           There was an error accessing your checkouts.
         </Text>
       ),
@@ -35,7 +35,9 @@ const ProfileTabs = ({ activePath }: ProfileTabsPropsType) => {
       content: holds ? (
         <RequestsTab />
       ) : (
-        <Text sx={{ mt: "s" }}>There was an error accessing your requests</Text>
+        <Text sx={{ mt: "m" }}>
+          There was an error accessing your requests.
+        </Text>
       ),
       urlPath: "requests",
     },
@@ -54,8 +56,12 @@ const ProfileTabs = ({ activePath }: ProfileTabsPropsType) => {
       urlPath: "settings",
     },
     {
-      label: "Lists",
-      content: <ListsTab />,
+      label: "Lists" + (lists ? ` (${lists.length})` : ""),
+      content: lists ? (
+        <ListsTab />
+      ) : (
+        <Text sx={{ mt: "m" }}>There was an error accessing your lists.</Text>
+      ),
       urlPath: "lists",
     },
   ]

--- a/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
+++ b/src/components/MyAccount/RequestsTab/RequestsTab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen, waitFor, within } from "../../../utils/testUtils"
+import { render, screen, within } from "../../../utils/testUtils"
 import {
   processedHolds,
   processedPatron,

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -26,6 +26,7 @@ export const idConstants = {
   browseResultsHeading: "browse-results-heading",
   searchResultsSort: "search-results-sort",
   browseResultsSort: "browse-results-sort",
+  listsSort: "lists-sort",
   filterResultsHeading: "filter-results-heading",
   activeFiltersHeading: "active-filters-heading",
   searchFiltersModal: "search-filters-modal",

--- a/src/models/List.ts
+++ b/src/models/List.ts
@@ -11,6 +11,7 @@ export default class List {
   listName: string
   patronId: string
   records: ListRecord[]
+  recordCount: string
   description: string | null
   createdDate: string
   modifiedDate: string
@@ -21,6 +22,7 @@ export default class List {
     this.description = result.description
     this.patronId = result.patronId
     this.records = this.buildRecordsFromListResult(result, bibDataMap)
+    this.recordCount = this.records.length.toString() || "0"
     this.createdDate = formatMMDDYYYY(result.createdDate)
     this.modifiedDate = formatMMDDYYYY(result.modifiedDate)
   }

--- a/src/models/ListRecord.ts
+++ b/src/models/ListRecord.ts
@@ -9,9 +9,9 @@ export default class ListRecord {
   uri: string
   addedDate: string
   title: string
-  itemCount: number
-  callNumber: string
-  location: string
+  itemCount?: number
+  callNumber?: string
+  location?: string
 
   constructor(result?: ListRecordResult, bibData?: any) {
     this.uri = result.uri

--- a/src/models/modelTests/List.test.ts
+++ b/src/models/modelTests/List.test.ts
@@ -10,7 +10,7 @@ describe("List model", () => {
 
   describe("constructor", () => {
     it("initializes the id", () => {
-      expect(list.id).toBe("12345000")
+      expect(list.id).toBe("12345000-aabb-bb")
     })
 
     it("initializes the listName", () => {

--- a/src/server/api/lists.ts
+++ b/src/server/api/lists.ts
@@ -1,3 +1,4 @@
+import type { ListSort } from "../../types/listTypes"
 import { logServerError } from "../../utils/logUtils"
 import nyplApiClient from "../nyplApiClient"
 
@@ -35,7 +36,7 @@ async function callListsServiceAndHandleError({
  *
  * @param {object} params
  * @param {string} params.patronId - The patron's ID.
- * @param {string} [params.sort] - Optional sort parameter.
+ * @param {ListSort} [params.sort] - Optional sort parameter.
  * @returns {Promise<object>} The patron's lists or an error object.
  */
 export async function fetchLists({
@@ -43,7 +44,7 @@ export async function fetchLists({
   sort,
 }: {
   patronId: string
-  sort?: string
+  sort?: ListSort
 }) {
   const path = sort
     ? `/patrons/${patronId}/lists?sort=${sort}`

--- a/src/server/api/lists.ts
+++ b/src/server/api/lists.ts
@@ -17,11 +17,11 @@ async function callListsServiceAndHandleError({
     const client = await nyplApiClient()
     const response = await apiCall(client)
     if (response.error) {
-      logServerError(methodName, `${response.error} Request: ${path}`)
+      logServerError(methodName, `${response.error?.message} Request: ${path}`)
       return {
         status: response.statusCode,
         name: response.name,
-        error: response.error,
+        error: response.error?.message,
       }
     }
     return onSuccess(response)
@@ -49,6 +49,7 @@ export async function fetchLists({
   const path = sort
     ? `/patrons/${patronId}/lists?sort=${sort}`
     : `/patrons/${patronId}/lists`
+  console.log(path)
   return callListsServiceAndHandleError({
     methodName: "fetchLists",
     path,

--- a/src/server/api/lists.ts
+++ b/src/server/api/lists.ts
@@ -17,11 +17,14 @@ async function callListsServiceAndHandleError({
     const client = await nyplApiClient()
     const response = await apiCall(client)
     if (response.error) {
-      logServerError(methodName, `${response.error?.message} Request: ${path}`)
+      logServerError(
+        methodName,
+        `${response.error || response.error.message} Request: ${path}`
+      )
       return {
         status: response.statusCode,
         name: response.name,
-        error: response.error?.message,
+        error: response.error || response.error.message,
       }
     }
     return onSuccess(response)
@@ -49,7 +52,6 @@ export async function fetchLists({
   const path = sort
     ? `/patrons/${patronId}/lists?sort=${sort}`
     : `/patrons/${patronId}/lists`
-  console.log(path)
   return callListsServiceAndHandleError({
     methodName: "fetchLists",
     path,

--- a/src/server/api/tests/lists.test.ts
+++ b/src/server/api/tests/lists.test.ts
@@ -33,10 +33,10 @@ describe("lists", () => {
       mockClient.get.mockResolvedValueOnce([{ id: "list1" }, { id: "list2" }])
       const result = await fetchLists({
         patronId: "12345",
-        sort: "modifiedDate",
+        sort: "modified_date_desc",
       })
       expect(mockClient.get).toHaveBeenCalledWith(
-        "/patrons/12345/lists?sort=modifiedDate"
+        "/patrons/12345/lists?sort=modified_date_desc"
       )
       expect(result).toEqual({
         status: 200,

--- a/src/types/listTypes.ts
+++ b/src/types/listTypes.ts
@@ -7,7 +7,7 @@ export interface ListErrorResponse {
 }
 
 export interface ListResult {
-  id: number
+  id: string
   listName: string
   patronId: string
   records: ListRecordResult[]

--- a/src/types/listTypes.ts
+++ b/src/types/listTypes.ts
@@ -21,3 +21,13 @@ export interface ListRecordResult {
   addedToListDate: string
   description: string
 }
+
+export type ListSort =
+  | "modified_date_desc"
+  | "modified_date_asc"
+  | "list_name_asc"
+  | "list_name_desc"
+  | "created_date_asc"
+  | "created_date_desc"
+  | "record_count_asc"
+  | "record_count_desc"

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -3,8 +3,8 @@
  * The allowed keys for the sort field and their respective labels
  */
 export const listSortOptions: Record<string, string> = {
-  count_desc: "Number of records (high to low)",
-  count_asc: "Number of records (low to high)",
+  record_count_desc: "Number of records (high to low)",
+  record_count_asc: "Number of records (low to high)",
   list_name_asc: "List name (A-Z)",
   list_name_desc: "List name (Z-A)",
   modified_date_desc: "Date modified (new to old)",

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -1,0 +1,14 @@
+/**
+ * listSortOptions
+ * The allowed keys for the sort field and their respective labels
+ */
+export const listSortOptions: Record<string, string> = {
+  count_desc: "Number of records (high to low)",
+  count_asc: "Number of records (low to high)",
+  list_name_asc: "List name (A-Z)",
+  list_name_desc: "List name (Z-A)",
+  modified_date_desc: "Date modified (new to old)",
+  modified_date_asc: "Date modified (old to new)",
+  created_date_desc: "Date created (new to old)",
+  created_date_asc: "Date created (old to new)",
+}

--- a/styles/components/MyAccount.module.scss
+++ b/styles/components/MyAccount.module.scss
@@ -136,6 +136,7 @@
 }
 
 .listTable {
+  font-size: 14px;
   thead > tr > th,
   thead > tr > th:last-of-type {
     vertical-align: top;

--- a/styles/components/MyAccount.module.scss
+++ b/styles/components/MyAccount.module.scss
@@ -137,6 +137,7 @@
 
 .listTable {
   font-size: 14px;
+  vertical-align: center;
   thead > tr > th,
   thead > tr > th:last-of-type {
     vertical-align: top;

--- a/styles/components/MyAccount.module.scss
+++ b/styles/components/MyAccount.module.scss
@@ -106,13 +106,44 @@
   }
 }
 
-.itemsTable {
+.accountItemsTable {
   thead > tr > th,
   thead > tr > th:last-of-type {
     vertical-align: top;
     text-transform: unset;
     font-weight: var(--nypl-fontWeights-bold);
     border-color: var(--nypl-colors-ui-gray-light-cool);
+    font-size: 16px;
+  }
+  tbody > tr > td,
+  tbody > tr > td:last-of-type {
+    border-color: var(--nypl-colors-ui-gray-light-cool);
+    width: var(--nypl-space-52);
+  }
+  tbody > tr > td:first-of-type {
+    width: var(--nypl-space-96);
+  }
+  tbody > tr > td:last-of-type {
+    width: var(--nypl-sizes-40);
+  }
+  @media only screen and (max-width: 600px) {
+    tbody > tr > td:first-of-type,
+    tbody > tr > td,
+    tbody > tr > td:last-of-type {
+      width: auto;
+    }
+  }
+}
+
+.listTable {
+  thead > tr > th,
+  thead > tr > th:last-of-type {
+    vertical-align: top;
+    text-transform: unset;
+    font-weight: var(--nypl-fontWeights-bold);
+    border-color: var(--nypl-colors-ui-gray-light-cool);
+    font-size: 14px;
+    text-transform: uppercase;
   }
   tbody > tr > td,
   tbody > tr > td:last-of-type {

--- a/styles/components/MyAccount.module.scss
+++ b/styles/components/MyAccount.module.scss
@@ -140,7 +140,6 @@
   thead > tr > th,
   thead > tr > th:last-of-type {
     vertical-align: top;
-    text-transform: unset;
     font-weight: var(--nypl-fontWeights-bold);
     border-color: var(--nypl-colors-ui-gray-light-cool);
     font-size: 14px;
@@ -149,14 +148,18 @@
   tbody > tr > td,
   tbody > tr > td:last-of-type {
     border-color: var(--nypl-colors-ui-gray-light-cool);
-    width: var(--nypl-space-52);
   }
-  tbody > tr > td:first-of-type {
-    width: var(--nypl-space-96);
+  thead > tr > th:last-of-type,
+  tbody > tr > td:last-of-type {
+    text-align: right;
   }
   tbody > tr > td:last-of-type {
-    width: var(--nypl-sizes-40);
+    padding-top: 8px;
   }
+  thead > tr > th:last-of-type {
+    padding-right: 24px;
+  }
+
   @media only screen and (max-width: 600px) {
     tbody > tr > td:first-of-type,
     tbody > tr > td,


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5245](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5245)

## This PR does the following:

- Establishes the lists tab, lists table 
- Sort menu and all list sorting functionality
- *** "Options" and "Create new list" buttons on this tab will not work yet ! Just placeholders
- ** *Eventual behavior is that all users will have at least one default list so right now if you log into an account with zero lists, the lists table still appears

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Test user barcode `23333094983077` has some example lists (message me for pw if you don't have it)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-5245]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ