### PR TITLE
SCC-5246: Single list display

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added series and genre to advanced search fields [SCC-5179](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5179)
 - Added lists API handlers [SCC-5243](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5243)
 - Added lists tab and all lists table [SCC-5245](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5245)
+- Added single list display [SCC-5246](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5246)
 
 ### Updated
 

--- a/pages/account/[[...index]].tsx
+++ b/pages/account/[[...index]].tsx
@@ -12,6 +12,7 @@ import { fetchLists } from "../../src/server/api/lists"
 import RCHead from "../../src/components/Head/RCHead"
 import TimedLogoutModal from "../../src/components/MyAccount/TimedLogoutModal"
 import { bootstrapConfig } from "../../lib/bootstrap"
+import { generateListSlug } from "../../src/utils/listUtils"
 
 interface MyAccountPropsType {
   accountData: MyAccountPatronData
@@ -130,11 +131,40 @@ export async function getServerSideProps({ req, res }) {
           tabsPath.startsWith(path)
         )
         if (tabsPath != matchedPath) {
-          return {
-            redirect: {
-              destination: "/account/" + matchedPath,
-              permanent: false,
-            },
+          if (!tabsPath.startsWith("lists/")) {
+            return {
+              redirect: {
+                destination: "/account/" + matchedPath,
+                permanent: false,
+              },
+            }
+          } else {
+            // Handle list URLs (match on the list ID)
+            const pathWithoutQuery = tabsPath.split("?")[0]
+            const listId = pathWithoutQuery.split("/")[1]
+            const list = lists?.find((l: any) => l.id === listId)
+            if (list) {
+              const slug = generateListSlug(list.name || list.listName)
+              const canonicalPath = `lists/${listId}${slug ? `/${slug}` : ""}`
+              if (pathWithoutQuery !== canonicalPath) {
+                const queryString = tabsPath.includes("?")
+                  ? `?${tabsPath.split("?")[1]}`
+                  : ""
+                return {
+                  redirect: {
+                    destination: `/account/${canonicalPath}${queryString}`,
+                    permanent: false,
+                  },
+                }
+              }
+            } else {
+              return {
+                redirect: {
+                  destination: "/account/lists",
+                  permanent: false,
+                },
+              }
+            }
           }
         }
       }
@@ -150,7 +180,7 @@ export async function getServerSideProps({ req, res }) {
           pickupLocations,
           lists,
         },
-        tabsPath,
+        tabsPath: tabsPath ? tabsPath.split("?")[0].split("/")[0] : null,
         isAuthenticated,
         renderAuthServerError: !redirectBasedOnNyplAccountRedirects,
       },
@@ -159,7 +189,7 @@ export async function getServerSideProps({ req, res }) {
     console.log(e.message)
     return {
       props: {
-        tabsPath,
+        tabsPath: tabsPath ? tabsPath.split("?")[0].split("/")[0] : null,
         isAuthenticated,
       },
     }

--- a/pages/account/[[...index]].tsx
+++ b/pages/account/[[...index]].tsx
@@ -144,7 +144,8 @@ export async function getServerSideProps({ req, res }) {
             const listId = pathWithoutQuery.split("/")[1]
             const list = lists?.find((l: any) => l.id === listId)
             if (list) {
-              const slug = generateListSlug(list.name || list.listName)
+              // Get a human-readable slug from the list's name and construct the id + slug URL
+              const slug = generateListSlug(list.listName)
               const canonicalPath = `lists/${listId}${slug ? `/${slug}` : ""}`
               if (pathWithoutQuery !== canonicalPath) {
                 const queryString = tabsPath.includes("?")
@@ -158,6 +159,7 @@ export async function getServerSideProps({ req, res }) {
                 }
               }
             } else {
+              // If the requested list ID does not exist in the user's account, fallback to all lists
               return {
                 redirect: {
                   destination: "/account/lists",

--- a/pages/api/account/lists/index.ts
+++ b/pages/api/account/lists/index.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next"
-import { fetchLists } from "../../../src/server/api/lists"
-import type { ListSort } from "../../../src/types/listTypes"
+import { fetchLists } from "../../../../src/server/api/lists"
+import type { ListSort } from "../../../../src/types/listTypes"
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/account/lists/records.ts
+++ b/pages/api/account/lists/records.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 import { fetchBibRecords } from "../../../../src/server/api/lists"
+import type { ListRecordsSort } from "../../../../src/types/listTypes"
 
 export default async function handler(
   req: NextApiRequest,
@@ -9,12 +10,12 @@ export default async function handler(
     return res.status(405).json({ error: "Method not allowed" })
   }
 
-  const { uris } = req.query
+  const { uris, sort } = req.query
 
   if (!uris || typeof uris !== "string") {
     return res.status(400).json({ error: "Missing or invalid uris" })
   }
 
-  const response = await fetchBibRecords(uris)
+  const response = await fetchBibRecords(uris, sort as ListRecordsSort)
   res.status(response.status || 200).json(response)
 }

--- a/pages/api/account/lists/records.ts
+++ b/pages/api/account/lists/records.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+import { fetchBibRecords } from "../../../../src/server/api/lists"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" })
+  }
+
+  const { uris } = req.query
+
+  if (!uris || typeof uris !== "string") {
+    return res.status(400).json({ error: "Missing or invalid uris" })
+  }
+
+  const response = await fetchBibRecords(uris)
+  res.status(response.status || 200).json(response)
+}

--- a/src/components/List/ManageListRecord.tsx
+++ b/src/components/List/ManageListRecord.tsx
@@ -1,0 +1,25 @@
+import { Button, Icon } from "@nypl/design-system-react-components"
+
+const ManageListRecord = () => {
+  return (
+    <Button variant="text">
+      <Icon align="left" size="medium">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <path
+            d="M17 3H7C5.9 3 5 3.9 5 5V21L12 18L19 21V5C19 3.9 18.1 3 17 3Z"
+            fill="#0069BF"
+          />
+        </svg>
+      </Icon>
+      Manage
+    </Button>
+  )
+}
+
+export default ManageListRecord

--- a/src/components/MyAccount/ListsTab/EmptyList.tsx
+++ b/src/components/MyAccount/ListsTab/EmptyList.tsx
@@ -1,0 +1,41 @@
+import { Text, Flex, Heading, Icon } from "@nypl/design-system-react-components"
+import Link from "../../Link/Link"
+
+const EmptyList = () => {
+  return (
+    <Flex
+      flexDir="column"
+      marginTop="xxxl"
+      marginBottom="xxl"
+      marginLeft="l"
+      marginRight="l"
+      alignItems="center"
+      justifyContent="center"
+      textAlign="center"
+    >
+      <Icon size="2xlarge">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="28"
+          height="36"
+          viewBox="0 0 28 36"
+          fill="none"
+        >
+          <path
+            d="M24 0C26.2 0 28 1.8 28 4V36L14 30L0 36V4C0 1.8 1.8 0 4 0H24ZM4 4V30L14 25.6396L24 30V4H4Z"
+            fill="#0069BF"
+          />
+        </svg>
+      </Icon>
+      <Heading level="h2" mt="s" mb="xs" size="heading5">
+        This list is currently empty
+      </Heading>
+      <Text mt="0" mb="0">
+        <Link href="/">Search the Research Catalog</Link> to find and save
+        records to lists
+      </Text>
+    </Flex>
+  )
+}
+
+export default EmptyList

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -1,9 +1,28 @@
-import { useContext } from "react"
-import { Box, Flex, Heading } from "@nypl/design-system-react-components"
+import { useContext, useRef, useState, useEffect } from "react"
+import {
+  Box,
+  Flex,
+  Heading,
+  Icon,
+  Pagination,
+  SkeletonLoader,
+  Table,
+  Text,
+} from "@nypl/design-system-react-components"
 import { PatronDataContext } from "../../../context/PatronDataContext"
+import styles from "../../../../styles/components/MyAccount.module.scss"
 import Link from "../../Link/Link"
 import type List from "../../../models/List"
 import { useRouter } from "next/router"
+import { idConstants, useFocusContext } from "../../../context/FocusContext"
+import { BASE_URL } from "../../../config/constants"
+import {
+  LIST_RECORDS_PER_PAGE,
+  listResultsHeading,
+  listSortOptions,
+} from "../../../utils/listUtils"
+import ListRecord from "../../../models/ListRecord"
+import ListSort from "./ListSort"
 
 const ListDisplay = ({ list }: { list?: List }) => {
   // Maybe..
@@ -13,18 +32,149 @@ const ListDisplay = ({ list }: { list?: List }) => {
 
   const router = useRouter()
 
+  const [listRecords, setListRecords] = useState<ListRecord[]>(
+    list?.records || []
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [currentPage, setCurrentPage] = useState(1)
+
+  useEffect(() => {
+    const fetchBibs = async () => {
+      if (!list || list.records.length === 0) return
+      setIsLoading(true)
+
+      const startIndex = (currentPage - 1) * LIST_RECORDS_PER_PAGE
+      const endIndex = startIndex + LIST_RECORDS_PER_PAGE
+      const pageRecords = list.records.slice(startIndex, endIndex)
+
+      const uris = pageRecords.map((r) => r.uri).join(",")
+      try {
+        const response = await fetch(
+          `${BASE_URL}/api/account/lists/records?uris=${uris}`
+        )
+        const data = await response.json()
+        if (data.bibData) {
+          const bibDataMap = data.bibData.reduce((acc: any, bib: any) => {
+            const bibResult = bib.result
+            const uri =
+              bibResult.uri ||
+              (bibResult["@id"] ? bibResult["@id"].substring(4) : "")
+            acc[uri] = bibResult
+            return acc
+          }, {})
+          const updatedRecords = pageRecords.map((record) => {
+            const bibData = bibDataMap[record.uri]
+            if (bibData) {
+              const updated = new ListRecord(
+                {
+                  uri: record.uri,
+                  addedToListDate: new Date().toISOString(),
+                } as any,
+                bibData
+              )
+              updated.addedDate = record.addedDate
+              return updated
+            }
+            return record
+          })
+          setListRecords(updatedRecords)
+        }
+      } catch (error) {
+        console.error("Error fetching bib data for list:", error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchBibs()
+  }, [list, currentPage])
+
+  const separatingDot = (i) => (
+    // @ts-ignore
+    <Icon key={`dot-${i}`} size="xxsmall" ml="xs" mr="xs" pb="xxs">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="4"
+        height="4"
+        viewBox="0 0 4 4"
+        fill="#000"
+      >
+        <circle cx="2" cy="2" r="2" fill="#000" />
+      </svg>
+    </Icon>
+  )
+  const metadata = [
+    `${list.recordCount} record${list.records.length === 1 ? "" : "s"}`,
+    `Last modified on ${list.modifiedDate}`,
+    `Created on ${list.createdDate}`,
+  ].filter(Boolean)
+
+  const joinedMetadata = metadata.reduce((acc, piece, i) => {
+    if (i > 0) acc.push(separatingDot(i))
+    acc.push(<Text key={i}>{piece}</Text>)
+    return acc
+  }, [])
+
+  const { setPersistentFocus } = useFocusContext()
+  const sortMenuRef = useRef<HTMLDivElement | null>(null)
+  const [activeSort, setActiveSort] = useState("added_date_desc")
+
+  const handleSortChange = async (selectedSortOption: string) => {
+    try {
+      //uhh
+    } catch (error) {
+      console.error("Error sorting lists:", error)
+    }
+    setActiveSort(selectedSortOption)
+    setPersistentFocus(idConstants.listsSort)
+  }
+
+  const tableData = listRecords.map((record: ListRecord) => {
+    return [
+      <>
+        <Link isUnderlined={false} href={`/bib/${record.uri}`} key={record.uri}>
+          {record.title}
+        </Link>{" "}
+        {record.itemCount > 1 && `(${record.itemCount} items)`}
+      </>,
+      record.callNumber,
+      record.location,
+      record.addedDate,
+      "Manage",
+    ]
+  })
+
+  const loader = (
+    <SkeletonLoader
+      showImage={false}
+      mb="m"
+      ml="0"
+      maxWidth="900px"
+      contentSize={5}
+      showHeading={false}
+    />
+  )
+
   return (
     <Flex flexDir="column">
-      <Box mb="l">
+      <Box mt="l" mb="l">
         <Link
-          variant="backwards"
+          isUnderlined={false}
           href="/account/lists"
           onClick={(e: any) => {
             e.preventDefault()
             router.push("/account/lists", undefined, { shallow: true })
           }}
         >
-          Back to all lists
+          <Icon
+            iconRotation="rotate90"
+            name="arrow"
+            size="xsmall"
+            align="right"
+            color="ui.link.primary"
+          />
+          <Box as="span" ml="xs">
+            Back to all lists
+          </Box>
         </Link>
       </Box>
       {list ? (
@@ -32,12 +182,82 @@ const ListDisplay = ({ list }: { list?: List }) => {
           <Heading level="h2" size="heading3">
             {list.listName}
           </Heading>
-          {list.description && (
-            <Box mb="m" color="ui.gray.dark">
+          <Box
+            mt="xs"
+            sx={{
+              p: {
+                display: "inline-block",
+              },
+            }}
+          >
+            {joinedMetadata}
+          </Box>
+          {list.description ? (
+            <Box as="span" mt="m">
               {list.description}
             </Box>
+          ) : (
+            <Box as="span" mt="m" color="ui.gray.dark" fontStyle="italic">
+              No description
+            </Box>
           )}
-          <Box mt="m"></Box>
+          <Flex
+            mt="m"
+            mb="xs"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Heading level="h3" size="heading6">
+              {listResultsHeading(list, currentPage)}
+            </Heading>
+            <ListSort
+              ref={sortMenuRef}
+              selectedValue={activeSort}
+              sortOptions={listSortOptions}
+              handleSortChange={handleSortChange}
+            />
+          </Flex>
+          {isLoading ? (
+            loader
+          ) : (
+            <Box display="grid">
+              <Table
+                className={styles.listTable}
+                columnHeaders={[
+                  "Title",
+                  "Call number",
+                  "Location",
+                  "Date added",
+                  "Action",
+                ]}
+                columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
+                columnStyles={[
+                  { width: 608, minWidth: 240 },
+                  { width: 192, minWidth: 120 },
+                  { width: 192, minWidth: 120 },
+                  { width: "auto", minWidth: 120 },
+                  { width: 128, minWidth: 128 },
+                ]}
+                tableData={tableData}
+                isScrollable
+                showRowDividers
+                my={{ base: 0, md: "s" }}
+                data-testid="list-records-table"
+              />
+              {list.records.length > LIST_RECORDS_PER_PAGE && (
+                <Pagination
+                  id="list-records-pagination"
+                  mt="l"
+                  initialPage={currentPage}
+                  currentPage={currentPage}
+                  pageCount={Math.ceil(
+                    list.records.length / LIST_RECORDS_PER_PAGE
+                  )}
+                  onPageChange={(page) => setCurrentPage(page)}
+                />
+              )}
+            </Box>
+          )}
         </>
       ) : (
         <Box>There was an error accessing your list.</Box>

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -1,95 +1,21 @@
-import { useContext, useRef, useState, useEffect } from "react"
 import {
   Box,
   Flex,
   Heading,
   Icon,
-  Pagination,
-  SkeletonLoader,
-  Table,
   Text,
 } from "@nypl/design-system-react-components"
-import { PatronDataContext } from "../../../context/PatronDataContext"
-import styles from "../../../../styles/components/MyAccount.module.scss"
 import Link from "../../Link/Link"
 import type List from "../../../models/List"
 import { useRouter } from "next/router"
-import { idConstants, useFocusContext } from "../../../context/FocusContext"
-import { BASE_URL } from "../../../config/constants"
-import {
-  LIST_RECORDS_PER_PAGE,
-  listResultsHeading,
-  listSortOptions,
-} from "../../../utils/listUtils"
-import ListRecord from "../../../models/ListRecord"
-import ListSort from "./ListSort"
+import { useFocusContext } from "../../../context/FocusContext"
 import ListOptions from "./ListOptions"
 import EmptyList from "./EmptyList"
+import ListRecordsTable from "./ListRecordsTable"
 
 const ListDisplay = ({ list }: { list?: List }) => {
-  // Maybe..
-  const {
-    updatedAccountData: { lists: listResults, patron },
-  } = useContext(PatronDataContext)
-
   const router = useRouter()
-  const listRecordsHeadingRef = useRef(null)
-
-  const [listRecords, setListRecords] = useState<ListRecord[]>(
-    list?.records || []
-  )
-  const [isLoading, setIsLoading] = useState(false)
-  const [currentPage, setCurrentPage] = useState(1)
-
-  useEffect(() => {
-    const fetchBibs = async () => {
-      if (!list || list.records.length === 0) return
-      setIsLoading(true)
-
-      const startIndex = (currentPage - 1) * LIST_RECORDS_PER_PAGE
-      const endIndex = startIndex + LIST_RECORDS_PER_PAGE
-      const pageRecords = list.records.slice(startIndex, endIndex)
-
-      const uris = pageRecords.map((r) => r.uri).join(",")
-      try {
-        const response = await fetch(
-          `${BASE_URL}/api/account/lists/records?uris=${uris}`
-        )
-        const data = await response.json()
-        if (data.bibData) {
-          const bibDataMap = data.bibData.reduce((acc: any, bib: any) => {
-            const bibResult = bib.result
-            const uri =
-              bibResult.uri ||
-              (bibResult["@id"] ? bibResult["@id"].substring(4) : "")
-            acc[uri] = bibResult
-            return acc
-          }, {})
-          const updatedRecords = pageRecords.map((record) => {
-            const bibData = bibDataMap[record.uri]
-            if (bibData) {
-              const updated = new ListRecord(
-                {
-                  uri: record.uri,
-                  addedToListDate: new Date().toISOString(),
-                } as any,
-                bibData
-              )
-              updated.addedDate = record.addedDate
-              return updated
-            }
-            return record
-          })
-          setListRecords(updatedRecords)
-        }
-      } catch (error) {
-        console.error("Error fetching bib data for list:", error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    fetchBibs()
-  }, [list, currentPage])
+  const { setPersistentFocus } = useFocusContext()
 
   const separatingDot = (i) => (
     // @ts-ignore
@@ -117,51 +43,6 @@ const ListDisplay = ({ list }: { list?: List }) => {
     return acc
   }, [])
 
-  const { setPersistentFocus } = useFocusContext()
-  const sortMenuRef = useRef<HTMLDivElement | null>(null)
-  const [activeSort, setActiveSort] = useState("added_date_desc")
-
-  const handleSortChange = async (selectedSortOption: string) => {
-    try {
-      //uhh
-    } catch (error) {
-      console.error("Error sorting lists:", error)
-    }
-    setActiveSort(selectedSortOption)
-    setPersistentFocus(idConstants.listsSort)
-  }
-
-  const handlePageChange = async (page: number) => {
-    setCurrentPage(page)
-    setPersistentFocus(idConstants.listRecordsHeading)
-  }
-
-  const tableData = listRecords.map((record: ListRecord) => {
-    return [
-      <>
-        <Link isUnderlined={false} href={`/bib/${record.uri}`} key={record.uri}>
-          {record.title}
-        </Link>{" "}
-        {record.itemCount > 1 && `(${record.itemCount} items)`}
-      </>,
-      record.callNumber,
-      record.location,
-      record.addedDate,
-      "Manage",
-    ]
-  })
-
-  const loader = (
-    <SkeletonLoader
-      showImage={false}
-      mb="m"
-      ml="0"
-      maxWidth="900px"
-      contentSize={5}
-      showHeading={false}
-    />
-  )
-
   return (
     <Flex flexDir="column">
       <Box mt="l" mb="l">
@@ -171,7 +52,14 @@ const ListDisplay = ({ list }: { list?: List }) => {
           onClick={(e: any) => {
             e.preventDefault()
             setPersistentFocus(null)
-            router.push("/account/lists", undefined, { shallow: true })
+            router.push(
+              {
+                pathname: "/account/[[...index]]",
+                query: { index: ["lists"] },
+              },
+              "/account/lists",
+              { shallow: true }
+            )
           }}
         >
           <Icon
@@ -212,73 +100,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
         <ListOptions />
       </Flex>
       {list.records.length > 0 ? (
-        <>
-          <Flex
-            mt="m"
-            mb="xs"
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Heading
-              level="h3"
-              size="heading6"
-              id="list-records-heading"
-              tabIndex={-1}
-              ref={listRecordsHeadingRef}
-              aria-live="polite"
-              pr="m"
-            >
-              {listResultsHeading(list, currentPage)}
-            </Heading>
-            <ListSort
-              ref={sortMenuRef}
-              selectedValue={activeSort}
-              sortOptions={listSortOptions}
-              handleSortChange={handleSortChange}
-            />
-          </Flex>
-          {isLoading ? (
-            loader
-          ) : (
-            <Box display="grid">
-              <Table
-                className={styles.listTable}
-                columnHeaders={[
-                  "Title",
-                  "Call number",
-                  "Location",
-                  "Date added",
-                  "Action",
-                ]}
-                columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
-                columnStyles={[
-                  { width: 608, minWidth: 240 },
-                  { width: 192, minWidth: 120 },
-                  { width: 192, minWidth: 120 },
-                  { width: "auto", minWidth: 120 },
-                  { width: 128, minWidth: 128 },
-                ]}
-                tableData={tableData}
-                isScrollable
-                showRowDividers
-                my={{ base: 0, md: "s" }}
-                data-testid="list-records-table"
-              />
-              {list.records.length > LIST_RECORDS_PER_PAGE && (
-                <Pagination
-                  id="list-records-pagination"
-                  mt="l"
-                  initialPage={currentPage}
-                  currentPage={currentPage}
-                  pageCount={Math.ceil(
-                    list.records.length / LIST_RECORDS_PER_PAGE
-                  )}
-                  onPageChange={handlePageChange}
-                />
-              )}
-            </Box>
-          )}
-        </>
+        <ListRecordsTable list={list} />
       ) : (
         <EmptyList />
       )}

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -1,0 +1,49 @@
+import { useContext } from "react"
+import { Box, Flex, Heading } from "@nypl/design-system-react-components"
+import { PatronDataContext } from "../../../context/PatronDataContext"
+import Link from "../../Link/Link"
+import type List from "../../../models/List"
+import { useRouter } from "next/router"
+
+const ListDisplay = ({ list }: { list?: List }) => {
+  // Maybe..
+  const {
+    updatedAccountData: { lists: listResults, patron },
+  } = useContext(PatronDataContext)
+
+  const router = useRouter()
+
+  return (
+    <Flex flexDir="column">
+      <Box mb="l">
+        <Link
+          variant="backwards"
+          href="/account/lists"
+          onClick={(e: any) => {
+            e.preventDefault()
+            router.push("/account/lists", undefined, { shallow: true })
+          }}
+        >
+          Back to all lists
+        </Link>
+      </Box>
+      {list ? (
+        <>
+          <Heading level="h2" size="heading3">
+            {list.listName}
+          </Heading>
+          {list.description && (
+            <Box mb="m" color="ui.gray.dark">
+              {list.description}
+            </Box>
+          )}
+          <Box mt="m"></Box>
+        </>
+      ) : (
+        <Box>There was an error accessing your list.</Box>
+      )}
+    </Flex>
+  )
+}
+
+export default ListDisplay

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -13,6 +13,8 @@ import ListOptions from "./ListOptions"
 import EmptyList from "./EmptyList"
 import ListRecordsTable from "./ListRecordsTable"
 
+/* ListDisplay renders the list metadata, list operations, and the ListRecordTable. */
+
 const ListDisplay = ({ list }: { list?: List }) => {
   const router = useRouter()
   const { setPersistentFocus } = useFocusContext()
@@ -32,7 +34,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
     </Icon>
   )
   const metadata = [
-    `${list.recordCount} record${list.records.length === 1 ? "" : "s"}`,
+    `${list.recordCount} record${list.recordCount === 1 ? "" : "s"}`,
     `Last modified on ${list.modifiedDate}`,
     `Created on ${list.createdDate}`,
   ].filter(Boolean)
@@ -99,11 +101,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
         )}
         <ListOptions />
       </Flex>
-      {list.records.length > 0 ? (
-        <ListRecordsTable list={list} />
-      ) : (
-        <EmptyList />
-      )}
+      {list.recordCount > 0 ? <ListRecordsTable list={list} /> : <EmptyList />}
     </Flex>
   )
 }

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -23,6 +23,8 @@ import {
 } from "../../../utils/listUtils"
 import ListRecord from "../../../models/ListRecord"
 import ListSort from "./ListSort"
+import ListOptions from "./ListOptions"
+import EmptyList from "./EmptyList"
 
 const ListDisplay = ({ list }: { list?: List }) => {
   // Maybe..
@@ -31,6 +33,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
   } = useContext(PatronDataContext)
 
   const router = useRouter()
+  const listRecordsHeadingRef = useRef(null)
 
   const [listRecords, setListRecords] = useState<ListRecord[]>(
     list?.records || []
@@ -128,6 +131,11 @@ const ListDisplay = ({ list }: { list?: List }) => {
     setPersistentFocus(idConstants.listsSort)
   }
 
+  const handlePageChange = async (page: number) => {
+    setCurrentPage(page)
+    setPersistentFocus(idConstants.listRecordsHeading)
+  }
+
   const tableData = listRecords.map((record: ListRecord) => {
     return [
       <>
@@ -162,6 +170,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
           href="/account/lists"
           onClick={(e: any) => {
             e.preventDefault()
+            setPersistentFocus(null)
             router.push("/account/lists", undefined, { shallow: true })
           }}
         >
@@ -172,42 +181,53 @@ const ListDisplay = ({ list }: { list?: List }) => {
             align="right"
             color="ui.link.primary"
           />
-          <Box as="span" ml="xs">
+          <Box as="span" ml="xs" fontSize="14px">
             Back to all lists
           </Box>
         </Link>
       </Box>
-      {list ? (
-        <>
-          <Heading level="h2" size="heading3">
-            {list.listName}
-          </Heading>
-          <Box
-            mt="xs"
-            sx={{
-              p: {
-                display: "inline-block",
-              },
-            }}
-          >
-            {joinedMetadata}
+      <Flex flexDir="column">
+        <Heading level="h2" size="heading3">
+          {list.listName}
+        </Heading>
+        <Box
+          mt="xs"
+          sx={{
+            p: {
+              display: "inline-block",
+            },
+          }}
+        >
+          {joinedMetadata}
+        </Box>
+        {list.description ? (
+          <Box as="span" mt="m">
+            {list.description}
           </Box>
-          {list.description ? (
-            <Box as="span" mt="m">
-              {list.description}
-            </Box>
-          ) : (
-            <Box as="span" mt="m" color="ui.gray.dark" fontStyle="italic">
-              No description
-            </Box>
-          )}
+        ) : (
+          <Box as="span" mt="m" color="ui.gray.dark" fontStyle="italic">
+            No description
+          </Box>
+        )}
+        <ListOptions />
+      </Flex>
+      {list.records.length > 0 ? (
+        <>
           <Flex
             mt="m"
             mb="xs"
             alignItems="center"
             justifyContent="space-between"
           >
-            <Heading level="h3" size="heading6">
+            <Heading
+              level="h3"
+              size="heading6"
+              id="list-records-heading"
+              tabIndex={-1}
+              ref={listRecordsHeadingRef}
+              aria-live="polite"
+              pr="m"
+            >
               {listResultsHeading(list, currentPage)}
             </Heading>
             <ListSort
@@ -253,14 +273,14 @@ const ListDisplay = ({ list }: { list?: List }) => {
                   pageCount={Math.ceil(
                     list.records.length / LIST_RECORDS_PER_PAGE
                   )}
-                  onPageChange={(page) => setCurrentPage(page)}
+                  onPageChange={handlePageChange}
                 />
               )}
             </Box>
           )}
         </>
       ) : (
-        <Box>There was an error accessing your list.</Box>
+        <EmptyList />
       )}
     </Flex>
   )

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -37,7 +37,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
     `${list.recordCount} record${list.recordCount === 1 ? "" : "s"}`,
     `Last modified on ${list.modifiedDate}`,
     `Created on ${list.createdDate}`,
-  ].filter(Boolean)
+  ]
 
   const joinedMetadata = metadata.reduce((acc, piece, i) => {
     if (i > 0) acc.push(separatingDot(i))

--- a/src/components/MyAccount/ListsTab/ListOptions.tsx
+++ b/src/components/MyAccount/ListsTab/ListOptions.tsx
@@ -1,0 +1,53 @@
+import { Button, ButtonGroup, Icon } from "@nypl/design-system-react-components"
+
+/**
+ * The ListOptions component renders the four list operation buttons displayed at the top of the single list view.
+ */
+const ListOptions = () => {
+  return (
+    <ButtonGroup mt="m">
+      <Button variant="secondary">
+        <Icon name="editorMode" align="left" size="medium" />
+        Edit
+      </Button>
+      <Button variant="secondary">
+        <Icon name="contentCopy" align="left" size="medium" />
+        Duplicate
+      </Button>
+      <Button variant="secondary">
+        <Icon align="left" size="medium">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+          >
+            <path
+              d="M15 9L13.9425 7.9425L9.75 12.1275V3H8.25V12.1275L4.065 7.935L3 9L9 15L15 9Z"
+              fill="#0069BF"
+            />
+          </svg>
+        </Icon>
+        Download
+      </Button>
+      <Button
+        variant="secondary"
+        sx={{
+          color: "ui.error.primary",
+          borderColor: "ui.error.primary",
+          _hover: {
+            color: "ui.error.primary",
+            borderColor: "ui.error.primary",
+            background: "ui.error.primary-05",
+          },
+        }}
+      >
+        <Icon name="actionDelete" align="left" size="medium" />
+        Delete
+      </Button>
+    </ButtonGroup>
+  )
+}
+
+export default ListOptions

--- a/src/components/MyAccount/ListsTab/ListOptionsModal.tsx
+++ b/src/components/MyAccount/ListsTab/ListOptionsModal.tsx
@@ -1,6 +1,10 @@
 import { Button, Flex, Icon } from "@nypl/design-system-react-components"
 import type List from "../../../models/List"
 
+/**
+ * The ListOptionsModal component renders the "Options" button and modal (with list operations)
+ *  displayed for each list in the user's lists table.
+ */
 const ListOptionsModal = ({ list }: { list: List }) => {
   return (
     <Flex justifyContent="flex-end" width="100%">

--- a/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
+++ b/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
@@ -1,0 +1,235 @@
+import {
+  SkeletonLoader,
+  Flex,
+  Heading,
+  Box,
+  Table,
+  Pagination,
+} from "@nypl/design-system-react-components"
+import { useRef, useState, useMemo, useEffect } from "react"
+import { BASE_URL } from "../../../config/constants"
+import { useFocusContext, idConstants } from "../../../context/FocusContext"
+import ListRecord from "../../../models/ListRecord"
+import {
+  LIST_RECORDS_PER_PAGE,
+  listResultsHeading,
+  listSortOptions,
+} from "../../../utils/listUtils"
+import ListSort from "./ListSort"
+import type List from "../../../models/List"
+import styles from "../../../../styles/components/MyAccount.module.scss"
+import Link from "../../Link/Link"
+
+// Merge list record data and sorted Discovery API bib data into sorted ListRecord array
+const buildListRecords = (
+  bibData: any[],
+  pageRecords: ListRecord[],
+  activeSort: string
+) => {
+  const pageRecordsMap = pageRecords.reduce((acc: any, record: any) => {
+    acc[record.uri] = record
+    return acc
+  }, {})
+
+  const updatedRecords = bibData.map((bib: any) => {
+    const bibResult = bib.result || bib
+    const uri =
+      bibResult.uri || (bibResult["@id"] ? bibResult["@id"].substring(4) : "")
+    const record = pageRecordsMap[uri] || { uri }
+    const updated = new ListRecord(
+      {
+        uri: record.uri,
+        addedToListDate: new Date().toISOString(),
+      } as any,
+      bibResult
+    )
+    updated.addedDate = record.addedDate
+    return updated
+  })
+
+  pageRecords.forEach((record) => {
+    if (!updatedRecords.find((r: any) => r.uri === record.uri)) {
+      updatedRecords.push(record)
+    }
+  })
+
+  // Sort by added date directly, not using Discovery API bib data
+  if (activeSort.includes("added_date")) {
+    updatedRecords.sort((a, b) => {
+      const indexA = pageRecords.findIndex((r) => r.uri === a.uri)
+      const indexB = pageRecords.findIndex((r) => r.uri === b.uri)
+      return indexA - indexB
+    })
+  }
+
+  return updatedRecords
+}
+
+const ListRecordsTable = ({ list }: { list: List }) => {
+  const listRecordsHeadingRef = useRef(null)
+  const { setPersistentFocus } = useFocusContext()
+  const sortMenuRef = useRef<HTMLDivElement | null>(null)
+  const [activeSort, setActiveSort] = useState("added_date_asc")
+
+  const [listRecords, setListRecords] = useState<ListRecord[]>(
+    list?.records || []
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const sortedRecords = useMemo(() => {
+    if (!list?.records) return []
+    const records = [...list.records]
+    if (activeSort === "added_date_asc") {
+      return records.reverse()
+    }
+    return records
+  }, [list, activeSort])
+
+  useEffect(() => {
+    const fetchBibData = async () => {
+      if (!list || sortedRecords.length === 0) return
+      setIsLoading(true)
+
+      const isLocalSort = activeSort.includes("added_date")
+      const startIndex = (currentPage - 1) * LIST_RECORDS_PER_PAGE
+      const endIndex = startIndex + LIST_RECORDS_PER_PAGE
+
+      // If sorting by title/author, fetch ALL records so the Discovery API can sort globally
+      // otherwise: sorting by date added, only need to fetch the 20 records for the current page
+      const recordsToFetch = isLocalSort
+        ? sortedRecords.slice(startIndex, endIndex)
+        : sortedRecords
+
+      const uris = recordsToFetch.map((r) => r.uri).join(",")
+
+      try {
+        const sortParam = isLocalSort ? "" : `&sort=${activeSort}`
+        const response = await fetch(
+          `${BASE_URL}/api/account/lists/records?uris=${uris}${sortParam}`
+        )
+        const data = await response.json()
+        if (data.bibData) {
+          let updatedRecords = buildListRecords(
+            data.bibData,
+            recordsToFetch,
+            activeSort
+          )
+
+          // slice out the current page to display if global fetch
+          if (!isLocalSort) {
+            updatedRecords = updatedRecords.slice(startIndex, endIndex)
+          }
+
+          setListRecords(updatedRecords)
+        }
+      } catch (error) {
+        console.error("Error fetching bib data for list:", error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchBibData()
+  }, [list, currentPage, activeSort, sortedRecords])
+
+  const handleSortChange = (selectedSortOption: string) => {
+    setActiveSort(selectedSortOption)
+    setCurrentPage(1)
+    setPersistentFocus(idConstants.listsSort)
+  }
+
+  const handlePageChange = async (page: number) => {
+    setCurrentPage(page)
+    setPersistentFocus(idConstants.listRecordsHeading)
+  }
+
+  const tableData = listRecords.map((record: ListRecord) => {
+    return [
+      <>
+        <Link isUnderlined={false} href={`/bib/${record.uri}`} key={record.uri}>
+          {record.title}
+        </Link>{" "}
+        {record.itemCount > 1 && `(${record.itemCount} items)`}
+      </>,
+      record.callNumber,
+      record.location,
+      record.addedDate,
+      "Manage",
+    ]
+  })
+
+  const loader = (
+    <SkeletonLoader
+      showImage={false}
+      mb="m"
+      ml="0"
+      maxWidth="1200px"
+      contentSize={5}
+      showHeading={false}
+    />
+  )
+  return (
+    <>
+      <Flex mt="m" mb="xs" alignItems="center" justifyContent="space-between">
+        <Heading
+          level="h3"
+          size="heading6"
+          id="list-records-heading"
+          tabIndex={-1}
+          ref={listRecordsHeadingRef}
+          aria-live="polite"
+          pr="m"
+        >
+          {listResultsHeading(list, currentPage)}
+        </Heading>
+        <ListSort
+          ref={sortMenuRef}
+          selectedValue={activeSort}
+          sortOptions={listSortOptions}
+          handleSortChange={handleSortChange}
+        />
+      </Flex>
+      {isLoading ? (
+        loader
+      ) : (
+        <Box display="grid">
+          <Table
+            className={styles.listTable}
+            columnHeaders={[
+              "Title",
+              "Call number",
+              "Location",
+              "Date added",
+              "Action",
+            ]}
+            columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
+            columnStyles={[
+              { width: 608, minWidth: 240 },
+              { width: 192, minWidth: 120 },
+              { width: 192, minWidth: 120 },
+              { width: "auto", minWidth: 120 },
+              { width: 128, minWidth: 128 },
+            ]}
+            tableData={tableData}
+            isScrollable
+            showRowDividers
+            my={{ base: 0, md: "s" }}
+            data-testid="list-records-table"
+          />
+          {list.records.length > LIST_RECORDS_PER_PAGE && (
+            <Pagination
+              id="list-records-pagination"
+              mt="l"
+              initialPage={currentPage}
+              currentPage={currentPage}
+              pageCount={Math.ceil(list.records.length / LIST_RECORDS_PER_PAGE)}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </Box>
+      )}
+    </>
+  )
+}
+
+export default ListRecordsTable

--- a/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
+++ b/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
@@ -9,61 +9,20 @@ import {
 import { useRef, useState, useMemo, useEffect } from "react"
 import { BASE_URL } from "../../../config/constants"
 import { useFocusContext, idConstants } from "../../../context/FocusContext"
-import ListRecord from "../../../models/ListRecord"
+import type ListRecord from "../../../models/ListRecord"
 import {
   LIST_RECORDS_PER_PAGE,
   listResultsHeading,
   listSortOptions,
+  buildListRecords,
 } from "../../../utils/listUtils"
 import ListSort from "./ListSort"
 import type List from "../../../models/List"
 import styles from "../../../../styles/components/MyAccount.module.scss"
 import Link from "../../Link/Link"
 
-// Merge list record data and sorted Discovery API bib data into sorted ListRecord array
-const buildListRecords = (
-  bibData: any[],
-  pageRecords: ListRecord[],
-  activeSort: string
-) => {
-  const pageRecordsMap = pageRecords.reduce((acc: any, record: any) => {
-    acc[record.uri] = record
-    return acc
-  }, {})
-
-  const updatedRecords = bibData.map((bib: any) => {
-    const bibResult = bib.result || bib
-    const uri =
-      bibResult.uri || (bibResult["@id"] ? bibResult["@id"].substring(4) : "")
-    const record = pageRecordsMap[uri] || { uri }
-    const updated = new ListRecord(
-      {
-        uri: record.uri,
-        addedToListDate: new Date().toISOString(),
-      } as any,
-      bibResult
-    )
-    updated.addedDate = record.addedDate
-    return updated
-  })
-
-  pageRecords.forEach((record) => {
-    if (!updatedRecords.find((r: any) => r.uri === record.uri)) {
-      updatedRecords.push(record)
-    }
-  })
-
-  // Sort by added date directly, not using Discovery API bib data
-  if (activeSort.includes("added_date")) {
-    updatedRecords.sort((a, b) => {
-      const indexA = pageRecords.findIndex((r) => r.uri === a.uri)
-      const indexB = pageRecords.findIndex((r) => r.uri === b.uri)
-      return indexA - indexB
-    })
-  }
-
-  return updatedRecords
-}
+/* The ListRecordsTable fetches corresponding bib data, merges it with the list records,
+ * sorts and paginates, and renders the results heading, sort menu, and table of records. */
 
 const ListRecordsTable = ({ list }: { list: List }) => {
   const listRecordsHeadingRef = useRef(null)
@@ -216,7 +175,7 @@ const ListRecordsTable = ({ list }: { list: List }) => {
             my={{ base: 0, md: "s" }}
             data-testid="list-records-table"
           />
-          {list.records.length > LIST_RECORDS_PER_PAGE && (
+          {list.recordCount > LIST_RECORDS_PER_PAGE && (
             <Pagination
               id="list-records-pagination"
               mt="l"

--- a/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
+++ b/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
@@ -45,6 +45,7 @@ const ListRecordsTable = ({ list }: { list: List }) => {
     return records
   }, [list, activeSort])
 
+  // TO DO: caching...
   useEffect(() => {
     const fetchBibData = async () => {
       if (!list || sortedRecords.length === 0) return
@@ -176,14 +177,19 @@ const ListRecordsTable = ({ list }: { list: List }) => {
             data-testid="list-records-table"
           />
           {list.recordCount > LIST_RECORDS_PER_PAGE && (
-            <Pagination
-              id="list-records-pagination"
-              mt="l"
-              initialPage={currentPage}
-              currentPage={currentPage}
-              pageCount={Math.ceil(list.records.length / LIST_RECORDS_PER_PAGE)}
-              onPageChange={handlePageChange}
-            />
+            <Flex justifyContent={{ base: "center", md: "flex-start" }}>
+              <Pagination
+                id="list-records-pagination"
+                mt="l"
+                width="auto"
+                initialPage={currentPage}
+                currentPage={currentPage}
+                pageCount={Math.ceil(
+                  list.records.length / LIST_RECORDS_PER_PAGE
+                )}
+                onPageChange={handlePageChange}
+              />
+            </Flex>
           )}
         </Box>
       )}

--- a/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
+++ b/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
@@ -131,7 +131,12 @@ const ListRecordsTable = ({ list }: { list: List }) => {
   )
   return (
     <>
-      <Flex mt="m" mb="xs" alignItems="center" justifyContent="space-between">
+      <Flex
+        mt="m"
+        mb={{ base: "s", md: "xs" }}
+        alignItems="center"
+        justifyContent="space-between"
+      >
         <Heading
           level="h3"
           size="heading6"
@@ -143,12 +148,14 @@ const ListRecordsTable = ({ list }: { list: List }) => {
         >
           {listResultsHeading(list, currentPage)}
         </Heading>
-        <ListSort
-          ref={sortMenuRef}
-          selectedValue={activeSort}
-          sortOptions={listSortOptions}
-          handleSortChange={handleSortChange}
-        />
+        <Box display={{ base: "none", sm: "flex" }}>
+          <ListSort
+            ref={sortMenuRef}
+            selectedValue={activeSort}
+            sortOptions={listSortOptions}
+            handleSortChange={handleSortChange}
+          />
+        </Box>
       </Flex>
       {isLoading ? (
         loader

--- a/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
+++ b/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
@@ -20,6 +20,7 @@ import ListSort from "./ListSort"
 import type List from "../../../models/List"
 import styles from "../../../../styles/components/MyAccount.module.scss"
 import Link from "../../Link/Link"
+import ManageListRecord from "../../List/ManageListRecord"
 
 /* The ListRecordsTable fetches corresponding bib data, merges it with the list records,
  * sorts and paginates, and renders the results heading, sort menu, and table of records. */
@@ -114,7 +115,7 @@ const ListRecordsTable = ({ list }: { list: List }) => {
       record.callNumber,
       record.location,
       record.addedDate,
-      "Manage",
+      <ManageListRecord key={record.uri} />,
     ]
   })
 
@@ -167,7 +168,7 @@ const ListRecordsTable = ({ list }: { list: List }) => {
               { width: 608, minWidth: 240 },
               { width: 192, minWidth: 120 },
               { width: 192, minWidth: 120 },
-              { width: "auto", minWidth: 120 },
+              { width: "auto", minWidth: 128 },
               { width: 128, minWidth: 128 },
             ]}
             tableData={tableData}

--- a/src/components/MyAccount/ListsTab/ListSort.tsx
+++ b/src/components/MyAccount/ListsTab/ListSort.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useEffect } from "react"
 import { idConstants, useFocusContext } from "../../../context/FocusContext"
 
 interface ListSortProps {
-  handleSortChange: (string) => Promise<void>
+  handleSortChange: (string) => Promise<void> | void
   selectedValue: string
   sortOptions: Record<string, string>
 }

--- a/src/components/MyAccount/ListsTab/ListSort.tsx
+++ b/src/components/MyAccount/ListsTab/ListSort.tsx
@@ -2,16 +2,16 @@ import { Box, Menu } from "@nypl/design-system-react-components"
 import { forwardRef, useEffect } from "react"
 import { idConstants, useFocusContext } from "../../../context/FocusContext"
 
-interface ListsSortProps {
+interface ListSortProps {
   handleSortChange: (string) => Promise<void>
   selectedValue: string
   sortOptions: Record<string, string>
 }
 
 /**
- * The ListsSort component renders a Menu component used for sorting a user's lists.
+ * The ListSort component renders a Menu component used for sorting a user's lists OR sorting the records in a list.
  */
-const ListsSort = forwardRef<HTMLDivElement, ListsSortProps>(
+const ListSort = forwardRef<HTMLDivElement, ListSortProps>(
   ({ handleSortChange, sortOptions, selectedValue }, ref) => {
     const { activeElementId } = useFocusContext()
 
@@ -57,6 +57,6 @@ const ListsSort = forwardRef<HTMLDivElement, ListsSortProps>(
   }
 )
 
-export default ListsSort
+export default ListSort
 
-ListsSort.displayName = "ListsSort"
+ListSort.displayName = "ListSort"

--- a/src/components/MyAccount/ListsTab/ListsDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListsDisplay.tsx
@@ -1,0 +1,126 @@
+import { useContext, useRef, useState, useEffect } from "react"
+import { Box, Flex, Table } from "@nypl/design-system-react-components"
+import { PatronDataContext } from "../../../context/PatronDataContext"
+import styles from "../../../../styles/components/MyAccount.module.scss"
+import List from "../../../models/List"
+import Link from "../../Link/Link"
+import ListsSort from "./ListsSort"
+import { idConstants, useFocusContext } from "../../../context/FocusContext"
+import { generateListSlug, listSortOptions } from "../../../utils/listUtils"
+import CreateListButton from "./CreateListButton"
+import ListOptionsModal from "./ListOptionsModal"
+import { BASE_URL } from "../../../config/constants"
+import { useRouter } from "next/router"
+
+const ListsDisplay = () => {
+  const {
+    updatedAccountData: { lists: listResults, patron },
+  } = useContext(PatronDataContext)
+
+  const router = useRouter()
+
+  const [lists, setLists] = useState(
+    listResults.map((list: any) => new List(list))
+  )
+
+  // Keep local lists in sync
+  useEffect(() => {
+    setLists(listResults.map((list: any) => new List(list)))
+  }, [listResults])
+
+  const { setPersistentFocus } = useFocusContext()
+  const sortMenuRef = useRef<HTMLDivElement | null>(null)
+  const [activeSort, setActiveSort] = useState("modified_date_desc")
+
+  const handleSortChange = async (selectedSortOption: string) => {
+    try {
+      const response = await fetch(
+        `${BASE_URL}/api/account/lists?patronId=${patron.id}&sort=${selectedSortOption}`
+      )
+      if (response.ok) {
+        const data = await response.json()
+        setLists(data.lists.map((list: any) => new List(list)))
+      }
+    } catch (error) {
+      console.error("Error sorting lists:", error)
+    }
+    setActiveSort(selectedSortOption)
+    setPersistentFocus(idConstants.listsSort)
+  }
+
+  const tableData = lists.map((list: List) => {
+    const slug = generateListSlug(list.listName)
+    const listUrl = `/account/lists/${list.id}${slug ? `/${slug}` : ""}`
+    return [
+      <Link
+        isUnderlined={false}
+        href={listUrl}
+        key={list.id}
+        onClick={(e: any) => {
+          e.preventDefault()
+          router.push(listUrl, undefined, { shallow: true })
+        }}
+      >
+        {list.listName}
+      </Link>,
+      list.description || (
+        <Box as="span" color="ui.gray.dark" fontStyle="italic">
+          No description
+        </Box>
+      ),
+      list.recordCount,
+      list.createdDate,
+      list.modifiedDate,
+      <ListOptionsModal key={list.id} list={list} />,
+    ]
+  })
+
+  return (
+    <Flex flexDir="column">
+      <Flex
+        flexDir={{ base: "column", sm: "row" }}
+        justifyContent="space-between"
+        mt="m"
+        mb="m"
+        gap="xs"
+      >
+        <CreateListButton />
+        <ListsSort
+          ref={sortMenuRef}
+          selectedValue={activeSort}
+          sortOptions={listSortOptions}
+          handleSortChange={handleSortChange}
+        />
+      </Flex>
+      <Box display="grid">
+        <Table
+          className={styles.listTable}
+          columnHeaders={[
+            "List name",
+            "List description",
+            "Records",
+            "Date created",
+            "Date modified",
+            "Action",
+          ]}
+          columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
+          columnStyles={[
+            { width: 320, minWidth: 240 },
+            { width: "auto", minWidth: 240 },
+            { width: 160, minWidth: 120 },
+            { width: 160, minWidth: 120 },
+            { width: 160, minWidth: 120 },
+            { width: 120, minWidth: 128 },
+          ]}
+          tableData={tableData}
+          isScrollable
+          showRowDividers
+          my={{ base: 0, md: "s" }}
+          data-testid="list-table"
+        />
+      </Box>
+    </Flex>
+  )
+}
+
+export default ListsDisplay

--- a/src/components/MyAccount/ListsTab/ListsDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListsDisplay.tsx
@@ -4,9 +4,9 @@ import { PatronDataContext } from "../../../context/PatronDataContext"
 import styles from "../../../../styles/components/MyAccount.module.scss"
 import List from "../../../models/List"
 import Link from "../../Link/Link"
-import ListsSort from "./ListsSort"
+import ListSort from "./ListSort"
 import { idConstants, useFocusContext } from "../../../context/FocusContext"
-import { generateListSlug, listSortOptions } from "../../../utils/listUtils"
+import { generateListSlug, listsSortOptions } from "../../../utils/listUtils"
 import CreateListButton from "./CreateListButton"
 import ListOptionsModal from "./ListOptionsModal"
 import { BASE_URL } from "../../../config/constants"
@@ -85,10 +85,10 @@ const ListsDisplay = () => {
         gap="xs"
       >
         <CreateListButton />
-        <ListsSort
+        <ListSort
           ref={sortMenuRef}
           selectedValue={activeSort}
-          sortOptions={listSortOptions}
+          sortOptions={listsSortOptions}
           handleSortChange={handleSortChange}
         />
       </Flex>

--- a/src/components/MyAccount/ListsTab/ListsDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListsDisplay.tsx
@@ -12,6 +12,7 @@ import ListOptionsModal from "./ListOptionsModal"
 import { BASE_URL } from "../../../config/constants"
 import { useRouter } from "next/router"
 
+/* ListsDisplay renders a sort menu and all of a user's lists in a table. */
 const ListsDisplay = () => {
   const {
     updatedAccountData: { lists: listResults, patron },
@@ -77,7 +78,7 @@ const ListsDisplay = () => {
           No description
         </Box>
       ),
-      list.recordCount,
+      list.recordCount.toString(),
       list.createdDate,
       list.modifiedDate,
       <ListOptionsModal key={list.id} list={list} />,

--- a/src/components/MyAccount/ListsTab/ListsDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListsDisplay.tsx
@@ -58,7 +58,16 @@ const ListsDisplay = () => {
         key={list.id}
         onClick={(e: any) => {
           e.preventDefault()
-          router.push(listUrl, undefined, { shallow: true })
+          const queryIndex = ["lists", list.id]
+          if (slug) queryIndex.push(slug)
+          router.push(
+            {
+              pathname: "/account/[[...index]]",
+              query: { index: queryIndex },
+            },
+            listUrl,
+            { shallow: true }
+          )
         }}
       >
         {list.listName}

--- a/src/components/MyAccount/ListsTab/ListsDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListsDisplay.tsx
@@ -104,7 +104,7 @@ const ListsDisplay = () => {
       </Flex>
       <Box display="grid">
         <Table
-          className={styles.listTable}
+          className={styles.listsTable}
           columnHeaders={[
             "List name",
             "List description",

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -84,7 +84,7 @@ describe("ListsTab", () => {
 
     const sortMenu = screen.getByLabelText("Sort by:", { exact: false })
     userEvent.click(sortMenu)
-    await userEvent.click(screen.getByText("List name (A-Z)"))
+    await userEvent.click(screen.getByText("List name (A - Z)"))
 
     expect(global.fetch).toHaveBeenCalledWith(
       `${BASE_URL}/api/account/lists?patronId=${processedPatron.id}&sort=list_name_asc`

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -8,6 +8,7 @@ import { BASE_URL } from "../../../config/constants"
 import { pickupLocations } from "../../../../__test__/fixtures/rawSierraAccountData"
 import { listsResponse } from "../../../../__test__/fixtures/listFixtures"
 import type { ListResult } from "../../../types/listTypes"
+import mockRouter from "next-router-mock"
 
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 
@@ -31,6 +32,7 @@ describe("ListsTab", () => {
   beforeEach(() => {
     window.localStorage.clear()
     jest.clearAllMocks()
+    mockRouter.query = { index: ["lists"] }
   })
 
   it("renders the create button and sort menu", () => {
@@ -95,5 +97,23 @@ describe("ListsTab", () => {
     // Now Spaghetti westerns should be in the first row
     expect(within(rows[1]).getByText("Spaghetti westerns")).toBeInTheDocument()
     expect(within(rows[2]).getByText("First list")).toBeInTheDocument()
+  })
+
+  it("renders a single list display when the URL matches", () => {
+    mockRouter.query = { index: ["lists", "123", "my-special-list"] }
+    const listsWithId123 = [
+      {
+        ...listsResponse[0],
+        id: "123",
+        listName: "My special list",
+        description: "A special description",
+      } as unknown as ListResult,
+    ]
+    renderWithPatronDataContext(listsWithId123)
+
+    expect(screen.getByText("Back to all lists")).toBeInTheDocument()
+    expect(screen.getByText("My special list")).toBeInTheDocument()
+    expect(screen.getByText("A special description")).toBeInTheDocument()
+    expect(screen.queryByText("Create new list")).not.toBeInTheDocument()
   })
 })

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -217,8 +217,8 @@ describe("ListsTab", () => {
     mockRouter.query = { index: ["lists", "123", "long-list"] }
     const records = Array.from({ length: 25 }, (_, i) => ({
       uri: `b${i}`,
-      addedDate: `01/01/2023`,
-      addedToListDate: `2023-01-01T12:00:00Z`,
+      addedDate: "01/01/2023",
+      addedToListDate: "2023-01-01T12:00:00Z",
     }))
 
     const longList = [

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -116,4 +116,165 @@ describe("ListsTab", () => {
     expect(screen.getByText("A special description")).toBeInTheDocument()
     expect(screen.queryByText("Create new list")).not.toBeInTheDocument()
   })
+
+  it("renders an empty list message when the list has no records", () => {
+    mockRouter.query = { index: ["lists", "123", "empty-list"] }
+    const emptyList = [
+      {
+        ...listsResponse[0],
+        id: "123",
+        listName: "Empty list",
+        recordCount: 0,
+        records: [],
+      } as unknown as ListResult,
+    ]
+    renderWithPatronDataContext(emptyList)
+
+    expect(screen.getByText("This list is currently empty")).toBeInTheDocument()
+    expect(screen.getByText(/Search the Research Catalog/)).toBeInTheDocument()
+  })
+
+  it("fetches and displays records in a single list", async () => {
+    mockRouter.query = { index: ["lists", "123", "my-list"] }
+    const listWithRecords = [
+      {
+        ...listsResponse[0],
+        id: "123",
+        listName: "My list",
+        recordCount: 2,
+        records: [
+          {
+            uri: "b123",
+            addedDate: "01/01/2023",
+            addedToListDate: "2023-01-01T12:00:00Z",
+          },
+          {
+            uri: "b456",
+            addedDate: "01/02/2023",
+            addedToListDate: "2023-01-02T12:00:00Z",
+          },
+        ],
+      } as unknown as ListResult,
+    ]
+
+    const mockBibData = {
+      bibData: [
+        {
+          result: {
+            uri: "b123",
+            titleDisplay: ["First Book"],
+            shelfMark: ["Call Number 1"],
+            location: "Location 1",
+            numItemsTotal: 1,
+          },
+        },
+        {
+          result: {
+            uri: "b456",
+            titleDisplay: ["Second Book"],
+            shelfMark: ["Call Number 2"],
+            location: "Location 2",
+            numItemsTotal: 2,
+          },
+        },
+      ],
+    }
+
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockBibData,
+    } as Response)
+
+    renderWithPatronDataContext(listWithRecords)
+
+    expect(screen.getByText("My list")).toBeInTheDocument()
+    expect(
+      screen.getByText("Sort by: Date added (new to old)")
+    ).toBeInTheDocument()
+
+    const table = await screen.findByTestId("list-records-table")
+    const rows = within(table).getAllByRole("row")
+
+    expect(rows.length).toBe(3)
+
+    expect(within(rows[1]).getByText("Second Book")).toBeInTheDocument()
+    expect(within(rows[1]).getByText("(2 items)")).toBeInTheDocument()
+    expect(within(rows[1]).getByText("Call Number 2")).toBeInTheDocument()
+    expect(within(rows[1]).getByText("Location 2")).toBeInTheDocument()
+    expect(within(rows[1]).getByText("1/2/2023")).toBeInTheDocument()
+
+    expect(within(rows[2]).getByText("First Book")).toBeInTheDocument()
+    expect(within(rows[2]).getByText("Call Number 1")).toBeInTheDocument()
+    expect(within(rows[2]).getByText("Location 1")).toBeInTheDocument()
+    expect(within(rows[2]).getByText("1/1/2023")).toBeInTheDocument()
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/api/account/lists/records?uris=b456,b123`
+    )
+  })
+
+  it("renders pagination when the list has more than 20 records", async () => {
+    mockRouter.query = { index: ["lists", "123", "long-list"] }
+    const records = Array.from({ length: 25 }, (_, i) => ({
+      uri: `b${i}`,
+      addedDate: `01/01/2023`,
+      addedToListDate: `2023-01-01T12:00:00Z`,
+    }))
+
+    const longList = [
+      {
+        ...listsResponse[0],
+        id: "123",
+        listName: "Long list",
+        recordCount: 25,
+        records,
+      } as unknown as ListResult,
+    ]
+
+    const mockBibData = {
+      bibData: Array.from({ length: 20 }, (_, i) => ({
+        result: {
+          uri: `b${i}`,
+          titleDisplay: [`Book ${i}`],
+        },
+      })),
+    }
+
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockBibData,
+    } as Response)
+
+    renderWithPatronDataContext(longList)
+
+    const table = await screen.findByTestId("list-records-table")
+    expect(table).toBeInTheDocument()
+
+    expect(
+      screen.getByText("Displaying 1-20 of 25 records")
+    ).toBeInTheDocument()
+  })
+
+  it("navigates back to all lists", async () => {
+    mockRouter.query = { index: ["lists", "123", "my-special-list"] }
+    mockRouter.asPath = "/account/lists/123/my-special-list"
+    const pushSpy = jest.spyOn(mockRouter, "push")
+    const listsWithId123 = [
+      {
+        ...listsResponse[0],
+        id: "123",
+        listName: "My special list",
+      } as unknown as ListResult,
+    ]
+    renderWithPatronDataContext(listsWithId123)
+
+    const backLink = screen.getByText("Back to all lists")
+    await userEvent.click(backLink)
+
+    expect(pushSpy).toHaveBeenCalledWith(
+      { pathname: "/account/[[...index]]", query: { index: ["lists"] } },
+      "/account/lists",
+      { shallow: true }
+    )
+  })
 })

--- a/src/components/MyAccount/ListsTab/ListsTab.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.tsx
@@ -8,7 +8,7 @@ import List from "../../../models/List"
 
 const ListsTab = () => {
   const {
-    updatedAccountData: { lists: listResults, patron },
+    updatedAccountData: { lists: listResults },
   } = useContext(PatronDataContext)
 
   const router = useRouter()

--- a/src/components/MyAccount/ListsTab/ListsTab.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.tsx
@@ -1,111 +1,29 @@
-import { useContext, useRef, useState, useEffect } from "react"
-import { Box, Flex, Table } from "@nypl/design-system-react-components"
+import { useContext, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
-import styles from "../../../../styles/components/MyAccount.module.scss"
+
+import { useRouter } from "next/router"
+import ListDisplay from "./ListDisplay"
+import ListsDisplay from "./ListsDisplay"
 import List from "../../../models/List"
-import Link from "../../Link/Link"
-import ListsSort from "./ListsSort"
-import { idConstants, useFocusContext } from "../../../context/FocusContext"
-import { listSortOptions } from "../../../utils/listUtils"
-import CreateListButton from "./CreateListButton"
-import ListOptionsModal from "./ListOptionsModal"
-import { BASE_URL } from "../../../config/constants"
 
 const ListsTab = () => {
   const {
     updatedAccountData: { lists: listResults, patron },
   } = useContext(PatronDataContext)
 
+  const router = useRouter()
+  const index = router.query.index as string[] | undefined
+  const isSingleList = index && index[0] === "lists" && index.length > 1
+  const listId = isSingleList ? index[1] : null
+
   const [lists, setLists] = useState(
     listResults.map((list: any) => new List(list))
   )
 
-  // Keep local lists in sync
-  useEffect(() => {
-    setLists(listResults.map((list: any) => new List(list)))
-  }, [listResults])
-
-  const tableData = lists.map((list: List) => [
-    <Link isUnderlined={false} href={`/account/lists/${list.id}`} key={list.id}>
-      {list.listName}
-    </Link>,
-    list.description || (
-      <Box as="span" color="ui.gray.dark" fontStyle="italic">
-        No description
-      </Box>
-    ),
-    list.recordCount,
-    list.createdDate,
-    list.modifiedDate,
-    <ListOptionsModal key={list.id} list={list} />,
-  ])
-
-  const { setPersistentFocus } = useFocusContext()
-  const sortMenuRef = useRef<HTMLDivElement | null>(null)
-  const [activeSort, setActiveSort] = useState("modified_date_desc")
-
-  const handleSortChange = async (selectedSortOption: string) => {
-    try {
-      const response = await fetch(
-        `${BASE_URL}/api/account/lists?patronId=${patron.id}&sort=${selectedSortOption}`
-      )
-      if (response.ok) {
-        const data = await response.json()
-        setLists(data.lists.map((list: any) => new List(list)))
-      }
-    } catch (error) {
-      console.error("Error sorting lists:", error)
-    }
-    setActiveSort(selectedSortOption)
-    setPersistentFocus(idConstants.listsSort)
-  }
-
-  return (
-    <Flex flexDir="column">
-      <Flex
-        flexDir={{ base: "column", sm: "row" }}
-        justifyContent="space-between"
-        mt="m"
-        mb="m"
-        gap="xs"
-      >
-        <CreateListButton />
-        <ListsSort
-          ref={sortMenuRef}
-          selectedValue={activeSort}
-          sortOptions={listSortOptions}
-          handleSortChange={handleSortChange}
-        />
-      </Flex>
-      <Box display="grid">
-        <Table
-          className={styles.listTable}
-          columnHeaders={[
-            "List name",
-            "List description",
-            "Records",
-            "Date created",
-            "Date modified",
-            "Action",
-          ]}
-          columnHeadersBackgroundColor={"ui.gray.x-light-cool"}
-          columnStyles={[
-            { width: 320, minWidth: 240 },
-            { width: "auto", minWidth: 240 },
-            { width: 160, minWidth: 120 },
-            { width: 160, minWidth: 120 },
-            { width: 160, minWidth: 120 },
-            { width: 120, minWidth: 128 },
-          ]}
-          tableData={tableData}
-          isScrollable
-          showRowDividers
-          my={{ base: 0, md: "s" }}
-          data-testid="list-table"
-        />
-      </Box>
-    </Flex>
-  )
+  if (isSingleList) {
+    const list = lists.find((l) => l.id === listId)
+    return <ListDisplay list={list} />
+  } else return <ListsDisplay />
 }
 
 export default ListsTab

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -36,6 +36,7 @@ export const idConstants = {
   dateFrom: "date-from",
   dateTo: "date-to",
   advancedSearchError: "advanced-search-error",
+  listRecordsHeading: "list-records-heading",
 }
 
 export const FocusProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/models/List.ts
+++ b/src/models/List.ts
@@ -11,7 +11,7 @@ export default class List {
   listName: string
   patronId: string
   records: ListRecord[]
-  recordCount: string
+  recordCount: number
   description: string | null
   createdDate: string
   modifiedDate: string
@@ -22,7 +22,7 @@ export default class List {
     this.description = result.description
     this.patronId = result.patronId
     this.records = this.buildRecordsFromListResult(result, bibDataMap)
-    this.recordCount = this.records.length.toString() || "0"
+    this.recordCount = this.records.length || 0
     this.createdDate = formatMMDDYYYY(result.createdDate)
     this.modifiedDate = formatMMDDYYYY(result.modifiedDate)
   }

--- a/src/models/ListRecord.ts
+++ b/src/models/ListRecord.ts
@@ -16,10 +16,11 @@ export default class ListRecord {
   constructor(result?: ListRecordResult, bibData?: any) {
     this.uri = result.uri
     this.addedDate = formatMMDDYYYY(result.addedToListDate)
-    this.title = bibData?.title || null
-    this.itemCount = bibData?.items?.length || 0
+    this.title = bibData?.titleDisplay?.[0] || bibData?.title?.[0] || null
+    this.itemCount = bibData?.numItemsTotal || bibData?.items?.length || 0
     // If bib level info is available:
-    this.callNumber = bibData?.callNumber || "Multiple"
+    this.callNumber =
+      bibData?.shelfMark?.[0] || bibData?.callNumber || "Multiple"
     this.location = bibData?.location || "Multiple"
   }
 }

--- a/src/server/api/lists.ts
+++ b/src/server/api/lists.ts
@@ -1,4 +1,4 @@
-import type { ListSort } from "../../types/listTypes"
+import type { ListSort, ListRecordsSort } from "../../types/listTypes"
 import { logServerError } from "../../utils/logUtils"
 import nyplApiClient from "../nyplApiClient"
 
@@ -242,10 +242,19 @@ export async function addRecordsToList({
  * Fetch Discovery API bib data for a set of list records.
  *
  * @param {string} uris - Comma separated string of URIs.
+ * @param {ListRecordsSort} [params.sort] - Optional sort parameter.
  * @returns {Promise<object>} - DiscoverySearchResultsElement[] of requested bibs.
  */
-export async function fetchBibRecords(uris: string) {
-  const path = `/discovery/resources?ids=${uris}`
+export async function fetchBibRecords(uris: string, sort?: ListRecordsSort) {
+  let path = `/discovery/resources?ids=${uris}`
+
+  if (sort) {
+    const parts = sort.split("_")
+    const order = parts.pop()
+    const sortBy = parts.join("_")
+    path += `&sort=${sortBy}&sort_direction=${order}`
+  }
+
   return callListsServiceAndHandleError({
     methodName: "fetchBibRecords",
     path,

--- a/src/server/api/lists.ts
+++ b/src/server/api/lists.ts
@@ -241,11 +241,11 @@ export async function addRecordsToList({
 /**
  * Fetch Discovery API bib data for a set of list records.
  *
- * @param {string[]} uris - An array of record URIs to fetch.
+ * @param {string} uris - Comma separated string of URIs.
  * @returns {Promise<object>} - DiscoverySearchResultsElement[] of requested bibs.
  */
-export async function fetchBibRecords(uris: string[]) {
-  const path = `/discovery/resources?ids=${uris.join(",")}`
+export async function fetchBibRecords(uris: string) {
+  const path = `/discovery/resources?ids=${uris}`
   return callListsServiceAndHandleError({
     methodName: "fetchBibRecords",
     path,

--- a/src/types/listTypes.ts
+++ b/src/types/listTypes.ts
@@ -31,3 +31,12 @@ export type ListSort =
   | "created_date_desc"
   | "record_count_asc"
   | "record_count_desc"
+
+export type ListRecordsSort =
+  | "modified_date_desc"
+  | "modified_date_asc"
+  | "title_asc"
+  | "title_desc"
+  | "callnumber_asc"
+  | "creator_desc"
+  | "creator_asc"

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -1,3 +1,5 @@
+import ListRecord from "../models/ListRecord"
+
 export const LIST_RECORDS_PER_PAGE = 20
 
 /**
@@ -38,7 +40,7 @@ export const generateListSlug = (name: string) => {
 }
 
 export const listResultsHeading = (list, currentPage) => {
-  const totalResults = list?.records.length || 0
+  const totalResults = list?.recordCount
   const resultsStart = (currentPage - 1) * LIST_RECORDS_PER_PAGE + 1
   const resultsEnd = Math.min(currentPage * LIST_RECORDS_PER_PAGE, totalResults)
   return `Displaying ${
@@ -46,4 +48,53 @@ export const listResultsHeading = (list, currentPage) => {
       ? `${resultsStart}-${resultsEnd} of ${totalResults.toLocaleString()}`
       : totalResults.toLocaleString()
   } item${totalResults === 1 ? "" : "s"}`
+}
+
+export const buildListRecords = (
+  bibData: any[],
+  pageRecords: ListRecord[],
+  activeSort: string
+): ListRecord[] => {
+  // Map of the page's list records keyed by their URI
+  const pageRecordsMap = pageRecords.reduce((acc: any, record: any) => {
+    acc[record.uri] = record
+    return acc
+  }, {})
+
+  // Map over the fetched bib data to instantiate ListRecords (preserve Discovery API sort order)
+  const updatedRecords = bibData.map((bib: any) => {
+    const bibResult = bib.result || bib
+    const uri =
+      bibResult.uri || (bibResult["@id"] ? bibResult["@id"].substring(4) : "")
+    const record = pageRecordsMap[uri] || { uri }
+    // Temp ListRecord
+    const updated = new ListRecord(
+      {
+        uri: record.uri,
+        addedToListDate: new Date().toISOString(),
+      } as any,
+      bibResult
+    )
+    // restore the addedDate
+    updated.addedDate = record.addedDate
+    return updated
+  })
+
+  // Append any records that Discovery API didn't return
+  pageRecords.forEach((record) => {
+    if (!updatedRecords.find((r: any) => r.uri === record.uri)) {
+      updatedRecords.push(record)
+    }
+  })
+
+  // Sort directly if added sort, don't use Discovery API bib sort
+  if (activeSort.includes("added_date")) {
+    updatedRecords.sort((a, b) => {
+      const indexA = pageRecords.findIndex((r) => r.uri === a.uri)
+      const indexB = pageRecords.findIndex((r) => r.uri === b.uri)
+      return indexA - indexB
+    })
+  }
+
+  return updatedRecords
 }

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -1,8 +1,10 @@
+export const LIST_RECORDS_PER_PAGE = 20
+
 /**
- * listSortOptions
- * The allowed keys for the sort field and their respective labels
+ * listsSortOptions
+ * The allowed sort keys for all lists
  */
-export const listSortOptions: Record<string, string> = {
+export const listsSortOptions: Record<string, string> = {
   record_count_desc: "Number of records (high to low)",
   record_count_asc: "Number of records (low to high)",
   list_name_asc: "List name (A-Z)",
@@ -13,10 +15,35 @@ export const listSortOptions: Record<string, string> = {
   created_date_asc: "Date created (old to new)",
 }
 
+/**
+ * listSortOptions
+ * The allowed sort keys for the records in a list
+ */
+export const listSortOptions: Record<string, string> = {
+  title_asc: "Title (A-Z)",
+  title_desc: "Title (Z-A)",
+  author_asc: "Author (A-Z)",
+  author_desc: "Author (Z-A)",
+  callnumber: "Call number",
+  added_date_desc: "Date added (new to old)",
+  added_date_asc: "Date added (old to new)",
+}
+
 export const generateListSlug = (name: string) => {
   if (!name) return ""
   return name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "")
+}
+
+export const listResultsHeading = (list, currentPage) => {
+  const totalResults = list?.records.length || 0
+  const resultsStart = (currentPage - 1) * LIST_RECORDS_PER_PAGE + 1
+  const resultsEnd = Math.min(currentPage * LIST_RECORDS_PER_PAGE, totalResults)
+  return `Displaying ${
+    totalResults > LIST_RECORDS_PER_PAGE
+      ? `${resultsStart}-${resultsEnd} of ${totalResults.toLocaleString()}`
+      : totalResults.toLocaleString()
+  } item${totalResults === 1 ? "" : "s"}`
 }

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -7,8 +7,8 @@ export const LIST_RECORDS_PER_PAGE = 20
 export const listsSortOptions: Record<string, string> = {
   record_count_desc: "Number of records (high to low)",
   record_count_asc: "Number of records (low to high)",
-  list_name_asc: "List name (A-Z)",
-  list_name_desc: "List name (Z-A)",
+  list_name_asc: "List name (A - Z)",
+  list_name_desc: "List name (Z - A)",
   modified_date_desc: "Date modified (new to old)",
   modified_date_asc: "Date modified (old to new)",
   created_date_desc: "Date created (new to old)",
@@ -20,13 +20,13 @@ export const listsSortOptions: Record<string, string> = {
  * The allowed sort keys for the records in a list
  */
 export const listSortOptions: Record<string, string> = {
-  title_asc: "Title (A-Z)",
-  title_desc: "Title (Z-A)",
-  author_asc: "Author (A-Z)",
-  author_desc: "Author (Z-A)",
-  callnumber: "Call number",
-  added_date_desc: "Date added (new to old)",
-  added_date_asc: "Date added (old to new)",
+  title_asc: "Title (A - Z)",
+  title_desc: "Title (Z - A)",
+  creator_asc: "Author (A - Z)",
+  creator_desc: "Author (Z - A)",
+  callnumber_asc: "Call number",
+  added_date_asc: "Date added (new to old)",
+  added_date_desc: "Date added (old to new)",
 }
 
 export const generateListSlug = (name: string) => {

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -12,3 +12,11 @@ export const listSortOptions: Record<string, string> = {
   created_date_desc: "Date created (new to old)",
   created_date_asc: "Date created (old to new)",
 }
+
+export const generateListSlug = (name: string) => {
+  if (!name) return ""
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+}

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -48,6 +48,12 @@ export const listResultsHeading = (list, currentPage) => {
   }`
 }
 
+/**
+ * Merges ListRecords from the user's account with their corresponding
+ * bib data from the Discovery API. It preserves the sort order
+ * returned by the Discovery API, handles missing bib data by appending
+ * those records to the end, and re-applies local sorting if sorting by "Date added".
+ */
 export const buildListRecords = (
   bibData: any[],
   pageRecords: ListRecord[],

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -43,11 +43,9 @@ export const listResultsHeading = (list, currentPage) => {
   const totalResults = list?.recordCount
   const resultsStart = (currentPage - 1) * LIST_RECORDS_PER_PAGE + 1
   const resultsEnd = Math.min(currentPage * LIST_RECORDS_PER_PAGE, totalResults)
-  return `Displaying ${
-    totalResults > LIST_RECORDS_PER_PAGE
-      ? `${resultsStart}-${resultsEnd} of ${totalResults.toLocaleString()}`
-      : totalResults.toLocaleString()
-  } item${totalResults === 1 ? "" : "s"}`
+  return `Displaying ${`${resultsStart}-${resultsEnd} of ${totalResults.toLocaleString()}`} record${
+    totalResults === 1 ? "" : "s"
+  }`
 }
 
 export const buildListRecords = (

--- a/styles/components/MyAccount.module.scss
+++ b/styles/components/MyAccount.module.scss
@@ -135,6 +135,41 @@
   }
 }
 
+.listsTable {
+  font-size: 14px;
+  vertical-align: center;
+  thead > tr > th,
+  thead > tr > th:last-of-type {
+    vertical-align: top;
+    font-weight: var(--nypl-fontWeights-bold);
+    border-color: var(--nypl-colors-ui-gray-light-cool);
+    font-size: 14px;
+    text-transform: uppercase;
+  }
+  tbody > tr > td,
+  tbody > tr > td:last-of-type {
+    border-color: var(--nypl-colors-ui-gray-light-cool);
+  }
+  thead > tr > th:last-of-type,
+  tbody > tr > td:last-of-type {
+    text-align: right;
+  }
+  tbody > tr > td:last-of-type {
+    padding-top: 8px;
+  }
+  thead > tr > th:last-of-type {
+    padding-right: 24px;
+  }
+
+  @media only screen and (max-width: 600px) {
+    tbody > tr > td:first-of-type,
+    tbody > tr > td,
+    tbody > tr > td:last-of-type {
+      width: auto;
+    }
+  }
+}
+
 .listTable {
   font-size: 14px;
   vertical-align: center;
@@ -156,6 +191,8 @@
   }
   tbody > tr > td:last-of-type {
     padding-top: 8px;
+    padding-right: 8px;
+    padding-bottom: 8px;
   }
   thead > tr > th:last-of-type {
     padding-right: 24px;


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5246](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5246)

## This PR does the following:

- Adds single list URL support within the My Account redirecting (see [AC](https://docs.google.com/document/d/1Lij_hWwC4j_ExNhXFuvJTTgX-KcyfX1u1VrZvvsRflU/edit?tab=t.0#heading=h.1nh2ayw6v9av)– using both the list ID and generating a slug from the title, but the the list ID should be enough to get you to the list. This may be iterated upon...)
- Adds empty list display
- Adds single list display + table
- Adds utils to smunge together the bib data and list record data into what we want
- Adds sorting for list records– again, splitting between what Discovery API can do (title, author, call number) and what Lists Service can do (date added)
- ** As previously, all CRUD buttons not working yet

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Test user barcode `23333094983077` has some example lists (message me for pw if you don't have it)!

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.


[SCC-5246]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ