### PR TITLE
Adding Lists context to search/bib

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added single list display [SCC-5246](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5246)
 - Added CRUD operations for lists [SCC-5247](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5247)
 - Added default list handling
+- Added lists context and manage bib button to search results/bib page
 
 ### Updated
 

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -13,6 +13,7 @@ jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 
 describe("Advanced search form", () => {
   beforeEach(async () => {
+    mockRouter.setCurrentUrl("/search/advanced")
     render(<AdvancedSearch isAuthenticated={true} />)
   })
   const submit = () => {
@@ -67,20 +68,12 @@ describe("Advanced search form", () => {
   }
   afterEach(async () => {
     await userEvent.click(screen.getByText("Clear fields"))
+    await delay(200)
   })
 
   it("displays alert when no fields are submitted", () => {
     submit()
     expect(screen.getByText(defaultEmptySearchErrorMessage)).toBeInTheDocument()
-  })
-
-  it("can set keyword, contributor, title, subject, genre, and series", async () => {
-    await updateAllFields()
-    submit()
-
-    expect(mockRouter.asPath).toBe(
-      "/search?q=spaghetti&title=il+amore+di+pasta&contributor=strega+nonna&callnumber=12345&standard_number=67890&subject=italian+food&genre=cookbooks&series=pasta+series&searched_from=advanced"
-    )
   })
   it("renders inputs for all text input fields", () => {
     textInputFields.map(({ label }) => {
@@ -89,13 +82,23 @@ describe("Advanced search form", () => {
     })
   })
 
+  it("can set keyword, contributor, title, subject, genre, and series", async () => {
+    await updateAllFields()
+    await delay(500)
+    submit()
+
+    expect(mockRouter.asPath).toBe(
+      "/search?q=spaghetti&title=il+amore+di+pasta&contributor=strega+nonna&callnumber=12345&standard_number=67890&subject=italian+food&genre=cookbooks&series=pasta+series&searched_from=advanced"
+    )
+  })
+
   it("defaults to call number sort when call number is the only field passed", async () => {
     const callNumberInput = screen.getByLabelText("Call number")
-    fireEvent.change(callNumberInput, { target: { value: "12345" } })
-    submit()
+    fireEvent.change(callNumberInput, { target: { value: "1234" } })
     await delay(500)
+    submit()
     expect(mockRouter.asPath).toBe(
-      "/search?q=&callnumber=12345&sort=callnumber&searched_from=advanced"
+      "/search?q=&callnumber=1234&sort=callnumber&searched_from=advanced"
     )
   })
 

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -92,8 +92,8 @@ describe("Advanced search form", () => {
   it("defaults to call number sort when call number is the only field passed", async () => {
     const callNumberInput = screen.getByLabelText("Call number")
     fireEvent.change(callNumberInput, { target: { value: "12345" } })
-    await delay(500)
     submit()
+    await delay(500)
     expect(mockRouter.asPath).toBe(
       "/search?q=&callnumber=12345&sort=callnumber&searched_from=advanced"
     )

--- a/pages/api/account/lists/records.ts
+++ b/pages/api/account/lists/records.ts
@@ -27,5 +27,14 @@ export default async function handler(
       patronId,
     })
     res.status(response.status || 200).json(response)
+  } else if (req.method === "DELETE") {
+    const response = await addRecordsToList({
+      records: uris,
+      listId,
+      patronId,
+    })
+    res.status(response.status || 200).json(response)
+  } else {
+    return res.status(405).json({ error: "Method not allowed" })
   }
 }

--- a/pages/api/account/lists/records.ts
+++ b/pages/api/account/lists/records.ts
@@ -1,21 +1,31 @@
 import type { NextApiRequest, NextApiResponse } from "next"
-import { fetchBibRecords } from "../../../../src/server/api/lists"
+import {
+  addRecordsToList,
+  fetchBibRecords,
+} from "../../../../src/server/api/lists"
 import type { ListRecordsSort } from "../../../../src/types/listTypes"
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method !== "GET") {
-    return res.status(405).json({ error: "Method not allowed" })
-  }
-
+  // Records requested in query for easy GETting, note that this flips the pattern of other list endpoints
   const { uris, sort } = req.query
+  const { listId, patronId } = req.body
 
   if (!uris || typeof uris !== "string") {
     return res.status(400).json({ error: "Missing or invalid uris" })
   }
 
-  const response = await fetchBibRecords(uris, sort as ListRecordsSort)
-  res.status(response.status || 200).json(response)
+  if (req.method === "GET") {
+    const response = await fetchBibRecords(uris, sort as ListRecordsSort)
+    res.status(response.status || 200).json(response)
+  } else if (req.method === "PATCH") {
+    const response = await addRecordsToList({
+      records: uris,
+      listId,
+      patronId,
+    })
+    res.status(response.status || 200).json(response)
+  }
 }

--- a/pages/api/account/lists/records.ts
+++ b/pages/api/account/lists/records.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 import {
   addRecordsToList,
+  deleteRecordFromList,
   fetchBibRecords,
 } from "../../../../src/server/api/lists"
 import type { ListRecordsSort } from "../../../../src/types/listTypes"
@@ -28,8 +29,8 @@ export default async function handler(
     })
     res.status(response.status || 200).json(response)
   } else if (req.method === "DELETE") {
-    const response = await addRecordsToList({
-      records: uris,
+    const response = await deleteRecordFromList({
+      record: uris,
       listId,
       patronId,
     })

--- a/pages/api/account/lists/records.ts
+++ b/pages/api/account/lists/records.ts
@@ -10,7 +10,9 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  // Records requested in query for easy GETting, note that this flips the pattern of other list endpoints
+  // Records requested in query for easy GETting.
+  // Note that this flips the pattern of other /lists endpoints,
+  // which indicate records in the body and the list ID in query params.
   const { uris, sort } = req.query
   const { listId, patronId } = req.body
 

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -50,6 +50,7 @@ import Link from "../../../src/components/Link/Link"
 import type { HTTPStatusCode } from "../../../src/types/appTypes"
 import PageError from "../../../src/components/Error/PageError"
 import UserGuideBanner from "../../../src/components/Banners/UserGuideBanner"
+import { ManageBibInList } from "../../../src/components/SearchResults/ManageBibInList"
 
 interface BibPropsType {
   discoveryBibResult: DiscoveryBibResult
@@ -236,9 +237,12 @@ export default function BibPage({
             Finding aid available
           </StatusBadge>
         )}
-        <Heading level="h2" size="heading3" mb="-m">
-          {bib.title}
-        </Heading>
+        <Flex flexDir="row" justifyContent="space-between" alignItems="center">
+          <Heading level="h2" size="heading3" mb="-m">
+            {bib.title}
+          </Heading>
+          <ManageBibInList bib={bib} isAuthenticated={isAuthenticated} />
+        </Flex>
         <BibDetails key="top-details" details={topDetails} />
         <Box mt="s">
           {findingAid && (

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -51,6 +51,8 @@ import type { HTTPStatusCode } from "../../../src/types/appTypes"
 import PageError from "../../../src/components/Error/PageError"
 import UserGuideBanner from "../../../src/components/Banners/UserGuideBanner"
 import { ManageBibInList } from "../../../src/components/SearchResults/ManageBibInList"
+import { PatronDataProvider } from "../../../src/context/PatronDataContext"
+import MyAccount from "../../../src/models/MyAccount"
 
 interface BibPropsType {
   discoveryBibResult: DiscoveryBibResult
@@ -59,6 +61,7 @@ interface BibPropsType {
   itemPage?: number
   viewAllItems?: boolean
   errorStatus?: HTTPStatusCode | null
+  accountData?: any
 }
 
 /**
@@ -71,6 +74,7 @@ export default function BibPage({
   itemPage = 1,
   viewAllItems = false,
   errorStatus = null,
+  accountData,
 }: BibPropsType) {
   const { push, query } = useRouter()
   const [bib, setBib] = useState(
@@ -226,7 +230,7 @@ export default function BibPage({
   }
 
   return (
-    <>
+    <PatronDataProvider value={accountData || null}>
       <RCHead metadataTitle={metadataTitle} />
       <Layout isAuthenticated={isAuthenticated} activePage="bib">
         <Box mb="l">
@@ -342,7 +346,7 @@ export default function BibPage({
                 width="max-content"
                 mt="s"
               >
-                View in legacy catalog
+                View in legacy catalog{" "}
               </Link>
             ) : null}
             <Link
@@ -357,7 +361,7 @@ export default function BibPage({
           </Flex>
         </Box>
       </Layout>
-    </>
+    </PatronDataProvider>
   )
 }
 
@@ -384,12 +388,22 @@ export async function getServerSideProps({ params, query, req }) {
       }
   }
 
+  let accountData = null
+  if (isAuthenticated) {
+    const patronId = patronTokenResponse.decodedPatron.sub
+    const accountModel = new MyAccount(null, patronId)
+    const lists = await accountModel.getLists(patronId)
+
+    accountData = { patron: { id: patronId }, lists }
+  }
+
   return {
     props: {
       discoveryBibResult: results.discoveryBibResult,
       annotatedMarc: results.annotatedMarc,
       isAuthenticated,
       itemPage: query.item_page ? parseInt(query.item_page) : 1,
+      accountData,
     },
   }
 }

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -1,5 +1,5 @@
 import type { SyntheticEvent } from "react"
-import { useState, useRef } from "react"
+import { useState, useRef, useEffect } from "react"
 import { useRouter } from "next/router"
 import {
   Heading,
@@ -53,6 +53,8 @@ import UserGuideBanner from "../../../src/components/Banners/UserGuideBanner"
 import { ManageBibInList } from "../../../src/components/SearchResults/ManageBibInList"
 import { PatronDataProvider } from "../../../src/context/PatronDataContext"
 import MyAccount from "../../../src/models/MyAccount"
+import type { StatusType } from "../../../src/components/MyAccount/Settings/StatusBanner"
+import { StatusBanner } from "../../../src/components/MyAccount/Settings/StatusBanner"
 
 interface BibPropsType {
   discoveryBibResult: DiscoveryBibResult
@@ -99,6 +101,18 @@ export default function BibPage({
   const itemTableHeadingRef = useRef<HTMLDivElement>(null)
   const viewAllLoadingTextRef = useRef<HTMLDivElement & HTMLLabelElement>(null)
   const controllerRef = useRef<AbortController>()
+
+  // Manage status banner display for list actions
+  const bannerRef = useRef<HTMLDivElement>(null)
+  const [status, setStatus] = useState<StatusType>("")
+  const [statusMessage, setStatusMessage] = useState<string>("")
+  useEffect(() => {
+    if (status !== "" && bannerRef.current) {
+      setTimeout(() => {
+        bannerRef.current?.focus()
+      }, 100)
+    }
+  }, [status])
 
   if (errorStatus) {
     return (
@@ -236,6 +250,15 @@ export default function BibPage({
         <Box mb="l">
           <UserGuideBanner />
         </Box>
+        <div
+          tabIndex={-1}
+          ref={bannerRef}
+          style={{ marginTop: "-16px", marginBottom: "32px" }}
+        >
+          {status !== "" && (
+            <StatusBanner status={status} statusMessage={statusMessage} />
+          )}
+        </div>
         {findingAid && (
           <StatusBadge mb="s" variant="informative">
             Finding aid available
@@ -245,7 +268,12 @@ export default function BibPage({
           <Heading level="h2" size="heading3" mb="-m">
             {bib.title}
           </Heading>
-          <ManageBibInList bib={bib} isAuthenticated={isAuthenticated} />
+          <ManageBibInList
+            setStatus={setStatus}
+            setStatusMessage={setStatusMessage}
+            bib={bib}
+            isAuthenticated={isAuthenticated}
+          />
         </Flex>
         <BibDetails key="top-details" details={topDetails} />
         <Box mt="s">
@@ -388,6 +416,7 @@ export async function getServerSideProps({ params, query, req }) {
       }
   }
 
+  // Get just patron and lists data
   let accountData = null
   if (isAuthenticated) {
     const patronId = patronTokenResponse.decodedPatron.sub

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -16,12 +16,15 @@ import { useFocusContext, idConstants } from "../../src/context/FocusContext"
 import type { HTTPStatusCode } from "../../src/types/appTypes"
 import Search from "../../src/components/Search/Search"
 import { appConfig } from "../../src/config/appConfig"
+import { PatronDataProvider } from "../../src/context/PatronDataContext"
+import MyAccount from "../../src/models/MyAccount"
 
 interface SearchPageProps {
   bannerNotification?: string
   results: SearchResultsResponse
   isAuthenticated: boolean
   errorStatus?: HTTPStatusCode | null
+  accountData?: any
 }
 
 /**
@@ -32,6 +35,7 @@ export default function SearchPage({
   results,
   isAuthenticated,
   errorStatus = null,
+  accountData,
 }: SearchPageProps) {
   const { push, query } = useRouter()
   // TODO: Move this to global context
@@ -64,17 +68,19 @@ export default function SearchPage({
   }
 
   return (
-    <Search
-      errorStatus={errorStatus}
-      results={results}
-      metadataTitle={`Search | ${SITE_NAME}`}
-      activePage="search"
-      bannerNotification={appConfig.searchNotification[appConfig.environment]}
-      isAuthenticated={isAuthenticated}
-      searchParams={searchParams}
-      handlePageChange={handlePageChange}
-      handleSortChange={handleSortChange}
-    />
+    <PatronDataProvider value={accountData || null}>
+      <Search
+        errorStatus={errorStatus}
+        results={results}
+        metadataTitle={`Search | ${SITE_NAME}`}
+        activePage="search"
+        bannerNotification={appConfig.searchNotification[appConfig.environment]}
+        isAuthenticated={isAuthenticated}
+        searchParams={searchParams}
+        handlePageChange={handlePageChange}
+        handleSortChange={handleSortChange}
+      />
+    </PatronDataProvider>
   )
 }
 
@@ -96,11 +102,22 @@ export async function getServerSideProps({ req, query }) {
 
   const isAuthenticated = patronTokenResponse.isTokenValid
 
+  // Get just patron and lists data
+  let accountData = null
+  if (isAuthenticated) {
+    const patronId = patronTokenResponse.decodedPatron.sub
+    const accountModel = new MyAccount(null, patronId)
+    const lists = await accountModel.getLists(patronId)
+
+    accountData = { patron: { id: patronId }, lists }
+  }
+
   return {
     props: {
       results,
       isAuthenticated,
       activePage: "search",
+      accountData,
     },
   }
 }

--- a/src/components/MyAccount/Settings/StatusBanner.tsx
+++ b/src/components/MyAccount/Settings/StatusBanner.tsx
@@ -27,7 +27,11 @@ const specificFailureContent = (statusMessage: string) => {
 }
 
 const specificSuccessContent = (statusMessage: string) => {
-  return <Text marginBottom={0}>{statusMessage}</Text>
+  if (typeof statusMessage === "string") {
+    return <Text marginBottom={0}>{statusMessage}</Text>
+  } else {
+    return statusMessage
+  }
 }
 
 const statusContent = (status, statusMessage) => {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -196,7 +196,13 @@ const Search = ({
             ) : (
               <SimpleGrid columns={1} id="search-results-list" gap="grid.s">
                 {searchResultBibs.map((bib: SearchResultsBib) => {
-                  return <SearchResult key={bib.id} bib={bib} />
+                  return (
+                    <SearchResult
+                      key={bib.id}
+                      bib={bib}
+                      isAuthenticated={isAuthenticated}
+                    />
+                  )
                 })}
               </SimpleGrid>
             )}

--- a/src/components/SearchResults/ManageBibInList.test.tsx
+++ b/src/components/SearchResults/ManageBibInList.test.tsx
@@ -1,0 +1,187 @@
+import React from "react"
+import { render, screen, waitFor } from "../../utils/testUtils"
+import userEvent from "@testing-library/user-event"
+import { ManageBibInList } from "./ManageBibInList"
+import { PatronDataContext } from "../../context/PatronDataContext"
+import { BASE_URL } from "../../config/constants"
+
+// Mocking window behavior
+const mockAssign = jest.fn()
+const mockReplaceState = jest.fn()
+
+Object.defineProperty(window, "location", {
+  value: {
+    href: "http://localhost/search",
+    pathname: "/search",
+    search: "",
+    hash: "",
+    assign: mockAssign,
+  },
+  writable: true,
+})
+
+Object.defineProperty(window, "history", {
+  value: {
+    replaceState: mockReplaceState,
+  },
+  writable: true,
+})
+
+const mockBib = { id: "b12345678" } as any
+
+describe("ManageBibInList", () => {
+  let mockSetStatus: jest.Mock
+  let mockSetStatusMessage: jest.Mock
+  let mockSetUpdatedAccountData: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSetStatus = jest.fn()
+    mockSetStatusMessage = jest.fn()
+    mockSetUpdatedAccountData = jest.fn()
+    window.location.search = ""
+  })
+
+  const renderWithContext = (lists: any[] = [], isAuthenticated = true) => {
+    const updatedAccountData = {
+      patron: { id: "12345" },
+      lists,
+    }
+
+    return render(
+      <PatronDataContext.Provider
+        value={
+          {
+            updatedAccountData,
+            setUpdatedAccountData: mockSetUpdatedAccountData,
+          } as any
+        }
+      >
+        <ManageBibInList
+          bib={mockBib}
+          isAuthenticated={isAuthenticated}
+          setStatus={mockSetStatus}
+          setStatusMessage={mockSetStatusMessage}
+        />
+      </PatronDataContext.Provider>
+    )
+  }
+
+  it("renders 'Save' when the user is not authenticated", () => {
+    renderWithContext([], false)
+    expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument()
+  })
+
+  it("renders 'Save' when the user is authenticated but the record is not in any list", () => {
+    renderWithContext([{ id: "list-1", isDefaultList: true, records: [] }])
+    expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument()
+  })
+
+  it("renders 'Remove' when the user is authenticated, has only the default list, and the record is saved", () => {
+    renderWithContext([
+      { id: "list-1", isDefaultList: true, records: [{ uri: "b12345678" }] },
+    ])
+    expect(screen.getByRole("button", { name: /Remove/i })).toBeInTheDocument()
+  })
+
+  it("renders 'Manage' when the user is authenticated, has multiple lists, and the record is saved", () => {
+    renderWithContext([
+      { id: "list-1", isDefaultList: true, records: [{ uri: "b12345678" }] },
+      { id: "list-2", isDefaultList: false, records: [] },
+    ])
+    expect(screen.getByRole("button", { name: /Manage/i })).toBeInTheDocument()
+  })
+
+  it("redirects to login when unauthenticated user clicks the button", async () => {
+    renderWithContext([], false)
+    await userEvent.click(screen.getByRole("button", { name: /Save/i }))
+    expect(mockAssign).toHaveBeenCalledWith(
+      expect.stringContaining("redirect_uri")
+    )
+  })
+
+  it("adds the record to the default list and sets success status on click", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        list: { id: "list-1", recordCount: 1, records: [{ uri: "b12345678" }] },
+      }),
+    } as Response)
+
+    renderWithContext([{ id: "list-1", isDefaultList: true, records: [] }])
+
+    await userEvent.click(screen.getByRole("button", { name: /Save/i }))
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/api/account/lists/records?uris=b12345678`,
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ patronId: "12345", listId: "list-1" }),
+      })
+    )
+
+    await waitFor(() => {
+      expect(mockSetStatus).toHaveBeenCalledWith("success")
+    })
+    expect(mockSetStatusMessage).toHaveBeenCalled()
+    expect(mockSetUpdatedAccountData).toHaveBeenCalled()
+  })
+
+  it("removes the record from the default list and sets success status on click", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        list: { id: "list-1", recordCount: 0, records: [] },
+      }),
+    } as Response)
+
+    renderWithContext([
+      { id: "list-1", isDefaultList: true, records: [{ uri: "b12345678" }] },
+    ])
+
+    await userEvent.click(screen.getByRole("button", { name: /Remove/i }))
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/api/account/lists/records?uris=b12345678`,
+      expect.objectContaining({
+        method: "DELETE",
+        body: JSON.stringify({ patronId: "12345", listId: "list-1" }),
+      })
+    )
+
+    await waitFor(() => {
+      expect(mockSetStatus).toHaveBeenCalledWith("success")
+    })
+    expect(mockSetStatusMessage).toHaveBeenCalled()
+    expect(mockSetUpdatedAccountData).toHaveBeenCalled()
+  })
+
+  it("handles delete failure (no records to delete)", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+    } as Response)
+
+    renderWithContext([{ id: "list-1", isDefaultList: true, records: [] }])
+
+    await userEvent.click(screen.getByRole("button", { name: /Save/i }))
+
+    await waitFor(() => {
+      expect(mockSetStatus).toHaveBeenCalledWith("failure")
+    })
+    expect(mockSetStatusMessage).toHaveBeenCalledWith(
+      "This record could not be saved."
+    )
+  })
+
+  it("focuses the expected button from the URL search params", () => {
+    window.location.search = "?focus=manage-bib-b12345678"
+
+    const focusSpy = jest.spyOn(HTMLButtonElement.prototype, "focus")
+
+    renderWithContext([{ id: "list-1", isDefaultList: true, records: [] }])
+    expect(focusSpy).toHaveBeenCalled()
+    expect(mockReplaceState).toHaveBeenCalled()
+
+    focusSpy.mockRestore()
+  })
+})

--- a/src/components/SearchResults/ManageBibInList.tsx
+++ b/src/components/SearchResults/ManageBibInList.tsx
@@ -1,26 +1,77 @@
-import { useContext, useEffect, useRef, useState } from "react"
-import { Button, Icon } from "@nypl/design-system-react-components"
+import { useContext, useEffect, useRef } from "react"
+import { Button, Icon, Text } from "@nypl/design-system-react-components"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import { appConfig } from "../../config/appConfig"
 import { encodeURIComponentWithPeriods } from "../../utils/appUtils"
 import type Bib from "../../models/Bib"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { BASE_URL } from "../../config/constants"
+import Link from "../Link/Link"
+import type { List } from "../../types/listTypes"
 
 interface ManageBibInListProps {
   bib: SearchResultsBib | Bib
   isAuthenticated: boolean
+  setStatus
+  setStatusMessage
 }
 
 export const ManageBibInList = ({
   bib,
   isAuthenticated,
+  setStatus,
+  setStatusMessage,
 }: ManageBibInListProps) => {
   const buttonRef = useRef<HTMLButtonElement>(null)
-  const { updatedAccountData } = useContext(PatronDataContext)
+  const { updatedAccountData, setUpdatedAccountData } =
+    useContext(PatronDataContext)
 
   const onlyHasDefaultList = updatedAccountData?.lists?.length === 1
 
+  const isSaved = updatedAccountData?.lists?.some((list) =>
+    list.records?.some((record) => record.uri === bib.id)
+  )
+  const buttonText = isSaved
+    ? onlyHasDefaultList
+      ? "Remove"
+      : "Manage"
+    : "Save"
+
+  const successRemoveDefault = (defaultListId) => (
+    <Text marginBottom={0}>
+      This record has been removed from{" "}
+      <Link
+        target="_blank"
+        color="ui.link.primary !important"
+        href={`/account/lists/${defaultListId}`}
+      >
+        My workspace (default list)
+      </Link>
+      . Lists can be managed from your{" "}
+      <Link target="_blank" color="ui.link.primary !important" href="/account">
+        patron account
+      </Link>
+      .
+    </Text>
+  )
+
+  const successAddDefault = (defaultListId) => (
+    <Text marginBottom={0}>
+      This record has been saved to{" "}
+      <Link
+        target="_blank"
+        color="ui.link.primary !important"
+        href={`/account/lists/${defaultListId}`}
+      >
+        My workspace (default list)
+      </Link>
+      . Lists can be managed from your{" "}
+      <Link target="_blank" color="ui.link.primary !important" href="/account">
+        patron account
+      </Link>
+      .
+    </Text>
+  )
   // Focus the Save button upon returning from the login redirect
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
@@ -41,7 +92,6 @@ export const ManageBibInList = ({
   }, [bib.id])
 
   const handleSaveClick = async (e: React.MouseEvent) => {
-    console.log("here")
     // Intercept if not logged in:
     if (!isAuthenticated) {
       e.preventDefault()
@@ -61,7 +111,7 @@ export const ManageBibInList = ({
     }
     // If user has only the default list:
     if (onlyHasDefaultList) {
-      const defaultList = updatedAccountData.lists?.find(
+      const defaultList = updatedAccountData?.lists?.find(
         (list) => list.isDefaultList
       )
       const defaultListId = defaultList?.id
@@ -70,37 +120,68 @@ export const ManageBibInList = ({
         const response = await fetch(
           `${BASE_URL}/api/account/lists/records?uris=${bib.id}`,
           {
-            method: "PATCH",
+            method: isSaved ? "DELETE" : "PATCH",
             headers: {
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              patronId: updatedAccountData.patron.id.toString(),
+              patronId: updatedAccountData?.patron?.id?.toString(),
               listId: defaultListId,
             }),
           }
         )
-        if (response.ok) {
-          const data = await response.json()
-
-          // setStatus("success")
-          // setStatusMessage("Your list has been duplicated.")
+        if (response.status === 200) {
+          if (setUpdatedAccountData && updatedAccountData) {
+            const updatedLists = updatedAccountData.lists.map((list) => {
+              if (list.id === defaultListId) {
+                if (isSaved) {
+                  return {
+                    ...list,
+                    records:
+                      list.records?.filter((r) => r.uri !== bib.id) || [],
+                    recordCount: Math.max(0, (list.recordCount || 0) - 1),
+                  }
+                } else {
+                  return {
+                    ...list,
+                    records: [{ uri: bib.id }, ...(list.records || [])],
+                    recordCount: (list.recordCount || 0) + 1,
+                  }
+                }
+              }
+              return list
+            })
+            setUpdatedAccountData({
+              ...updatedAccountData,
+              lists: updatedLists as List[],
+            })
+          }
+          setStatus("success")
+          setStatusMessage(
+            isSaved
+              ? successRemoveDefault(defaultListId)
+              : successAddDefault(defaultListId)
+          )
         } else {
-          // setStatus("failure")
-          // setStatusMessage("Your list could not be duplicated.")
+          setStatus("failure")
+          setStatusMessage(
+            `This record could not be ${isSaved ? "removed" : "saved"}.`
+          )
         }
       } catch (error) {
         console.error(
-          `Error adding record ${bib.id} to list ${defaultListId}:`,
+          `Error ${isSaved ? "removing" : "adding"} record ${bib.id} ${
+            isSaved ? "from" : "to"
+          } list ${defaultListId}:`,
           error
         )
-        // setStatus("failure")
-        // setStatusMessage("Your list could not be duplicated.")
+        setStatus("failure")
+        setStatusMessage(
+          `This record could not be ${isSaved ? "removed" : "saved"}.`
+        )
       }
     }
   }
-
-  const [buttonText, setButtonText] = useState("Save")
 
   return (
     <Button
@@ -109,16 +190,23 @@ export const ManageBibInList = ({
       onClick={handleSaveClick}
       variant="text"
     >
-      {/* TODO: Update to bookmark/bookmark outlined icon */}
-      <Icon>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            fill="#0069BF"
-            d="M17 3C18.1 3 19 3.9 19 5V21L12 18L5 21V5C5 3.9 5.9 3 7 3H17ZM7 5V18L12 15.8203L17 18V5H7Z"
-          />
-        </svg>
+      {/* TODO: Update to bookmark/bookmark outlined DS icon */}
+      <Icon size="large">
+        {isSaved ? (
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path
+              fill="#0069BF"
+              d="M17 3H7C5.9 3 5 3.9 5 5V21L12 18L19 21V5C19 3.9 18.1 3 17 3Z"
+            />
+          </svg>
+        ) : (
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path
+              fill="#0069BF"
+              d="M17 3C18.1 3 19 3.9 19 5V21L12 18L5 21V5C5 3.9 5.9 3 7 3H17ZM7 5V18L12 15.8203L17 18V5H7Z"
+            />
+          </svg>
+        )}
       </Icon>
       {buttonText}
     </Button>

--- a/src/components/SearchResults/ManageBibInList.tsx
+++ b/src/components/SearchResults/ManageBibInList.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef } from "react"
+import { useContext, useEffect, useRef, useState } from "react"
 import { Button, Icon, Text } from "@nypl/design-system-react-components"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import { appConfig } from "../../config/appConfig"
@@ -23,6 +23,7 @@ export const ManageBibInList = ({
   setStatusMessage,
 }: ManageBibInListProps) => {
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const [isLoading, setIsLoading] = useState(false)
   const { updatedAccountData, setUpdatedAccountData } =
     useContext(PatronDataContext)
 
@@ -55,7 +56,7 @@ export const ManageBibInList = ({
     </Text>
   )
 
-  const successAddDefault = (defaultListId) => (
+  const successSaveDefault = (defaultListId) => (
     <Text marginBottom={0}>
       This record has been saved to{" "}
       <Link
@@ -115,6 +116,9 @@ export const ManageBibInList = ({
         (list) => list.isDefaultList
       )
       const defaultListId = defaultList?.id
+      setStatus("")
+      setStatusMessage("")
+      setIsLoading(true)
 
       try {
         const response = await fetch(
@@ -130,37 +134,28 @@ export const ManageBibInList = ({
             }),
           }
         )
-        if (response.status === 200) {
-          if (setUpdatedAccountData && updatedAccountData) {
-            const updatedLists = updatedAccountData.lists.map((list) => {
-              if (list.id === defaultListId) {
-                if (isSaved) {
-                  return {
-                    ...list,
-                    records:
-                      list.records?.filter((r) => r.uri !== bib.id) || [],
-                    recordCount: Math.max(0, (list.recordCount || 0) - 1),
-                  }
-                } else {
-                  return {
-                    ...list,
-                    records: [{ uri: bib.id }, ...(list.records || [])],
-                    recordCount: (list.recordCount || 0) + 1,
-                  }
+        if (response.ok) {
+          const responseData = await response.json()
+          const updatedList = responseData.list || responseData
+
+          if (setUpdatedAccountData) {
+            setUpdatedAccountData((prevData: any) => {
+              const data = prevData || updatedAccountData
+              if (!data || !data.lists) return data
+              const updatedLists = data.lists.map((list: List) => {
+                if (list.id === defaultListId) {
+                  return { ...list, ...updatedList }
                 }
-              }
-              return list
-            })
-            setUpdatedAccountData({
-              ...updatedAccountData,
-              lists: updatedLists as List[],
+                return list
+              })
+              return { ...data, lists: updatedLists as List[] }
             })
           }
           setStatus("success")
           setStatusMessage(
             isSaved
               ? successRemoveDefault(defaultListId)
-              : successAddDefault(defaultListId)
+              : successSaveDefault(defaultListId)
           )
         } else {
           setStatus("failure")
@@ -179,6 +174,8 @@ export const ManageBibInList = ({
         setStatusMessage(
           `This record could not be ${isSaved ? "removed" : "saved"}.`
         )
+      } finally {
+        setIsLoading(false)
       }
     }
   }
@@ -189,6 +186,7 @@ export const ManageBibInList = ({
       id={`manage-bib-${bib.id}`}
       onClick={handleSaveClick}
       variant="text"
+      isDisabled={isLoading}
     >
       {/* TODO: Update to bookmark/bookmark outlined DS icon */}
       <Icon size="large">

--- a/src/components/SearchResults/ManageBibInList.tsx
+++ b/src/components/SearchResults/ManageBibInList.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from "react"
+import { useContext, useEffect, useRef } from "react"
 import { Button, Icon } from "@nypl/design-system-react-components"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import { appConfig } from "../../config/appConfig"
 import { encodeURIComponentWithPeriods } from "../../utils/appUtils"
 import type Bib from "../../models/Bib"
+import { PatronDataContext } from "../../context/PatronDataContext"
 
 interface ManageBibInListProps {
   bib: SearchResultsBib | Bib
@@ -15,6 +16,10 @@ export const ManageBibInList = ({
   isAuthenticated,
 }: ManageBibInListProps) => {
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const { setUpdatedAccountData, updatedAccountData } =
+    useContext(PatronDataContext)
+
+  const onlyDefaultList = updatedAccountData.lists?.length === 1
 
   // Focus the Save button upon returning from the login redirect
   useEffect(() => {
@@ -52,6 +57,41 @@ export const ManageBibInList = ({
 
       window.location.assign(`${loginEndpoint}?redirect_uri=${encodedRedirect}`)
       return
+    }
+    // If user has only the default list:
+    if (onlyDefaultList) {
+      try {
+        const response = await fetch(`${BASE_URL}/api/account/lists/list`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            patronId: patron.id.toString(),
+            listName: `${list.listName.substring(0, 90)} (copy)`,
+            description: list.description,
+            records: list.records ? list.records.map((r) => r.uri) : [],
+          }),
+        })
+        if (response.ok) {
+          const data = await response.json()
+          if (data && data.list) {
+            setUpdatedAccountData({
+              ...updatedAccountData,
+              lists: [data.list, ...lists],
+            })
+          }
+          setStatus("success")
+          setStatusMessage("Your list has been duplicated.")
+        } else {
+          setStatus("failure")
+          setStatusMessage("Your list could not be duplicated.")
+        }
+      } catch (error) {
+        console.error("Error duplicating list:", error)
+        setStatus("failure")
+        setStatusMessage("Your list could not be duplicated.")
+      }
     }
   }
 

--- a/src/components/SearchResults/ManageBibInList.tsx
+++ b/src/components/SearchResults/ManageBibInList.tsx
@@ -8,6 +8,7 @@ import { PatronDataContext } from "../../context/PatronDataContext"
 import { BASE_URL } from "../../config/constants"
 import Link from "../Link/Link"
 import type { List } from "../../types/listTypes"
+import { useFocusContext } from "../../context/FocusContext"
 
 interface ManageBibInListProps {
   bib: SearchResultsBib | Bib
@@ -26,6 +27,7 @@ export const ManageBibInList = ({
   const [isLoading, setIsLoading] = useState(false)
   const { updatedAccountData, setUpdatedAccountData } =
     useContext(PatronDataContext)
+  const { setPersistentFocus } = useFocusContext()
 
   const onlyHasDefaultList = updatedAccountData?.lists?.length === 1
 
@@ -79,7 +81,7 @@ export const ManageBibInList = ({
     const focusTarget = params.get("focus")
 
     if (focusTarget === `manage-bib-${bib.id}`) {
-      buttonRef.current?.focus()
+      setPersistentFocus(`manage-bib-${bib.id}`)
       // Clean up the URL
       params.delete("focus")
       const newUrl =
@@ -88,7 +90,7 @@ export const ManageBibInList = ({
         window.location.hash
 
       window.history.replaceState({}, "", newUrl)
-      //And open menu...
+      // And open menu...
     }
   }, [bib.id])
 
@@ -138,19 +140,18 @@ export const ManageBibInList = ({
           const responseData = await response.json()
           const updatedList = responseData.list || responseData
 
-          if (setUpdatedAccountData) {
-            setUpdatedAccountData((prevData: any) => {
-              const data = prevData || updatedAccountData
-              if (!data || !data.lists) return data
-              const updatedLists = data.lists.map((list: List) => {
-                if (list.id === defaultListId) {
-                  return { ...list, ...updatedList }
-                }
-                return list
-              })
-              return { ...data, lists: updatedLists as List[] }
+          setUpdatedAccountData((prevData: any) => {
+            const data = prevData || updatedAccountData
+            if (!data || !data.lists) return data
+            const updatedLists = data.lists.map((list: List) => {
+              if (list.id === defaultListId) {
+                return { ...list, ...updatedList }
+              }
+              return list
             })
-          }
+            return { ...data, lists: updatedLists as List[] }
+          })
+
           setStatus("success")
           setStatusMessage(
             isSaved
@@ -182,7 +183,6 @@ export const ManageBibInList = ({
 
   return (
     <Button
-      ref={buttonRef}
       id={`manage-bib-${bib.id}`}
       onClick={handleSaveClick}
       variant="text"

--- a/src/components/SearchResults/ManageBibInList.tsx
+++ b/src/components/SearchResults/ManageBibInList.tsx
@@ -3,9 +3,10 @@ import { Button, Icon } from "@nypl/design-system-react-components"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import { appConfig } from "../../config/appConfig"
 import { encodeURIComponentWithPeriods } from "../../utils/appUtils"
+import type Bib from "../../models/Bib"
 
 interface ManageBibInListProps {
-  bib: SearchResultsBib
+  bib: SearchResultsBib | Bib
   isAuthenticated: boolean
 }
 

--- a/src/components/SearchResults/ManageBibInList.tsx
+++ b/src/components/SearchResults/ManageBibInList.tsx
@@ -1,10 +1,11 @@
-import { useContext, useEffect, useRef } from "react"
+import { useContext, useEffect, useRef, useState } from "react"
 import { Button, Icon } from "@nypl/design-system-react-components"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import { appConfig } from "../../config/appConfig"
 import { encodeURIComponentWithPeriods } from "../../utils/appUtils"
 import type Bib from "../../models/Bib"
 import { PatronDataContext } from "../../context/PatronDataContext"
+import { BASE_URL } from "../../config/constants"
 
 interface ManageBibInListProps {
   bib: SearchResultsBib | Bib
@@ -16,10 +17,9 @@ export const ManageBibInList = ({
   isAuthenticated,
 }: ManageBibInListProps) => {
   const buttonRef = useRef<HTMLButtonElement>(null)
-  const { setUpdatedAccountData, updatedAccountData } =
-    useContext(PatronDataContext)
+  const { updatedAccountData } = useContext(PatronDataContext)
 
-  const onlyDefaultList = updatedAccountData.lists?.length === 1
+  const onlyHasDefaultList = updatedAccountData?.lists?.length === 1
 
   // Focus the Save button upon returning from the login redirect
   useEffect(() => {
@@ -40,8 +40,9 @@ export const ManageBibInList = ({
     }
   }, [bib.id])
 
-  const handleSaveClick = (e: React.MouseEvent) => {
-    // Intercept if not logged in
+  const handleSaveClick = async (e: React.MouseEvent) => {
+    console.log("here")
+    // Intercept if not logged in:
     if (!isAuthenticated) {
       e.preventDefault()
 
@@ -59,41 +60,47 @@ export const ManageBibInList = ({
       return
     }
     // If user has only the default list:
-    if (onlyDefaultList) {
+    if (onlyHasDefaultList) {
+      const defaultList = updatedAccountData.lists?.find(
+        (list) => list.isDefaultList
+      )
+      const defaultListId = defaultList?.id
+
       try {
-        const response = await fetch(`${BASE_URL}/api/account/lists/list`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            patronId: patron.id.toString(),
-            listName: `${list.listName.substring(0, 90)} (copy)`,
-            description: list.description,
-            records: list.records ? list.records.map((r) => r.uri) : [],
-          }),
-        })
+        const response = await fetch(
+          `${BASE_URL}/api/account/lists/records?uris=${bib.id}`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              patronId: updatedAccountData.patron.id.toString(),
+              listId: defaultListId,
+            }),
+          }
+        )
         if (response.ok) {
           const data = await response.json()
-          if (data && data.list) {
-            setUpdatedAccountData({
-              ...updatedAccountData,
-              lists: [data.list, ...lists],
-            })
-          }
-          setStatus("success")
-          setStatusMessage("Your list has been duplicated.")
+
+          // setStatus("success")
+          // setStatusMessage("Your list has been duplicated.")
         } else {
-          setStatus("failure")
-          setStatusMessage("Your list could not be duplicated.")
+          // setStatus("failure")
+          // setStatusMessage("Your list could not be duplicated.")
         }
       } catch (error) {
-        console.error("Error duplicating list:", error)
-        setStatus("failure")
-        setStatusMessage("Your list could not be duplicated.")
+        console.error(
+          `Error adding record ${bib.id} to list ${defaultListId}:`,
+          error
+        )
+        // setStatus("failure")
+        // setStatusMessage("Your list could not be duplicated.")
       }
     }
   }
+
+  const [buttonText, setButtonText] = useState("Save")
 
   return (
     <Button
@@ -106,14 +113,14 @@ export const ManageBibInList = ({
       <Icon>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <path
-            fill-rule="evenodd"
-            clip-rule="evenodd"
+            fillRule="evenodd"
+            clipRule="evenodd"
             fill="#0069BF"
             d="M17 3C18.1 3 19 3.9 19 5V21L12 18L5 21V5C5 3.9 5.9 3 7 3H17ZM7 5V18L12 15.8203L17 18V5H7Z"
           />
         </svg>
       </Icon>
-      Save
+      {buttonText}
     </Button>
   )
 }

--- a/src/components/SearchResults/ManageBibInList.tsx
+++ b/src/components/SearchResults/ManageBibInList.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react"
+import { Button, Icon } from "@nypl/design-system-react-components"
+import type SearchResultsBib from "../../models/SearchResultsBib"
+import { appConfig } from "../../config/appConfig"
+import { encodeURIComponentWithPeriods } from "../../utils/appUtils"
+
+interface ManageBibInListProps {
+  bib: SearchResultsBib
+  isAuthenticated: boolean
+}
+
+export const ManageBibInList = ({
+  bib,
+  isAuthenticated,
+}: ManageBibInListProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  // Focus the Save button upon returning from the login redirect
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const focusTarget = params.get("focus")
+
+    if (focusTarget === `manage-bib-${bib.id}`) {
+      buttonRef.current?.focus()
+      // Clean up the URL
+      params.delete("focus")
+      const newUrl =
+        window.location.pathname +
+        (params.toString() ? `?${params.toString()}` : "") +
+        window.location.hash
+
+      window.history.replaceState({}, "", newUrl)
+      //And open menu...
+    }
+  }, [bib.id])
+
+  const handleSaveClick = (e: React.MouseEvent) => {
+    // Intercept if not logged in
+    if (!isAuthenticated) {
+      e.preventDefault()
+
+      const currentUrl = new URL(window.location.href)
+      currentUrl.searchParams.set("focus", `manage-bib-${bib.id}`)
+
+      const loginEndpoint =
+        appConfig.urls?.loginUrl?.[appConfig.environment] ||
+        appConfig.apiEndpoints?.loginUrl?.[appConfig.environment]
+      const encodedRedirect = encodeURIComponentWithPeriods(
+        currentUrl.toString()
+      )
+
+      window.location.assign(`${loginEndpoint}?redirect_uri=${encodedRedirect}`)
+      return
+    }
+  }
+
+  return (
+    <Button
+      ref={buttonRef}
+      id={`manage-bib-${bib.id}`}
+      onClick={handleSaveClick}
+      variant="text"
+    >
+      {/* TODO: Update to bookmark/bookmark outlined icon */}
+      <Icon>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            fill="#0069BF"
+            d="M17 3C18.1 3 19 3.9 19 5V21L12 18L5 21V5C5 3.9 5.9 3 7 3H17ZM7 5V18L12 15.8203L17 18V5H7Z"
+          />
+        </svg>
+      </Icon>
+      Save
+    </Button>
+  )
+}

--- a/src/components/SearchResults/SearchResult.test.tsx
+++ b/src/components/SearchResults/SearchResult.test.tsx
@@ -10,7 +10,7 @@ import type { DiscoveryBibResult } from "../../types/bibTypes"
 describe("SearchResult with Physical Items", () => {
   beforeEach(() => {
     const bib = new SearchResultsBib(searchResultPhysicalItems)
-    render(<SearchResult bib={bib} />)
+    render(<SearchResult isAuthenticated={false} bib={bib} />)
   })
 
   it("renders a title link with the correct bib href", async () => {
@@ -32,7 +32,7 @@ describe("SearchResult with Many Physical Items", () => {
     const bib = new SearchResultsBib(
       searchResultManyPhysicalItems as DiscoveryBibResult
     )
-    render(<SearchResult bib={bib} />)
+    render(<SearchResult isAuthenticated={false} bib={bib} />)
   })
 
   it("renders a link to the bib page with the correct text when there are more than the set limit of items per search result", async () => {
@@ -53,7 +53,7 @@ describe("SearchResult with Many Physical Items", () => {
 describe("SearchResult with Electronic Resources", () => {
   it("renders the correct item message for bib with electronic resources", async () => {
     const bib = new SearchResultsBib(searchResultElectronicResources)
-    render(<SearchResult bib={bib} />)
+    render(<SearchResult isAuthenticated={false} bib={bib} />)
     screen.getByText("1 resource")
   })
 })

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -8,6 +8,7 @@ import {
   SimpleGrid,
   StatusBadge,
   Icon,
+  Flex,
 } from "@nypl/design-system-react-components"
 import Link from "../Link/Link"
 import ElectronicResourcesLink from "./ElectronicResourcesLink"
@@ -15,15 +16,17 @@ import type SearchResultsBib from "../../models/SearchResultsBib"
 import { PATHS } from "../../config/constants"
 import FindingAid from "../BibPage/FindingAid"
 import SearchResultItems from "./SearchResultItems"
+import { ManageBibInList } from "./ManageBibInList"
 
 interface SearchResultProps {
   bib: SearchResultsBib
+  isAuthenticated: boolean
 }
 
 /**
  * The SearchResult component displays a single search result element.
  */
-const SearchResult = ({ bib }: SearchResultProps) => {
+const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
   const separatingDot = (i) => (
     // @ts-ignore
     <Icon key={`dot-${i}`} size="xxsmall" ml="xs" mr="xs" pb="xxs">
@@ -70,12 +73,17 @@ const SearchResult = ({ bib }: SearchResultProps) => {
         size="heading5"
         sx={{ a: { textDecoration: "none" } }}
       >
-        {bib.findingAid && (
-          <StatusBadge variant="informative" mb="s">
-            Finding aid available
-          </StatusBadge>
-        )}
-        <Link href={`${PATHS.BIB}/${bib.id}`}>{bib.titleDisplay}</Link>
+        <Flex flexDir="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            {bib.findingAid && (
+              <StatusBadge variant="informative" mb="s">
+                Finding aid available
+              </StatusBadge>
+            )}
+            <Link href={`${PATHS.BIB}/${bib.id}`}>{bib.titleDisplay}</Link>
+          </Box>
+          <ManageBibInList bib={bib} isAuthenticated={isAuthenticated} />
+        </Flex>
       </CardHeading>
       <CardContent data-testid="card-content">
         <Box

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -17,6 +17,9 @@ import { PATHS } from "../../config/constants"
 import FindingAid from "../BibPage/FindingAid"
 import SearchResultItems from "./SearchResultItems"
 import { ManageBibInList } from "./ManageBibInList"
+import type { StatusType } from "../MyAccount/Settings/StatusBanner"
+import { StatusBanner } from "../MyAccount/Settings/StatusBanner"
+import { useEffect, useRef, useState } from "react"
 
 interface SearchResultProps {
   bib: SearchResultsBib
@@ -53,6 +56,18 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
     return acc
   }, [])
 
+  // Manage status banner display for list actions
+  const bannerRef = useRef<HTMLDivElement>(null)
+  const [status, setStatus] = useState<StatusType>("")
+  const [statusMessage, setStatusMessage] = useState<string>("")
+  useEffect(() => {
+    if (status !== "" && bannerRef.current) {
+      setTimeout(() => {
+        bannerRef.current?.focus()
+      }, 100)
+    }
+  }, [status])
+
   return (
     <Card
       key={bib.id}
@@ -82,7 +97,12 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
             )}
             <Link href={`${PATHS.BIB}/${bib.id}`}>{bib.titleDisplay}</Link>
           </Box>
-          <ManageBibInList bib={bib} isAuthenticated={isAuthenticated} />
+          <ManageBibInList
+            bib={bib}
+            isAuthenticated={isAuthenticated}
+            setStatus={setStatus}
+            setStatusMessage={setStatusMessage}
+          />
         </Flex>
       </CardHeading>
       <CardContent data-testid="card-content">
@@ -95,6 +115,11 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
         >
           {joinedMetadata}
         </Box>
+        <div tabIndex={-1} ref={bannerRef} style={{ marginTop: "24px" }}>
+          {status !== "" && (
+            <StatusBanner status={status} statusMessage={statusMessage} />
+          )}
+        </div>
         {(bib.findingAid || bib.hasElectronicResources) && (
           <Box width="100%" mt="s">
             {bib.findingAid ? (

--- a/src/server/api/lists.ts
+++ b/src/server/api/lists.ts
@@ -181,31 +181,30 @@ export async function deleteList({
 }
 
 /**
- * Delete records from a list.
+ * Delete a record from a list.
  *
  * @param {object} params
  * @param {string} params.patronId - The patron's ID.
  * @param {string} params.listId - The ID of the list to update.
- * @param {string[]} params.records - An array of record IDs to remove from the list.
+ * @param {string[]} params.record - A record ID to remove from the list.
  * @returns {Promise<object>} A success status or an error object.
  */
-export async function deleteRecordsFromList({
+export async function deleteRecordFromList({
   patronId,
   listId,
-  records,
+  record,
 }: {
   patronId: string
   listId: string
-  records: string[]
+  record: string
 }) {
-  const path = `/patrons/${patronId}/list/${listId}/records`
-  const body = {
-    records,
-  }
+  const path = `/patrons/${patronId}/list/${listId}/records?records=${record}`
+
   return callListsServiceAndHandleError({
-    methodName: "deleteRecordsFromList",
+    methodName: "deleteRecordFromList",
     path,
-    apiCall: (client) => client.delete(path, body),
+    apiCall: (client) => client.delete(path),
+    onSuccess: (response) => ({ status: 200, list: response }),
   })
 }
 
@@ -215,7 +214,7 @@ export async function deleteRecordsFromList({
  * @param {object} params
  * @param {string} params.patronId - The patron's ID.
  * @param {string} params.listId - The ID of the list to update.
- * @param {string[]} params.records - An array of record IDs to add to the list.
+ * @param {string[]} params.records - A string of comma-separated record IDs to add to the list.
  * @returns {Promise<object>} A success status or an error object.
  */
 export async function addRecordsToList({
@@ -235,6 +234,7 @@ export async function addRecordsToList({
     methodName: "addRecordsToList",
     path,
     apiCall: (client) => client.patch(path, body),
+    onSuccess: (response) => ({ status: 200, list: response }),
   })
 }
 

--- a/src/server/api/lists.ts
+++ b/src/server/api/lists.ts
@@ -225,11 +225,11 @@ export async function addRecordsToList({
 }: {
   patronId: string
   listId: string
-  records: string[]
+  records: string
 }) {
   const path = `/patrons/${patronId}/list/${listId}/records`
   const body = {
-    records,
+    records: records.split(","),
   }
   return callListsServiceAndHandleError({
     methodName: "addRecordsToList",

--- a/src/server/api/tests/lists.test.ts
+++ b/src/server/api/tests/lists.test.ts
@@ -4,7 +4,7 @@ import {
   createList,
   updateList,
   deleteList,
-  deleteRecordsFromList,
+  deleteRecordFromList,
   addRecordsToList,
 } from "../lists"
 import nyplApiClient from "../../nyplApiClient"
@@ -188,7 +188,7 @@ describe("lists", () => {
     })
   })
 
-  describe("deleteRecordsFromList", () => {
+  describe("deleteRecordFromList", () => {
     it("returns success on successful deletion", async () => {
       mockClient.delete.mockResolvedValueOnce({
         id: "123",
@@ -199,18 +199,26 @@ describe("lists", () => {
         listName: "list 1",
         description: null,
       })
-      const result = await deleteRecordsFromList({
+      const result = await deleteRecordFromList({
         patronId: "12345",
         listId: "123",
-        records: ["b123", "b345"],
+        record: "b123",
       })
       expect(mockClient.delete).toHaveBeenCalledWith(
-        "/patrons/12345/list/123/records",
-        {
-          records: ["b123", "b345"],
-        }
+        "/patrons/12345/list/123/records?records=b123"
       )
-      expect(result).toEqual({ status: 200 })
+      expect(result).toEqual({
+        status: 200,
+        list: {
+          createdDate: "2026-04-15T15:58:58.396947",
+          description: null,
+          id: "123",
+          listName: "list 1",
+          modifiedDate: "2026-04-22T10:11:20.584139",
+          patronId: "12345",
+          records: [],
+        },
+      })
     })
   })
 
@@ -228,7 +236,7 @@ describe("lists", () => {
       const result = await addRecordsToList({
         patronId: "12345",
         listId: "123",
-        records: ["b123", "b345"],
+        records: "b123,b345",
       })
       expect(mockClient.patch).toHaveBeenCalledWith(
         "/patrons/12345/list/123/records",
@@ -236,7 +244,18 @@ describe("lists", () => {
           records: ["b123", "b345"],
         }
       )
-      expect(result).toEqual({ status: 200 })
+      expect(result).toEqual({
+        status: 200,
+        list: {
+          id: "123",
+          patronId: "12345",
+          records: ["b123", "b345"],
+          createdDate: "2026-04-15T15:58:58.396947",
+          modifiedDate: "2026-04-22T10:11:20.584139",
+          listName: "second list",
+          description: null,
+        },
+      })
     })
   })
 })

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -3,12 +3,15 @@ import { render, type RenderOptions } from "@testing-library/react"
 import { FeedbackProvider } from "../context/FeedbackContext"
 import { FocusProvider } from "../context/FocusContext"
 import { BrowseProvider } from "../context/BrowseContext"
+import { PatronDataProvider } from "../context/PatronDataContext"
 
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
   return (
     <FeedbackProvider value={null}>
       <FocusProvider>
-        <BrowseProvider>{children}</BrowseProvider>
+        <BrowseProvider>
+          <PatronDataProvider value={null}>{children}</PatronDataProvider>
+        </BrowseProvider>
       </FocusProvider>
     </FeedbackProvider>
   )


### PR DESCRIPTION
## Ticket:

- no ref, another Lists chunk

## This PR does the following:

- Adds `ManageBibInList` button, which so far handles saving and removing a bib from the one default list
- Adds `PatronDataContext` to search and bib pages, only populated with the patron and their lists (to avoid fetching all the other slow Sierra data) which is enough to display whether a bib is in a list or not
- Adds authentication check and redirect of focus back to where you left it when you try to save a bib not logged in
- Reworks delete record endpoint (also [some work in ListsService](https://github.com/NYPL/ListsService/commit/d1c46065f43080e13dabf084b047b1c12256ac89)), can be extended easily to delete in bulk but right now only use case is deleting one record at a time, so the endpoint reflects that
- To come: the full manage bib menu, where you can add/remove to multiple lists and create a list etc. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Best tested on `webapplicant0` since Hank has only the one default list. Try adding and removing bibs from search results and the bib page, try logging out and getting redirected back in and confirming you end up where you were originally

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I updated the CHANGELOG with the appropriate information and JIRA ticket number (if applicable).
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.
