### PR TITLE
Add default list handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added lists tab and all lists table [SCC-5245](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5245)
 - Added single list display [SCC-5246](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5246)
 - Added CRUD operations for lists [SCC-5247](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5247)
+- Added default list handling
 
 ### Updated
 

--- a/__test__/fixtures/listFixtures.ts
+++ b/__test__/fixtures/listFixtures.ts
@@ -38,11 +38,13 @@ export const processedLists: List[] = [
     modifiedDate: "4/15/2026",
     listName: "First list",
     description: null,
+    isDefaultList: true,
   },
   {
     id: "1234-cc-vv",
     patronId: "12345",
     recordCount: 1,
+    isDefaultList: false,
     records: [
       {
         uri: "b12404033",

--- a/src/components/MyAccount/ListsTab/ListActions/ListActionsButtons.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/ListActionsButtons.tsx
@@ -1,0 +1,69 @@
+import { Button, ButtonGroup, Icon } from "@nypl/design-system-react-components"
+import { EditListButton } from "./CreateEditList"
+import type { List } from "../../../../types/listTypes"
+
+/**
+ * The ListOptionsButtons component renders the four list operation buttons displayed at the top of the single list view.
+ */
+const ListOptionsButtons = ({
+  list,
+  setStatus,
+  setStatusMessage,
+  bannerRef,
+}: {
+  list: List
+  setStatus: any
+  setStatusMessage: any
+  bannerRef: any
+}) => {
+  return (
+    <ButtonGroup mt="m">
+      <EditListButton
+        list={list}
+        setStatus={setStatus}
+        setStatusMessage={setStatusMessage}
+        bannerRef={bannerRef}
+      />
+      <Button variant="secondary">
+        <Icon name="contentCopy" align="left" size="medium" />
+        Duplicate
+      </Button>
+      <Button variant="secondary">
+        <Icon align="left" size="medium">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+          >
+            <path
+              d="M15 9L13.9425 7.9425L9.75 12.1275V3H8.25V12.1275L4.065 7.935L3 9L9 15L15 9Z"
+              fill="#0069BF"
+            />
+          </svg>
+        </Icon>
+        Download
+      </Button>
+      {!list.isDefaultList && (
+        <Button
+          variant="secondary"
+          sx={{
+            color: "ui.error.primary",
+            borderColor: "ui.error.primary",
+            _hover: {
+              color: "ui.error.primary",
+              borderColor: "ui.error.primary",
+              background: "ui.error.primary-05",
+            },
+          }}
+        >
+          <Icon name="actionDelete" align="left" size="medium" />
+          Delete
+        </Button>
+      )}
+    </ButtonGroup>
+  )
+}
+
+export default ListOptionsButtons

--- a/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
@@ -100,17 +100,6 @@ const ListActionsMenu = ({
   const listOptions: ListItemsData[] = [
     {
       type: "action",
-      id: "edit",
-      label: "Edit",
-      media: { type: "icon", name: "editorMode" },
-      onClick: () => {
-        setStatus("")
-        setStatusMessage("")
-        openEdit()
-      },
-    },
-    {
-      type: "action",
       id: "duplicate",
       label: "Duplicate",
       media: { type: "icon", name: "contentCopy" },
@@ -175,6 +164,17 @@ const ListActionsMenu = ({
         setStatusMessage("")
         setModalProps(deleteListModalProps as ConfirmationModalProps)
         openModal()
+      },
+    })
+    listOptions.unshift({
+      type: "action",
+      id: "edit",
+      label: "Edit",
+      media: { type: "icon", name: "editorMode" },
+      onClick: () => {
+        setStatus("")
+        setStatusMessage("")
+        openEdit()
       },
     })
   }

--- a/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
@@ -162,7 +162,10 @@ const ListActionsMenu = ({
         downloadList(list, "modified_date_asc", setStatus, setStatusMessage)
       },
     },
-    {
+  ]
+
+  if (!list.isDefaultList) {
+    listOptions.push({
       type: "action",
       id: "delete",
       label: "Delete",
@@ -173,15 +176,19 @@ const ListActionsMenu = ({
         setModalProps(deleteListModalProps as ConfirmationModalProps)
         openModal()
       },
-    },
-  ]
+    })
+  }
 
   return (
     <>
       <Flex justifyContent="flex-end" width="100%">
         <Menu
           id="list-options-menu"
-          className={`${styles.listOptionsMenu} no-print`}
+          className={`${
+            list.isDefaultList
+              ? styles.defaultListOptionsMenu
+              : styles.listOptionsMenu
+          } no-print`}
           showLabel={false}
           showBorder={true}
           labelText="Options"

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -194,12 +194,14 @@ const ListDisplay = ({ list }: { list?: List }) => {
           </Box>
         )}
         <ButtonGroup mt="m">
-          <EditListButton
-            list={list}
-            bannerRef={bannerRef}
-            setStatus={setStatus}
-            setStatusMessage={setStatusMessage}
-          />
+          {!list.isDefaultList && (
+            <EditListButton
+              list={list}
+              bannerRef={bannerRef}
+              setStatus={setStatus}
+              setStatusMessage={setStatusMessage}
+            />
+          )}
           <Button
             variant="secondary"
             onClick={async () => {

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -278,27 +278,29 @@ const ListDisplay = ({ list }: { list?: List }) => {
             </Icon>
             Download
           </Button>
-          <Button
-            variant="secondary"
-            sx={{
-              color: "ui.error.primary",
-              borderColor: "ui.error.primary",
-              _hover: {
+          {!list.isDefaultList && (
+            <Button
+              variant="secondary"
+              sx={{
                 color: "ui.error.primary",
                 borderColor: "ui.error.primary",
-                background: "ui.error.primary-05",
-              },
-            }}
-            onClick={() => {
-              setStatus("")
-              setStatusMessage("")
-              setModalProps(deleteListModalProps as ConfirmationModalProps)
-              openModal()
-            }}
-          >
-            <Icon name="actionDelete" align="left" size="medium" />
-            Delete
-          </Button>
+                _hover: {
+                  color: "ui.error.primary",
+                  borderColor: "ui.error.primary",
+                  background: "ui.error.primary-05",
+                },
+              }}
+              onClick={() => {
+                setStatus("")
+                setStatusMessage("")
+                setModalProps(deleteListModalProps as ConfirmationModalProps)
+                openModal()
+              }}
+            >
+              <Icon name="actionDelete" align="left" size="medium" />
+              Delete
+            </Button>
+          )}
         </ButtonGroup>
         <Modal {...modalProps} />
         <div tabIndex={-1} ref={bannerRef} style={{ marginTop: "24px" }}>

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -276,7 +276,7 @@ describe("ListsTab", () => {
     )
   })
 
-  it("does not render the Delete option for the default list in the all lists view", async () => {
+  it("does not render the Delete or Edit options for the default list in the all lists view", async () => {
     const defaultList = {
       ...processedLists[0],
       id: "999",
@@ -289,12 +289,12 @@ describe("ListsTab", () => {
     const optionsMenuButton = screen.getByLabelText("Options")
     await userEvent.click(optionsMenuButton)
 
-    expect(screen.getByText("Edit")).toBeInTheDocument()
     expect(screen.getByText("Duplicate")).toBeInTheDocument()
     expect(screen.queryByText("Delete")).not.toBeInTheDocument()
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument()
   })
 
-  it("does not render the Delete button for the default list in the single list view", () => {
+  it("does not render the Delete or Edit buttons for the default list in the single list view", () => {
     mockRouter.query = { index: ["lists", "999", "my-workspace"] }
     const defaultList = {
       ...processedLists[0],
@@ -306,8 +306,8 @@ describe("ListsTab", () => {
     renderWithPatronDataContext([defaultList])
 
     expect(screen.getByText("My workspace")).toBeInTheDocument()
-    expect(screen.getByText("Edit")).toBeInTheDocument()
     expect(screen.getByText("Duplicate")).toBeInTheDocument()
     expect(screen.queryByText("Delete")).not.toBeInTheDocument()
+    expect(screen.getByText("Edit")).not.toBeInTheDocument()
   })
 })

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -308,6 +308,6 @@ describe("ListsTab", () => {
     expect(screen.getByText("My workspace")).toBeInTheDocument()
     expect(screen.getByText("Duplicate")).toBeInTheDocument()
     expect(screen.queryByText("Delete")).not.toBeInTheDocument()
-    expect(screen.getByText("Edit")).not.toBeInTheDocument()
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument()
   })
 })

--- a/src/components/MyAccount/ListsTab/ListsTab.test.tsx
+++ b/src/components/MyAccount/ListsTab/ListsTab.test.tsx
@@ -275,4 +275,39 @@ describe("ListsTab", () => {
       { shallow: true }
     )
   })
+
+  it("does not render the Delete option for the default list in the all lists view", async () => {
+    const defaultList = {
+      ...processedLists[0],
+      id: "999",
+      listName: "My workspace",
+      isDefaultList: true,
+    } as unknown as List
+
+    renderWithPatronDataContext([defaultList])
+
+    const optionsMenuButton = screen.getByLabelText("Options")
+    await userEvent.click(optionsMenuButton)
+
+    expect(screen.getByText("Edit")).toBeInTheDocument()
+    expect(screen.getByText("Duplicate")).toBeInTheDocument()
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument()
+  })
+
+  it("does not render the Delete button for the default list in the single list view", () => {
+    mockRouter.query = { index: ["lists", "999", "my-workspace"] }
+    const defaultList = {
+      ...processedLists[0],
+      id: "999",
+      listName: "My workspace",
+      isDefaultList: true,
+    } as unknown as List
+
+    renderWithPatronDataContext([defaultList])
+
+    expect(screen.getByText("My workspace")).toBeInTheDocument()
+    expect(screen.getByText("Edit")).toBeInTheDocument()
+    expect(screen.getByText("Duplicate")).toBeInTheDocument()
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument()
+  })
 })

--- a/src/models/MyAccount.ts
+++ b/src/models/MyAccount.ts
@@ -19,7 +19,7 @@ import { buildPatron, formatDate } from "../utils/myAccountUtils"
 import { getPickupLocations } from "../utils/pickupLocationsUtils"
 import type { List, ListRecord, ListResult } from "../types/listTypes"
 import { formatMMDDYYYY } from "../utils/dateUtils"
-import { fetchLists } from "../server/api/lists"
+import { fetchLists, createList } from "../server/api/lists"
 import { buildListRecordWithBibData } from "../utils/listUtils"
 
 class MyAccountModelError extends Error {
@@ -100,7 +100,35 @@ export default class MyAccount {
 
   async getLists(patronId) {
     const listsResult = await fetchLists({ patronId })
-    return this.buildLists(listsResult?.lists)
+    const lists = listsResult?.lists
+
+    // If patron has no lists, create their default list
+    if (lists && lists.length === 0) {
+      const createResult = await createList({
+        patronId,
+        listName: "My workspace (default list)",
+        description: "Default list- cannot be deleted",
+      })
+      if (createResult.status === 200 && createResult.list) {
+        lists.push(createResult.list)
+      }
+    }
+
+    const builtLists = this.buildLists(lists || [])
+
+    // Set the isDefaultList prop
+    if (lists && lists.length > 0) {
+      const defaultListId = lists.reduce((oldest, current) => {
+        const currentDate = new Date(current.createdDate).getTime()
+        const oldestDate = new Date(oldest.createdDate).getTime()
+        return currentDate < oldestDate ? current : oldest
+      }).id
+      builtLists.forEach((list) => {
+        list.isDefaultList = list.id === defaultListId
+      })
+    }
+
+    return builtLists
   }
 
   async fetchBibItemData(

--- a/src/types/listTypes.ts
+++ b/src/types/listTypes.ts
@@ -15,6 +15,7 @@ export interface List {
   description: string | null
   createdDate: string
   modifiedDate: string
+  isDefaultList?: boolean
 }
 
 export interface ListRecord {

--- a/styles/components/MyAccount.module.scss
+++ b/styles/components/MyAccount.module.scss
@@ -223,6 +223,14 @@
   }
 }
 
+.defaultListOptionsMenu {
+  [role="menuitem"] {
+    svg {
+      fill: var(--nypl-colors-ui-gray-dark);
+    }
+  }
+}
+
 .changeLocation {
   margin-bottom: 0;
   width: max-content;


### PR DESCRIPTION
## Ticket:

- no ticket just trying to split up Lists work into more bite sized chunks

## This PR does the following:

- Adds the default list to all user accounts and disables deletion and editing
- Note that for test users who already had list(s), their default undeletable list will be set as the oldest created one– no reason this should be an issue in production though (when lists are deployed, every user will have their default list created on login)
- An alternate way to handle this is by adding a `isDefaultList` field in ListsService instead of letting FE handle it but I'm not particularly pressed either way...


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Log in to a clean account (`webapplicant0`, message me for pw) and confirm that their one list is initialized with title "My workspace (default)" and is not deletable or editable (no option in the menu, no button in the single list view)

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
