### PR TITLE
SCC-5269: Warning log for no results with single filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Added
+
 - Added warn log for no results from query with a single filter and no keyword [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)
 
 ## [2.0.0] 2026-06-04

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+- Added warn log for no results from query with a single filter and no keyword [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)
+
 ## [2.0.0] 2026-06-04
 
 ### Added

--- a/__test__/pages/browse/authors/authorResults.test.tsx
+++ b/__test__/pages/browse/authors/authorResults.test.tsx
@@ -7,17 +7,12 @@ import { fetchSearchResults } from "../../../../src/server/api/search"
 import { results } from "../../../fixtures/searchResultsManyBibs"
 import userEvent from "@testing-library/user-event"
 import initializePatronTokenAuth from "../../../../src/server/auth"
+import { logSingleFilterNoResults } from "../../../../src/utils/logUtils"
 
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 jest.mock("../../../../src/server/auth")
 jest.mock("../../../../src/server/api/search")
-
-jest.mock("@nypl/node-utils", () => ({
-  logger: {
-    warn: jest.fn(),
-  },
-}))
-import { logger } from "@nypl/node-utils"
+jest.mock("../../../../src/utils/logUtils")
 
 describe("Browse author/contributor results page", () => {
   it("displays bibs and contributor heading", async () => {
@@ -152,11 +147,9 @@ describe("getServerSideProps", () => {
     )
   })
 
-  it("logs a warning with the correct referer when no results are found, and there is a single filter with no keyword", async () => {
-    ;(fetchSearchResults as jest.Mock).mockResolvedValue({
-      status: 404,
-      message: "No results found",
-    })
+  it("makes the correct call to logSingleFilterNoResults", async () => {
+    const response404 = { status: 404, message: "No results found" }
+    ;(fetchSearchResults as jest.Mock).mockResolvedValue(response404)
 
     const params = { slug: "test" }
     const query = { page: "2" }
@@ -167,8 +160,11 @@ describe("getServerSideProps", () => {
     }
 
     await getServerSideProps({ req, query, params })
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Warning in fetchSearchResults: Possible bad incoming link; referer: a cat"
+    expect(logSingleFilterNoResults).toHaveBeenCalledWith(
+      "browse authors",
+      response404,
+      expect.any(Object),
+      "a cat"
     )
   })
 })

--- a/__test__/pages/browse/authors/authorResults.test.tsx
+++ b/__test__/pages/browse/authors/authorResults.test.tsx
@@ -12,6 +12,13 @@ jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 jest.mock("../../../../src/server/auth")
 jest.mock("../../../../src/server/api/search")
 
+jest.mock("@nypl/node-utils", () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+}))
+import { logger } from "@nypl/node-utils"
+
 describe("Browse author/contributor results page", () => {
   it("displays bibs and contributor heading", async () => {
     await mockRouter.push({
@@ -142,6 +149,26 @@ describe("getServerSideProps", () => {
         page: 2,
         role: "performer",
       })
+    )
+  })
+
+  it("logs a warning with the correct referer when no results are found, and there is a single filter with no keyword", async () => {
+    ;(fetchSearchResults as jest.Mock).mockResolvedValue({
+      status: 404,
+      message: "No results found",
+    })
+
+    const params = { slug: "test" }
+    const query = { page: "2" }
+    const req = {
+      headers: {
+        referer: "a cat",
+      },
+    }
+
+    await getServerSideProps({ req, query, params })
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Warning in fetchSearchResults: Possible bad incoming link; referer: a cat"
     )
   })
 })

--- a/__test__/pages/browse/authors/authorResults.test.tsx
+++ b/__test__/pages/browse/authors/authorResults.test.tsx
@@ -161,7 +161,7 @@ describe("getServerSideProps", () => {
 
     await getServerSideProps({ req, query, params })
     expect(logSingleFilterNoResults).toHaveBeenCalledWith(
-      "browse authors",
+      "browse authors gSSP",
       response404,
       expect.any(Object),
       "a cat"

--- a/__test__/pages/browse/subjects/subjectResults.test.tsx
+++ b/__test__/pages/browse/subjects/subjectResults.test.tsx
@@ -12,6 +12,13 @@ jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 jest.mock("../../../../src/server/auth")
 jest.mock("../../../../src/server/api/search")
 
+jest.mock("@nypl/node-utils", () => ({
+  logger: {
+    warn: jest.fn(),
+  },
+}))
+import { logger } from "@nypl/node-utils"
+
 describe("Browse subject heading results page", () => {
   it("displays bibs and heading", async () => {
     await mockRouter.push({
@@ -114,6 +121,26 @@ describe("getServerSideProps", () => {
         filters: { subjectLiteral: ["test"] },
         page: 2,
       })
+    )
+  })
+
+  it("logs a warning with the correct referer when no results are found, and there is a single filter with no keyword", async () => {
+    ;(fetchSearchResults as jest.Mock).mockResolvedValue({
+      status: 404,
+      message: "No results found",
+    })
+
+    const params = { slug: "test" }
+    const query = { page: "2" }
+    const req = {
+      headers: {
+        referer: "a cat",
+      },
+    }
+
+    await getServerSideProps({ req, query, params })
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Warning in fetchSearchResults: Possible bad incoming link; referer: a cat"
     )
   })
 })

--- a/__test__/pages/browse/subjects/subjectResults.test.tsx
+++ b/__test__/pages/browse/subjects/subjectResults.test.tsx
@@ -133,7 +133,7 @@ describe("getServerSideProps", () => {
 
     await getServerSideProps({ req, query, params })
     expect(logSingleFilterNoResults).toHaveBeenCalledWith(
-      "browse subjects",
+      "browse subjects gSSP",
       response404,
       expect.any(Object),
       "a cat"

--- a/__test__/pages/browse/subjects/subjectResults.test.tsx
+++ b/__test__/pages/browse/subjects/subjectResults.test.tsx
@@ -7,17 +7,12 @@ import { fetchSearchResults } from "../../../../src/server/api/search"
 import { results } from "../../../fixtures/searchResultsManyBibs"
 import userEvent from "@testing-library/user-event"
 import initializePatronTokenAuth from "../../../../src/server/auth"
+import { logSingleFilterNoResults } from "../../../../src/utils/logUtils"
 
 jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 jest.mock("../../../../src/server/auth")
 jest.mock("../../../../src/server/api/search")
-
-jest.mock("@nypl/node-utils", () => ({
-  logger: {
-    warn: jest.fn(),
-  },
-}))
-import { logger } from "@nypl/node-utils"
+jest.mock("../../../../src/utils/logUtils")
 
 describe("Browse subject heading results page", () => {
   it("displays bibs and heading", async () => {
@@ -124,11 +119,9 @@ describe("getServerSideProps", () => {
     )
   })
 
-  it("logs a warning with the correct referer when no results are found, and there is a single filter with no keyword", async () => {
-    ;(fetchSearchResults as jest.Mock).mockResolvedValue({
-      status: 404,
-      message: "No results found",
-    })
+  it("makes the correct call to logSingleFilterNoResults", async () => {
+    const response404 = { status: 404, message: "No results found" }
+    ;(fetchSearchResults as jest.Mock).mockResolvedValue(response404)
 
     const params = { slug: "test" }
     const query = { page: "2" }
@@ -139,8 +132,11 @@ describe("getServerSideProps", () => {
     }
 
     await getServerSideProps({ req, query, params })
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Warning in fetchSearchResults: Possible bad incoming link; referer: a cat"
+    expect(logSingleFilterNoResults).toHaveBeenCalledWith(
+      "browse subjects",
+      response404,
+      expect.any(Object),
+      "a cat"
     )
   })
 })

--- a/__test__/pages/search/search.test.tsx
+++ b/__test__/pages/search/search.test.tsx
@@ -2,7 +2,7 @@ import { getServerSideProps } from "../../../pages/search/index"
 import initializePatronTokenAuth from "../../../src/server/auth"
 import { fetchSearchResults } from "../../../src/server/api/search"
 import { mapQueryToSearchParams } from "../../../src/utils/searchUtils"
-import { SearchQueryParams } from "../../../src/types/searchTypes"
+import type { SearchQueryParams } from "../../../src/types/searchTypes"
 import { logSingleFilterNoResults } from "../../../src/utils/logUtils"
 
 jest.mock("../../../src/server/auth")

--- a/__test__/pages/search/search.test.tsx
+++ b/__test__/pages/search/search.test.tsx
@@ -15,6 +15,24 @@ const mockReq = {
   },
 }
 
+jest.mock("@nypl/node-utils", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+import { logger } from "@nypl/node-utils"
+
+const mockReqWithReferer = {
+  ...mockReq,
+  headers: {
+    host: "local.nypl.org:8080",
+    referer:
+      "http://local.nypl.org:8080/research/research-catalog/bib/b16767329",
+  },
+}
+
 describe("Search page", () => {
   beforeEach(() => {
     ;(initializePatronTokenAuth as jest.Mock).mockResolvedValue({
@@ -102,6 +120,20 @@ describe("Search page", () => {
       expect(response).toEqual({
         props: { errorStatus: 404 },
       })
+    })
+    it("logs a warning with the correct referer when no results are found, and there is a single filter with no keyword", async () => {
+      ;(fetchSearchResults as jest.Mock).mockResolvedValue({
+        status: 404,
+        message: "No results found",
+      })
+
+      await getServerSideProps({
+        req: mockReqWithReferer,
+        query: { "filters[language][0]": "lang:fre" },
+      })
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Warning in fetchSearchResults: Possible bad incoming link; referer: http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
+      )
     })
     it("handles general server errors", async () => {
       ;(fetchSearchResults as jest.Mock).mockResolvedValue({

--- a/__test__/pages/search/search.test.tsx
+++ b/__test__/pages/search/search.test.tsx
@@ -1,9 +1,13 @@
 import { getServerSideProps } from "../../../pages/search/index"
 import initializePatronTokenAuth from "../../../src/server/auth"
 import { fetchSearchResults } from "../../../src/server/api/search"
+import { mapQueryToSearchParams } from "../../../src/utils/searchUtils"
+import { SearchQueryParams } from "../../../src/types/searchTypes"
+import { logSingleFilterNoResults } from "../../../src/utils/logUtils"
 
 jest.mock("../../../src/server/auth")
 jest.mock("../../../src/server/api/search")
+jest.mock("../../../src/utils/logUtils")
 
 const mockReq = {
   headers: {
@@ -14,15 +18,6 @@ const mockReq = {
     nyplIdentityPatron: '{"access_token":123}',
   },
 }
-
-jest.mock("@nypl/node-utils", () => ({
-  logger: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  },
-}))
-import { logger } from "@nypl/node-utils"
 
 const mockReqWithReferer = {
   ...mockReq,
@@ -121,18 +116,20 @@ describe("Search page", () => {
         props: { errorStatus: 404 },
       })
     })
-    it("logs a warning with the correct referer when no results are found, and there is a single filter with no keyword", async () => {
-      ;(fetchSearchResults as jest.Mock).mockResolvedValue({
-        status: 404,
-        message: "No results found",
-      })
+    it("makes the correct call to logSingleFilterNoResults", async () => {
+      const response404 = { status: 404, message: "No results found" }
+      const query = { "filters[language][0]": "lang:fre" } as SearchQueryParams
+      ;(fetchSearchResults as jest.Mock).mockResolvedValue(response404)
 
       await getServerSideProps({
         req: mockReqWithReferer,
-        query: { "filters[language][0]": "lang:fre" },
+        query,
       })
-      expect(logger.warn).toHaveBeenCalledWith(
-        "Warning in fetchSearchResults: Possible bad incoming link; referer: http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
+      expect(logSingleFilterNoResults).toHaveBeenCalledWith(
+        "search page",
+        response404,
+        mapQueryToSearchParams(query),
+        "http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
       )
     })
     it("handles general server errors", async () => {

--- a/__test__/pages/search/search.test.tsx
+++ b/__test__/pages/search/search.test.tsx
@@ -126,7 +126,7 @@ describe("Search page", () => {
         query,
       })
       expect(logSingleFilterNoResults).toHaveBeenCalledWith(
-        "search page",
+        "search page gSSP",
         response404,
         mapQueryToSearchParams(query),
         "http://local.nypl.org:8080/research/research-catalog/bib/b16767329"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "research-catalog",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "AWS_PROFILE=nypl-digital-dev next dev -p 8080",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "research-catalog",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "scripts": {
     "dev": "AWS_PROFILE=nypl-digital-dev next dev -p 8080",
     "build": "next build",

--- a/pages/browse/authors/[slug].tsx
+++ b/pages/browse/authors/[slug].tsx
@@ -4,6 +4,7 @@ import initializePatronTokenAuth from "../../../src/server/auth"
 import {
   mapQueryToSearchParams,
   checkForRedirectOnMatch,
+  filtersObjectLength,
 } from "../../../src/utils/searchUtils"
 import type { SearchResultsResponse } from "../../../src/types/searchTypes"
 import type { HTTPStatusCode } from "../../../src/types/appTypes"
@@ -11,6 +12,7 @@ import Search from "../../../src/components/Search/Search"
 import { useRouter } from "next/router"
 import { idConstants, useFocusContext } from "../../../src/context/FocusContext"
 import { buildLockedBrowseQuery } from "../../../src/utils/browseUtils"
+import { logServerWarn } from "../../../src/utils/logUtils"
 
 interface ContributorResultsProps {
   bannerNotification?: string
@@ -88,6 +90,7 @@ export default function ContributorResults({
 export async function getServerSideProps({ req, query, params }) {
   const bannerNotification = process.env.SEARCH_RESULTS_NOTIFICATION || ""
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+  const referer = req.headers?.referer
   const slug: string = params.slug as string
   const role = typeof query.role === "string" ? query.role : null
 
@@ -97,7 +100,20 @@ export async function getServerSideProps({ req, query, params }) {
     field: "contributorLiteral",
   })
 
-  const results = await fetchSearchResults(mapQueryToSearchParams(baseQuery))
+  const searchParams = mapQueryToSearchParams(baseQuery)
+
+  const results = await fetchSearchResults(searchParams)
+
+  // Check for possible bad incoming link (no results with one filter and no keyword)
+  if (
+    results.status === 404 &&
+    filtersObjectLength(searchParams.filters) === 1 &&
+    !searchParams.q
+  )
+    logServerWarn(
+      "fetchSearchResults",
+      `Possible bad incoming link; referer: ${referer}`
+    )
 
   if (results.status !== 200) {
     return { props: { errorStatus: results.status } }

--- a/pages/browse/authors/[slug].tsx
+++ b/pages/browse/authors/[slug].tsx
@@ -103,7 +103,7 @@ export async function getServerSideProps({ req, query, params }) {
   const results = await fetchSearchResults(searchParams)
 
   logSingleFilterNoResults(
-    "browse authors",
+    "browse authors gSSP",
     results,
     searchParams,
     req.headers?.referer

--- a/pages/browse/authors/[slug].tsx
+++ b/pages/browse/authors/[slug].tsx
@@ -4,7 +4,6 @@ import initializePatronTokenAuth from "../../../src/server/auth"
 import {
   mapQueryToSearchParams,
   checkForRedirectOnMatch,
-  filtersObjectLength,
 } from "../../../src/utils/searchUtils"
 import type { SearchResultsResponse } from "../../../src/types/searchTypes"
 import type { HTTPStatusCode } from "../../../src/types/appTypes"
@@ -12,7 +11,7 @@ import Search from "../../../src/components/Search/Search"
 import { useRouter } from "next/router"
 import { idConstants, useFocusContext } from "../../../src/context/FocusContext"
 import { buildLockedBrowseQuery } from "../../../src/utils/browseUtils"
-import { logServerWarn } from "../../../src/utils/logUtils"
+import { logSingleFilterNoResults } from "../../../src/utils/logUtils"
 
 interface ContributorResultsProps {
   bannerNotification?: string
@@ -90,7 +89,6 @@ export default function ContributorResults({
 export async function getServerSideProps({ req, query, params }) {
   const bannerNotification = process.env.SEARCH_RESULTS_NOTIFICATION || ""
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
-  const referer = req.headers?.referer
   const slug: string = params.slug as string
   const role = typeof query.role === "string" ? query.role : null
 
@@ -104,16 +102,12 @@ export async function getServerSideProps({ req, query, params }) {
 
   const results = await fetchSearchResults(searchParams)
 
-  // Check for possible bad incoming link (no results with one filter and no keyword)
-  if (
-    results.status === 404 &&
-    filtersObjectLength(searchParams.filters) === 1 &&
-    !searchParams.q
+  logSingleFilterNoResults(
+    "browse authors",
+    results,
+    searchParams,
+    req.headers?.referer
   )
-    logServerWarn(
-      "fetchSearchResults",
-      `Possible bad incoming link; referer: ${referer}`
-    )
 
   if (results.status !== 200) {
     return { props: { errorStatus: results.status } }

--- a/pages/browse/subjects/[slug].tsx
+++ b/pages/browse/subjects/[slug].tsx
@@ -4,7 +4,6 @@ import initializePatronTokenAuth from "../../../src/server/auth"
 import {
   mapQueryToSearchParams,
   checkForRedirectOnMatch,
-  filtersObjectLength,
 } from "../../../src/utils/searchUtils"
 import type { SearchResultsResponse } from "../../../src/types/searchTypes"
 import type { HTTPStatusCode } from "../../../src/types/appTypes"
@@ -12,7 +11,7 @@ import Search from "../../../src/components/Search/Search"
 import { useRouter } from "next/router"
 import { idConstants, useFocusContext } from "../../../src/context/FocusContext"
 import { buildLockedBrowseQuery } from "../../../src/utils/browseUtils"
-import { logServerWarn } from "../../../src/utils/logUtils"
+import { logSingleFilterNoResults } from "../../../src/utils/logUtils"
 
 interface SubjectHeadingResultsProps {
   bannerNotification?: string
@@ -87,7 +86,6 @@ export default function SubjectHeadingResults({
 export async function getServerSideProps({ req, query, params }) {
   const bannerNotification = process.env.SEARCH_RESULTS_NOTIFICATION || ""
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
-  const referer = req.headers?.referer
   const slug: string = params.slug as string
 
   const baseQuery = buildLockedBrowseQuery({
@@ -100,16 +98,12 @@ export async function getServerSideProps({ req, query, params }) {
 
   const results = await fetchSearchResults(searchParams)
 
-  // Check for possible bad incoming link (no results with one filter and no keyword)
-  if (
-    results.status === 404 &&
-    filtersObjectLength(searchParams.filters) === 1 &&
-    !searchParams.q
+  logSingleFilterNoResults(
+    "browse subjects",
+    results,
+    searchParams,
+    req.headers?.referer
   )
-    logServerWarn(
-      "fetchSearchResults",
-      `Possible bad incoming link; referer: ${referer}`
-    )
 
   if (results.status !== 200) {
     return { props: { errorStatus: results.status } }

--- a/pages/browse/subjects/[slug].tsx
+++ b/pages/browse/subjects/[slug].tsx
@@ -99,7 +99,7 @@ export async function getServerSideProps({ req, query, params }) {
   const results = await fetchSearchResults(searchParams)
 
   logSingleFilterNoResults(
-    "browse subjects",
+    "browse subjects gSSP",
     results,
     searchParams,
     req.headers?.referer

--- a/pages/browse/subjects/[slug].tsx
+++ b/pages/browse/subjects/[slug].tsx
@@ -4,6 +4,7 @@ import initializePatronTokenAuth from "../../../src/server/auth"
 import {
   mapQueryToSearchParams,
   checkForRedirectOnMatch,
+  filtersObjectLength,
 } from "../../../src/utils/searchUtils"
 import type { SearchResultsResponse } from "../../../src/types/searchTypes"
 import type { HTTPStatusCode } from "../../../src/types/appTypes"
@@ -11,6 +12,7 @@ import Search from "../../../src/components/Search/Search"
 import { useRouter } from "next/router"
 import { idConstants, useFocusContext } from "../../../src/context/FocusContext"
 import { buildLockedBrowseQuery } from "../../../src/utils/browseUtils"
+import { logServerWarn } from "../../../src/utils/logUtils"
 
 interface SubjectHeadingResultsProps {
   bannerNotification?: string
@@ -85,6 +87,7 @@ export default function SubjectHeadingResults({
 export async function getServerSideProps({ req, query, params }) {
   const bannerNotification = process.env.SEARCH_RESULTS_NOTIFICATION || ""
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+  const referer = req.headers?.referer
   const slug: string = params.slug as string
 
   const baseQuery = buildLockedBrowseQuery({
@@ -93,7 +96,20 @@ export async function getServerSideProps({ req, query, params }) {
     field: "subjectLiteral",
   })
 
-  const results = await fetchSearchResults(mapQueryToSearchParams(baseQuery))
+  const searchParams = mapQueryToSearchParams(baseQuery)
+
+  const results = await fetchSearchResults(searchParams)
+
+  // Check for possible bad incoming link (no results with one filter and no keyword)
+  if (
+    results.status === 404 &&
+    filtersObjectLength(searchParams.filters) === 1 &&
+    !searchParams.q
+  )
+    logServerWarn(
+      "fetchSearchResults",
+      `Possible bad incoming link; referer: ${referer}`
+    )
 
   if (results.status !== 200) {
     return { props: { errorStatus: results.status } }

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -4,6 +4,7 @@ import {
   mapQueryToSearchParams,
   getSearchQuery,
   checkForRedirectOnMatch,
+  filtersObjectLength,
 } from "../../src/utils/searchUtils"
 import type {
   SearchResultsResponse,
@@ -20,6 +21,7 @@ import type {
 } from "../../src/types/appTypes"
 import Search from "../../src/components/Search/Search"
 import { appConfig } from "../../src/config/appConfig"
+import { logServerWarn } from "../../src/utils/logUtils"
 
 interface SearchPageProps {
   bannerNotification?: string
@@ -87,8 +89,22 @@ export default function SearchPage({
 
 export async function getServerSideProps({ req, query }) {
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
+  const referer = req.headers?.referer
 
-  const results = await fetchSearchResults(mapQueryToSearchParams(query))
+  const searchParams = mapQueryToSearchParams(query)
+
+  const results = await fetchSearchResults(searchParams)
+
+  // Check for possible bad incoming link (no results with one filter and no keyword)
+  if (
+    results.status === 404 &&
+    filtersObjectLength(searchParams.filters) === 1 &&
+    !searchParams.q
+  )
+    logServerWarn(
+      "fetchSearchResults",
+      `Possible bad incoming link; referer: ${referer}`
+    )
 
   // Direct to error display according to status
   if (results.status !== 200) {

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -94,7 +94,7 @@ export async function getServerSideProps({ req, query }) {
   const results = await fetchSearchResults(searchParams)
 
   logSingleFilterNoResults(
-    "search page",
+    "search page gSSP",
     results,
     searchParams,
     req.headers?.referer

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -4,7 +4,6 @@ import {
   mapQueryToSearchParams,
   getSearchQuery,
   checkForRedirectOnMatch,
-  filtersObjectLength,
 } from "../../src/utils/searchUtils"
 import type {
   SearchResultsResponse,
@@ -21,7 +20,7 @@ import type {
 } from "../../src/types/appTypes"
 import Search from "../../src/components/Search/Search"
 import { appConfig } from "../../src/config/appConfig"
-import { logServerWarn } from "../../src/utils/logUtils"
+import { logSingleFilterNoResults } from "../../src/utils/logUtils"
 
 interface SearchPageProps {
   bannerNotification?: string
@@ -89,22 +88,17 @@ export default function SearchPage({
 
 export async function getServerSideProps({ req, query }) {
   const patronTokenResponse = await initializePatronTokenAuth(req.cookies)
-  const referer = req.headers?.referer
 
   const searchParams = mapQueryToSearchParams(query)
 
   const results = await fetchSearchResults(searchParams)
 
-  // Check for possible bad incoming link (no results with one filter and no keyword)
-  if (
-    results.status === 404 &&
-    filtersObjectLength(searchParams.filters) === 1 &&
-    !searchParams.q
+  logSingleFilterNoResults(
+    "search page",
+    results,
+    searchParams,
+    req.headers?.referer
   )
-    logServerWarn(
-      "fetchSearchResults",
-      `Possible bad incoming link; referer: ${referer}`
-    )
 
   // Direct to error display according to status
   if (results.status !== 200) {

--- a/src/utils/logUtils.ts
+++ b/src/utils/logUtils.ts
@@ -30,7 +30,7 @@ export const logSingleFilterNoResults = (
     !searchParams.q
   )
     logServerWarn(
-      "Search results gSSP",
-      `Link to single filter, no results at ${location}; referer: ${referer}`
+      location,
+      `Link to single filter, no results; referer: ${referer}`
     )
 }

--- a/src/utils/logUtils.ts
+++ b/src/utils/logUtils.ts
@@ -17,7 +17,6 @@ export const logServerWarn = (location: string, message: string): void => {
  * (indicated by a 404 response with one filter applied and no keyword, and a referer present).
  * If this is the case, logs a server warning
  */
-// Check for possible bad incoming link (no results with one filter and no keyword)
 export const logSingleFilterNoResults = (
   location: string,
   results: SearchResultsResponse,

--- a/src/utils/logUtils.ts
+++ b/src/utils/logUtils.ts
@@ -1,4 +1,6 @@
 import { logger } from "@nypl/node-utils"
+import type { SearchParams, SearchResultsResponse } from "../types/searchTypes"
+import { filtersObjectLength } from "./searchUtils"
 
 export const logServerError = (location: string, message: string): void => {
   logger.error(`Error in ${location}: ${message}`)
@@ -6,4 +8,30 @@ export const logServerError = (location: string, message: string): void => {
 
 export const logServerWarn = (location: string, message: string): void => {
   logger.warn(`Warning in ${location}: ${message}`)
+}
+
+/**
+ * logSingleFilterNoResults
+ * Given location, SearchResultsResponse, SearchParams, and (possibly empty) request referer,
+ * checks for a possible malformed incoming link
+ * (indicated by a 404 response with one filter applied and no keyword, and a referer present).
+ * If this is the case, logs a server warning
+ */
+// Check for possible bad incoming link (no results with one filter and no keyword)
+export const logSingleFilterNoResults = (
+  location: string,
+  results: SearchResultsResponse,
+  searchParams: SearchParams,
+  referer: string | undefined
+): void => {
+  if (
+    referer &&
+    results.status === 404 &&
+    filtersObjectLength(searchParams.filters) === 1 &&
+    !searchParams.q
+  )
+    logServerWarn(
+      "Search results gSSP",
+      `Link to single filter, no results at ${location}; referer: ${referer}`
+    )
 }

--- a/src/utils/utilsTests/logUtils.test.ts
+++ b/src/utils/utilsTests/logUtils.test.ts
@@ -26,13 +26,13 @@ describe("logUtils", () => {
     })
     it("logs the correct warning if conditions apply", () => {
       logSingleFilterNoResults(
-        "search page",
+        "search page gSSP",
         mock404Result,
         mockSearchParamSingleFilter,
         "http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
       )
       expect(logger.warn).toHaveBeenCalledWith(
-        "Warning in Search results gSSP: Link to single filter, no results at search page; referer: http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
+        "Warning in search page gSSP: Link to single filter, no results; referer: http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
       )
     })
     it("doesn't log when referer is undefined", () => {

--- a/src/utils/utilsTests/logUtils.test.ts
+++ b/src/utils/utilsTests/logUtils.test.ts
@@ -1,0 +1,48 @@
+import type { HTTPStatusCode } from "../../types/appTypes"
+import { logSingleFilterNoResults } from "../logUtils"
+
+jest.mock("@nypl/node-utils", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+import { logger } from "@nypl/node-utils"
+
+const mock404Result = {
+  status: 404 as HTTPStatusCode,
+}
+const mockSearchParamSingleFilter = {
+  filters: {
+    language: ["lang:rus"],
+  },
+}
+
+describe("logUtils", () => {
+  describe("logSingleFilterNoResults", () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    it("logs the correct warning if conditions apply", () => {
+      logSingleFilterNoResults(
+        "search page",
+        mock404Result,
+        mockSearchParamSingleFilter,
+        "http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
+      )
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Warning in Search results gSSP: Link to single filter, no results at search page; referer: http://local.nypl.org:8080/research/research-catalog/bib/b16767329"
+      )
+    })
+    it("doesn't log when referer is undefined", () => {
+      logSingleFilterNoResults(
+        "search page",
+        mock404Result,
+        mockSearchParamSingleFilter,
+        undefined
+      )
+      expect(logger.warn).toHaveBeenCalledTimes(0)
+    })
+  })
+})


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)

## This PR does the following:

- Logs a warning when a search query is performed with no keyword and a single filter, and no results are found

## How has this been tested? How should a reviewer test this?

- Run RC locally and use Postman/curl to send a request to a bad filter (e.g. http://local.nypl.org:8080/research/research-catalog/search?filters%5Bformat%5D%5D
), manually setting referrer in the headers. Verify that the warning log has been logged locally with the correct referrer.

## Accessibility updates?

- N/A

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.


[SCC-5269]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ