### PR TITLE
Fix status/focus

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated series links in bib details [SCC-5195](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5195)
+- Condensed status state for account banners
 
 ## [1.9.0] 2026-04-14
 

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -92,7 +92,7 @@ describe("Advanced search form", () => {
   it("defaults to call number sort when call number is the only field passed", async () => {
     const callNumberInput = screen.getByLabelText("Call number")
     fireEvent.change(callNumberInput, { target: { value: "12345" } })
-    await delay(500)
+    await delay(600)
     submit()
     expect(mockRouter.asPath).toBe(
       "/search?q=&callnumber=12345&sort=callnumber&searched_from=advanced"

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -14,6 +14,7 @@ jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 describe("Advanced search form", () => {
   beforeEach(async () => {
     render(<AdvancedSearch isAuthenticated={true} />)
+    await delay(200)
   })
   const submit = () => {
     fireEvent.click(screen.getByTestId("submit-advanced-search-button"))
@@ -67,6 +68,8 @@ describe("Advanced search form", () => {
   }
   afterEach(async () => {
     await userEvent.click(screen.getByText("Clear fields"))
+    // Flush any pending focus delays triggered by clearing the form
+    await delay(200)
   })
 
   it("displays alert when no fields are submitted", () => {
@@ -171,6 +174,8 @@ describe("Advanced search form", () => {
       "Division multiselect, 1 item selected"
     )
     await userEvent.click(screen.getByText("Clear fields"))
+    // Allow focus delay to resolve before assertions
+    await delay(200)
     ;[
       keywordInput,
       contributorInput,

--- a/__test__/pages/search/advancedSearchForm.test.tsx
+++ b/__test__/pages/search/advancedSearchForm.test.tsx
@@ -13,8 +13,8 @@ jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 
 describe("Advanced search form", () => {
   beforeEach(async () => {
+    mockRouter.setCurrentUrl("/search/advanced")
     render(<AdvancedSearch isAuthenticated={true} />)
-    await delay(200)
   })
   const submit = () => {
     fireEvent.click(screen.getByTestId("submit-advanced-search-button"))
@@ -68,22 +68,11 @@ describe("Advanced search form", () => {
   }
   afterEach(async () => {
     await userEvent.click(screen.getByText("Clear fields"))
-    // Flush any pending focus delays triggered by clearing the form
-    await delay(200)
   })
 
   it("displays alert when no fields are submitted", () => {
     submit()
     expect(screen.getByText(defaultEmptySearchErrorMessage)).toBeInTheDocument()
-  })
-
-  it("can set keyword, contributor, title, subject, genre, and series", async () => {
-    await updateAllFields()
-    submit()
-
-    expect(mockRouter.asPath).toBe(
-      "/search?q=spaghetti&title=il+amore+di+pasta&contributor=strega+nonna&callnumber=12345&standard_number=67890&subject=italian+food&genre=cookbooks&series=pasta+series&searched_from=advanced"
-    )
   })
   it("renders inputs for all text input fields", () => {
     textInputFields.map(({ label }) => {
@@ -92,13 +81,23 @@ describe("Advanced search form", () => {
     })
   })
 
+  it("can set keyword, contributor, title, subject, genre, and series", async () => {
+    await updateAllFields()
+    await delay(500)
+    submit()
+
+    expect(mockRouter.asPath).toBe(
+      "/search?q=spaghetti&title=il+amore+di+pasta&contributor=strega+nonna&callnumber=12345&standard_number=67890&subject=italian+food&genre=cookbooks&series=pasta+series&searched_from=advanced"
+    )
+  })
+
   it("defaults to call number sort when call number is the only field passed", async () => {
     const callNumberInput = screen.getByLabelText("Call number")
-    fireEvent.change(callNumberInput, { target: { value: "12345" } })
-    await delay(600)
+    fireEvent.change(callNumberInput, { target: { value: "1234" } })
+    await delay(500)
     submit()
     expect(mockRouter.asPath).toBe(
-      "/search?q=&callnumber=12345&sort=callnumber&searched_from=advanced"
+      "/search?q=&callnumber=1234&sort=callnumber&searched_from=advanced"
     )
   })
 
@@ -174,8 +173,6 @@ describe("Advanced search form", () => {
       "Division multiselect, 1 item selected"
     )
     await userEvent.click(screen.getByText("Clear fields"))
-    // Allow focus delay to resolve before assertions
-    await delay(200)
     ;[
       keywordInput,
       contributorInput,

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -55,6 +55,7 @@ import { PatronDataProvider } from "../../../src/context/PatronDataContext"
 import MyAccount from "../../../src/models/MyAccount"
 import { StatusBanner } from "../../../src/components/MyAccount/Settings/StatusBanner"
 import type { StatusBannerState } from "../../../src/components/MyAccount/Settings/StatusBanner"
+import { idConstants } from "../../../src/context/FocusContext"
 
 interface BibPropsType {
   discoveryBibResult: DiscoveryBibResult
@@ -103,15 +104,7 @@ export default function BibPage({
   const controllerRef = useRef<AbortController>()
 
   // Manage status banner display for list actions
-  const bannerRef = useRef<HTMLDivElement>(null)
   const [status, setStatus] = useState<StatusBannerState | null>(null)
-  useEffect(() => {
-    if (status && bannerRef.current) {
-      setTimeout(() => {
-        bannerRef.current?.focus()
-      }, 100)
-    }
-  }, [status])
 
   if (errorStatus) {
     return (
@@ -251,7 +244,7 @@ export default function BibPage({
         </Box>
         <div
           tabIndex={-1}
-          ref={bannerRef}
+          id={idConstants.listStatusBanner}
           style={{ marginTop: "-16px", marginBottom: "32px" }}
         >
           {status && (

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -53,8 +53,8 @@ import UserGuideBanner from "../../../src/components/Banners/UserGuideBanner"
 import { ManageBibInList } from "../../../src/components/List/ManageBibInList"
 import { PatronDataProvider } from "../../../src/context/PatronDataContext"
 import MyAccount from "../../../src/models/MyAccount"
-import type { StatusType } from "../../../src/components/MyAccount/Settings/StatusBanner"
 import { StatusBanner } from "../../../src/components/MyAccount/Settings/StatusBanner"
+import type { StatusBannerState } from "../../../src/components/MyAccount/Settings/StatusBanner"
 
 interface BibPropsType {
   discoveryBibResult: DiscoveryBibResult
@@ -104,10 +104,9 @@ export default function BibPage({
 
   // Manage status banner display for list actions
   const bannerRef = useRef<HTMLDivElement>(null)
-  const [status, setStatus] = useState<StatusType>("")
-  const [statusMessage, setStatusMessage] = useState<string>("")
+  const [status, setStatus] = useState<StatusBannerState | null>(null)
   useEffect(() => {
-    if (status !== "" && bannerRef.current) {
+    if (status && bannerRef.current) {
       setTimeout(() => {
         bannerRef.current?.focus()
       }, 100)
@@ -255,8 +254,8 @@ export default function BibPage({
           ref={bannerRef}
           style={{ marginTop: "-16px", marginBottom: "32px" }}
         >
-          {status !== "" && (
-            <StatusBanner status={status} statusMessage={statusMessage} />
+          {status && (
+            <StatusBanner type={status.type} message={status.message} />
           )}
         </div>
         {findingAid && (
@@ -270,7 +269,6 @@ export default function BibPage({
           </Heading>
           <ManageBibInList
             setStatus={setStatus}
-            setStatusMessage={setStatusMessage}
             recordId={bib.id}
             isAuthenticated={isAuthenticated}
           />

--- a/src/components/List/ManageBibInList.test.tsx
+++ b/src/components/List/ManageBibInList.test.tsx
@@ -190,16 +190,4 @@ describe("ManageBibInList", () => {
       )
     })
   })
-
-  it("focuses the expected button from the URL search params", () => {
-    window.location.search = "?focus=manage-bib-b12345678"
-
-    const focusSpy = jest.spyOn(HTMLButtonElement.prototype, "focus")
-
-    renderWithContext([{ id: "list-1", isDefaultList: true, records: [] }])
-    expect(focusSpy).toHaveBeenCalled()
-    expect(mockReplaceState).toHaveBeenCalled()
-
-    focusSpy.mockRestore()
-  })
 })

--- a/src/components/List/ManageBibInList.test.tsx
+++ b/src/components/List/ManageBibInList.test.tsx
@@ -123,7 +123,7 @@ describe("ManageBibInList", () => {
 
     await waitFor(() => {
       expect(mockSetStatus).toHaveBeenLastCalledWith(
-        DYNAMIC_STATUS_MESSAGES["save-record-success"]("list-1")
+        DYNAMIC_STATUS_MESSAGES.saveRecordSuccess("list-1")
       )
     })
     expect(mockSetUpdatedAccountData).toHaveBeenCalled()
@@ -153,7 +153,7 @@ describe("ManageBibInList", () => {
 
     await waitFor(() => {
       expect(mockSetStatus).toHaveBeenCalledWith(
-        DYNAMIC_STATUS_MESSAGES["remove-record-success"]("list-1")
+        DYNAMIC_STATUS_MESSAGES.removeRecordSuccess("list-1")
       )
     })
     expect(mockSetUpdatedAccountData).toHaveBeenCalled()
@@ -186,7 +186,7 @@ describe("ManageBibInList", () => {
 
     await waitFor(() => {
       expect(mockSetStatus).toHaveBeenCalledWith(
-        STATIC_STATUS_MESSAGES["save-record-failure"]
+        STATIC_STATUS_MESSAGES.saveRecordFailure
       )
     })
   })

--- a/src/components/List/ManageBibInList.test.tsx
+++ b/src/components/List/ManageBibInList.test.tsx
@@ -4,6 +4,10 @@ import userEvent from "@testing-library/user-event"
 import { ManageBibInList } from "./ManageBibInList"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { BASE_URL } from "../../config/constants"
+import {
+  DYNAMIC_STATUS_MESSAGES,
+  STATIC_STATUS_MESSAGES,
+} from "../../utils/statusUtils"
 
 // Mocking window behavior
 const mockAssign = jest.fn()
@@ -31,13 +35,11 @@ const mockBib = { id: "b12345678" } as any
 
 describe("ManageBibInList", () => {
   let mockSetStatus: jest.Mock
-  let mockSetStatusMessage: jest.Mock
   let mockSetUpdatedAccountData: jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockSetStatus = jest.fn()
-    mockSetStatusMessage = jest.fn()
     mockSetUpdatedAccountData = jest.fn()
     window.location.search = ""
   })
@@ -61,7 +63,6 @@ describe("ManageBibInList", () => {
           recordId={mockBib.id}
           isAuthenticated={isAuthenticated}
           setStatus={mockSetStatus}
-          setStatusMessage={mockSetStatusMessage}
         />
       </PatronDataContext.Provider>
     )
@@ -121,9 +122,10 @@ describe("ManageBibInList", () => {
     )
 
     await waitFor(() => {
-      expect(mockSetStatus).toHaveBeenCalledWith("success")
+      expect(mockSetStatus).toHaveBeenLastCalledWith(
+        DYNAMIC_STATUS_MESSAGES["save-record-success"]("list-1")
+      )
     })
-    expect(mockSetStatusMessage).toHaveBeenCalled()
     expect(mockSetUpdatedAccountData).toHaveBeenCalled()
   })
 
@@ -150,9 +152,10 @@ describe("ManageBibInList", () => {
     )
 
     await waitFor(() => {
-      expect(mockSetStatus).toHaveBeenCalledWith("success")
+      expect(mockSetStatus).toHaveBeenCalledWith(
+        DYNAMIC_STATUS_MESSAGES["remove-record-success"]("list-1")
+      )
     })
-    expect(mockSetStatusMessage).toHaveBeenCalled()
     expect(mockSetUpdatedAccountData).toHaveBeenCalled()
   })
 
@@ -182,11 +185,10 @@ describe("ManageBibInList", () => {
     await userEvent.click(screen.getByRole("button", { name: /Save/i }))
 
     await waitFor(() => {
-      expect(mockSetStatus).toHaveBeenCalledWith("failure")
+      expect(mockSetStatus).toHaveBeenCalledWith(
+        STATIC_STATUS_MESSAGES["save-record-failure"]
+      )
     })
-    expect(mockSetStatusMessage).toHaveBeenCalledWith(
-      "This record could not be saved."
-    )
   })
 
   it("focuses the expected button from the URL search params", () => {

--- a/src/components/List/ManageBibInList.tsx
+++ b/src/components/List/ManageBibInList.tsx
@@ -2,7 +2,6 @@ import { useContext, useEffect, useRef, useState } from "react"
 import {
   Button,
   Icon,
-  Text,
   Box,
   useNYPLBreakpoints,
 } from "@nypl/design-system-react-components"
@@ -10,7 +9,6 @@ import { appConfig } from "../../config/appConfig"
 import { encodeURIComponentWithPeriods } from "../../utils/appUtils"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { BASE_URL } from "../../config/constants"
-import Link from "../Link/Link"
 import type { List } from "../../types/listTypes"
 import {
   Popover,
@@ -20,12 +18,15 @@ import {
   DrawerOverlay,
 } from "@chakra-ui/react"
 import { ManageBibInListMenu } from "./ManageBibInListMenu"
+import {
+  DYNAMIC_STATUS_MESSAGES,
+  STATIC_STATUS_MESSAGES,
+} from "../../utils/statusUtils"
 
 interface ManageBibInListProps {
   recordId: string
   isAuthenticated: boolean
   setStatus
-  setStatusMessage
 }
 
 /* Render button to indicate saved state of bib and open list management menu.
@@ -34,7 +35,6 @@ export const ManageBibInList = ({
   recordId,
   isAuthenticated,
   setStatus,
-  setStatusMessage,
 }: ManageBibInListProps) => {
   const buttonRef = useRef<HTMLButtonElement>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -53,42 +53,6 @@ export const ManageBibInList = ({
       ? "Remove"
       : "Manage"
     : "Save"
-
-  const successRemoveDefault = (defaultListId) => (
-    <Text marginBottom={0}>
-      This record has been removed from{" "}
-      <Link
-        target="_blank"
-        color="ui.link.primary !important"
-        href={`/account/lists/${defaultListId}`}
-      >
-        My workspace (default list)
-      </Link>
-      . Lists can be managed from your{" "}
-      <Link target="_blank" color="ui.link.primary !important" href="/account">
-        patron account
-      </Link>
-      .
-    </Text>
-  )
-
-  const successSaveDefault = (defaultListId) => (
-    <Text marginBottom={0}>
-      This record has been saved to{" "}
-      <Link
-        target="_blank"
-        color="ui.link.primary !important"
-        href={`/account/lists/${defaultListId}`}
-      >
-        My workspace (default list)
-      </Link>
-      . Lists can be managed from your{" "}
-      <Link target="_blank" color="ui.link.primary !important" href="/account">
-        patron account
-      </Link>
-      .
-    </Text>
-  )
 
   // Manage bib menu state
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -139,8 +103,7 @@ export const ManageBibInList = ({
         (list) => list.isDefaultList
       )
       const defaultListId = defaultList?.id
-      setStatus("")
-      setStatusMessage("")
+      setStatus(null)
       setIsLoading(true)
 
       try {
@@ -174,16 +137,16 @@ export const ManageBibInList = ({
               return { ...data, lists: updatedLists as List[] }
             })
           }
-          setStatus("success")
-          setStatusMessage(
+          setStatus(
             isSaved
-              ? successRemoveDefault(defaultListId)
-              : successSaveDefault(defaultListId)
+              ? DYNAMIC_STATUS_MESSAGES["remove-record-success"](defaultListId)
+              : DYNAMIC_STATUS_MESSAGES["save-record-success"](defaultListId)
           )
         } else {
-          setStatus("failure")
-          setStatusMessage(
-            `This record could not be ${isSaved ? "removed" : "saved"}.`
+          setStatus(
+            isSaved
+              ? STATIC_STATUS_MESSAGES["remove-record-failure"]
+              : STATIC_STATUS_MESSAGES["save-record-failure"]
           )
         }
       } catch (error) {
@@ -193,9 +156,10 @@ export const ManageBibInList = ({
           } list ${defaultListId}:`,
           error
         )
-        setStatus("failure")
-        setStatusMessage(
-          `This record could not be ${isSaved ? "removed" : "saved"}.`
+        setStatus(
+          isSaved
+            ? STATIC_STATUS_MESSAGES["remove-record-failure"]
+            : STATIC_STATUS_MESSAGES["save-record-failure"]
         )
       } finally {
         setIsLoading(false)
@@ -262,7 +226,6 @@ export const ManageBibInList = ({
             isOpen={isOpen}
             onClose={onClose}
             setStatus={setStatus}
-            setStatusMessage={setStatusMessage}
             recordId={recordId}
             isMobile={isMobile}
           />
@@ -285,7 +248,6 @@ export const ManageBibInList = ({
         isOpen={isOpen}
         onClose={onClose}
         setStatus={setStatus}
-        setStatusMessage={setStatusMessage}
         recordId={recordId}
         isMobile={isMobile}
       />

--- a/src/components/List/ManageBibInList.tsx
+++ b/src/components/List/ManageBibInList.tsx
@@ -139,14 +139,14 @@ export const ManageBibInList = ({
           }
           setStatus(
             isSaved
-              ? DYNAMIC_STATUS_MESSAGES["remove-record-success"](defaultListId)
-              : DYNAMIC_STATUS_MESSAGES["save-record-success"](defaultListId)
+              ? DYNAMIC_STATUS_MESSAGES.removeRecordSuccess(defaultListId)
+              : DYNAMIC_STATUS_MESSAGES.saveRecordSuccess(defaultListId)
           )
         } else {
           setStatus(
             isSaved
-              ? STATIC_STATUS_MESSAGES["remove-record-failure"]
-              : STATIC_STATUS_MESSAGES["save-record-failure"]
+              ? STATIC_STATUS_MESSAGES.removeRecordFailure
+              : STATIC_STATUS_MESSAGES.saveRecordFailure
           )
         }
       } catch (error) {
@@ -158,8 +158,8 @@ export const ManageBibInList = ({
         )
         setStatus(
           isSaved
-            ? STATIC_STATUS_MESSAGES["remove-record-failure"]
-            : STATIC_STATUS_MESSAGES["save-record-failure"]
+            ? STATIC_STATUS_MESSAGES.removeRecordFailure
+            : STATIC_STATUS_MESSAGES.saveRecordFailure
         )
       } finally {
         setIsLoading(false)

--- a/src/components/List/ManageBibInListMenu.test.tsx
+++ b/src/components/List/ManageBibInListMenu.test.tsx
@@ -5,18 +5,17 @@ import { ManageBibInListMenu } from "./ManageBibInListMenu"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { BASE_URL } from "../../config/constants"
 import { Popover } from "@chakra-ui/react"
+import { STATIC_STATUS_MESSAGES } from "../../utils/statusUtils"
 
 describe("ManageBibInListMenu", () => {
   let mockOnClose: jest.Mock
   let mockSetStatus: jest.Mock
-  let mockSetStatusMessage: jest.Mock
   let mockSetUpdatedAccountData: jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockOnClose = jest.fn()
     mockSetStatus = jest.fn()
-    mockSetStatusMessage = jest.fn()
     mockSetUpdatedAccountData = jest.fn()
     global.fetch = jest.fn()
   })
@@ -41,7 +40,6 @@ describe("ManageBibInListMenu", () => {
             isOpen={true}
             onClose={mockOnClose}
             setStatus={mockSetStatus}
-            setStatusMessage={mockSetStatusMessage}
             recordId="b12345678"
           />
         </Popover>
@@ -112,7 +110,7 @@ describe("ManageBibInListMenu", () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText("List created.")).toBeInTheDocument()
+      expect(screen.getByText(/List created/)).toBeInTheDocument()
     })
     expect(mockSetUpdatedAccountData).toHaveBeenCalled()
   })
@@ -139,7 +137,9 @@ describe("ManageBibInListMenu", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2)
 
     await waitFor(() => {
-      expect(mockSetStatus).toHaveBeenCalledWith("success")
+      expect(mockSetStatus).toHaveBeenCalledWith(
+        STATIC_STATUS_MESSAGES["list-changes-success"]
+      )
     })
     expect(mockOnClose).toHaveBeenCalled()
   })

--- a/src/components/List/ManageBibInListMenu.test.tsx
+++ b/src/components/List/ManageBibInListMenu.test.tsx
@@ -138,7 +138,7 @@ describe("ManageBibInListMenu", () => {
 
     await waitFor(() => {
       expect(mockSetStatus).toHaveBeenCalledWith(
-        STATIC_STATUS_MESSAGES["list-changes-success"]
+        STATIC_STATUS_MESSAGES.listChangesSuccess
       )
     })
     expect(mockOnClose).toHaveBeenCalled()

--- a/src/components/List/ManageBibInListMenu.tsx
+++ b/src/components/List/ManageBibInListMenu.tsx
@@ -25,6 +25,7 @@ import { SearchableCheckboxGroup } from "./SearchableCheckboxGroup"
 import { STATIC_STATUS_MESSAGES } from "../../utils/statusUtils"
 import { StatusBanner } from "../MyAccount/Settings/StatusBanner"
 import type { StatusBannerState } from "../MyAccount/Settings/StatusBanner"
+import { idConstants, useFocusContext } from "../../context/FocusContext"
 
 /** Render list management menu (inside Chakra Popover, Drawer on mobile) */
 export const ManageBibInListMenu = ({
@@ -46,6 +47,7 @@ export const ManageBibInListMenu = ({
     useContext(PatronDataContext)
   const patron = updatedAccountData?.patron
   const lists = updatedAccountData?.lists || []
+  const { setPersistentFocus } = useFocusContext()
 
   // Create list form banner and button focus management
   const createListButtonRef = useRef<HTMLButtonElement>(null)
@@ -231,8 +233,10 @@ export const ManageBibInListMenu = ({
           return { ...data, lists: updatedLists }
         })
         setStatus(STATIC_STATUS_MESSAGES["list-changes-success"])
+        setPersistentFocus(idConstants.listStatusBanner)
       } else {
         setStatus(STATIC_STATUS_MESSAGES["list-changes-failure"])
+        setPersistentFocus(idConstants.listStatusBanner)
       }
     } catch (error) {
       console.error("Error updating bib in lists:", error)

--- a/src/components/List/ManageBibInListMenu.tsx
+++ b/src/components/List/ManageBibInListMenu.tsx
@@ -21,9 +21,10 @@ import {
 import { useContext, useState, useEffect, useRef } from "react"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { BASE_URL } from "../../config/constants"
-import type { StatusType } from "../MyAccount/Settings/StatusBanner"
-import { StatusBanner } from "../MyAccount/Settings/StatusBanner"
 import { SearchableCheckboxGroup } from "./SearchableCheckboxGroup"
+import { STATIC_STATUS_MESSAGES } from "../../utils/statusUtils"
+import { StatusBanner } from "../MyAccount/Settings/StatusBanner"
+import type { StatusBannerState } from "../MyAccount/Settings/StatusBanner"
 
 /** Render list management menu (inside Chakra Popover, Drawer on mobile) */
 export const ManageBibInListMenu = ({
@@ -31,7 +32,6 @@ export const ManageBibInListMenu = ({
   onClose,
   list,
   setStatus,
-  setStatusMessage,
   recordId,
   isMobile,
 }: {
@@ -39,7 +39,6 @@ export const ManageBibInListMenu = ({
   onClose: () => void
   list?: any
   setStatus: any
-  setStatusMessage: any
   recordId: string
   isMobile?: boolean
 }) => {
@@ -51,11 +50,10 @@ export const ManageBibInListMenu = ({
   // Create list form banner and button focus management
   const createListButtonRef = useRef<HTMLButtonElement>(null)
   const internalBannerRef = useRef<HTMLDivElement>(null)
-  const [listCreationStatus, setListCreationStatus] = useState<StatusType>("")
-  const [listCreationStatusMessage, setListCreationStatusMessage] =
-    useState<string>("")
+  const [listCreationStatus, setListCreationStatus] =
+    useState<StatusBannerState | null>(null)
   useEffect(() => {
-    if (listCreationStatus !== "" && internalBannerRef.current) {
+    if (listCreationStatus && internalBannerRef.current) {
       setTimeout(() => {
         internalBannerRef.current?.focus()
       }, 100)
@@ -87,8 +85,8 @@ export const ManageBibInListMenu = ({
     if (isOpen) {
       setListName(list?.listName || "")
       setShowCreateForm(false)
-      setStatus("")
-      setListCreationStatus("")
+      setStatus(null)
+      setListCreationStatus(null)
       setSelectedLists(
         lists
           ?.filter((l: any) =>
@@ -127,11 +125,9 @@ export const ManageBibInListMenu = ({
           })
           setSelectedLists((prev) => [...prev, data.list.id])
         }
-        setListCreationStatus("success")
-        setListCreationStatusMessage("List created.")
+        setListCreationStatus(STATIC_STATUS_MESSAGES["create-list-success"])
       } else {
-        setListCreationStatus("failure")
-        setListCreationStatusMessage("List creation failed.")
+        setListCreationStatus(STATIC_STATUS_MESSAGES["create-list-failure"])
       }
     } catch (error) {
       console.error("Error creating list:", error)
@@ -234,14 +230,12 @@ export const ManageBibInListMenu = ({
 
           return { ...data, lists: updatedLists }
         })
+        setStatus(STATIC_STATUS_MESSAGES["list-changes-success"])
+      } else {
+        setStatus(STATIC_STATUS_MESSAGES["list-changes-failure"])
       }
-
-      setStatus("success")
-      setStatusMessage("Your list changes have been saved.")
     } catch (error) {
       console.error("Error updating bib in lists:", error)
-      setStatus("failure")
-      setStatusMessage("Your list changes could not be saved.")
     } finally {
       setIsSubmitting(false)
       onClose()
@@ -292,6 +286,7 @@ export const ManageBibInListMenu = ({
       </HeaderWrapper>
       <BodyWrapper
         sx={{
+          fontWeight: "normal",
           maxHeight: "360px",
           overflowY: "auto",
           ...(isMobile
@@ -367,11 +362,15 @@ export const ManageBibInListMenu = ({
           </Button>
         )}
 
-        <div tabIndex={-1} ref={internalBannerRef} style={{ marginTop: "8px" }}>
-          {listCreationStatus !== "" && (
+        <div
+          tabIndex={-1}
+          ref={internalBannerRef}
+          style={{ marginTop: "8px", marginBottom: "16px" }}
+        >
+          {listCreationStatus && (
             <StatusBanner
-              status={listCreationStatus}
-              statusMessage={listCreationStatusMessage}
+              type={listCreationStatus.type}
+              message={listCreationStatus.message}
             />
           )}
         </div>

--- a/src/components/List/ManageBibInListMenu.tsx
+++ b/src/components/List/ManageBibInListMenu.tsx
@@ -127,9 +127,9 @@ export const ManageBibInListMenu = ({
           })
           setSelectedLists((prev) => [...prev, data.list.id])
         }
-        setListCreationStatus(STATIC_STATUS_MESSAGES["create-list-success"])
+        setListCreationStatus(STATIC_STATUS_MESSAGES.createListSuccess)
       } else {
-        setListCreationStatus(STATIC_STATUS_MESSAGES["create-list-failure"])
+        setListCreationStatus(STATIC_STATUS_MESSAGES.createListFailure)
       }
     } catch (error) {
       console.error("Error creating list:", error)
@@ -232,10 +232,10 @@ export const ManageBibInListMenu = ({
 
           return { ...data, lists: updatedLists }
         })
-        setStatus(STATIC_STATUS_MESSAGES["list-changes-success"])
+        setStatus(STATIC_STATUS_MESSAGES.listChangesSuccess)
         setPersistentFocus(idConstants.listStatusBanner)
       } else {
-        setStatus(STATIC_STATUS_MESSAGES["list-changes-failure"])
+        setStatus(STATIC_STATUS_MESSAGES.listChangesFailure)
         setPersistentFocus(idConstants.listStatusBanner)
       }
     } catch (error) {

--- a/src/components/List/ManageBibInListMenu.tsx
+++ b/src/components/List/ManageBibInListMenu.tsx
@@ -18,7 +18,7 @@ import {
   DrawerFooter,
   DrawerHeader,
 } from "@chakra-ui/react"
-import { useContext, useState, useEffect, useRef } from "react"
+import { useContext, useState, useEffect } from "react"
 import { PatronDataContext } from "../../context/PatronDataContext"
 import { BASE_URL } from "../../config/constants"
 import { SearchableCheckboxGroup } from "./SearchableCheckboxGroup"
@@ -49,18 +49,9 @@ export const ManageBibInListMenu = ({
   const lists = updatedAccountData?.lists || []
   const { setPersistentFocus } = useFocusContext()
 
-  // Create list form banner and button focus management
-  const createListButtonRef = useRef<HTMLButtonElement>(null)
-  const internalBannerRef = useRef<HTMLDivElement>(null)
+  // Create list form status banner
   const [listCreationStatus, setListCreationStatus] =
     useState<StatusBannerState | null>(null)
-  useEffect(() => {
-    if (listCreationStatus && internalBannerRef.current) {
-      setTimeout(() => {
-        internalBannerRef.current?.focus()
-      }, 100)
-    }
-  }, [listCreationStatus])
 
   const [listName, setListName] = useState(list?.listName || "")
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -72,15 +63,6 @@ export const ManageBibInListMenu = ({
       )
       .map((l: any) => l.id) || []
   )
-
-  // Keeping focus within the create list form
-  useEffect(() => {
-    if (showCreateForm) {
-      setTimeout(() => {
-        document.getElementById("list-name")?.focus()
-      }, 50)
-    }
-  }, [showCreateForm])
 
   // Reset whole menu state on open
   useEffect(() => {
@@ -131,6 +113,7 @@ export const ManageBibInListMenu = ({
       } else {
         setListCreationStatus(STATIC_STATUS_MESSAGES.createListFailure)
       }
+      setPersistentFocus(idConstants.listMenuStatusBanner)
     } catch (error) {
       console.error("Error creating list:", error)
     } finally {
@@ -233,11 +216,10 @@ export const ManageBibInListMenu = ({
           return { ...data, lists: updatedLists }
         })
         setStatus(STATIC_STATUS_MESSAGES.listChangesSuccess)
-        setPersistentFocus(idConstants.listStatusBanner)
       } else {
         setStatus(STATIC_STATUS_MESSAGES.listChangesFailure)
-        setPersistentFocus(idConstants.listStatusBanner)
       }
+      setPersistentFocus(idConstants.listStatusBanner)
     } catch (error) {
       console.error("Error updating bib in lists:", error)
     } finally {
@@ -314,7 +296,7 @@ export const ManageBibInListMenu = ({
           >
             <FormField>
               <TextInput
-                id="list-name"
+                id={idConstants.createListNameInput}
                 value={listName}
                 labelText="List name (required)"
                 showLabel={true}
@@ -345,7 +327,7 @@ export const ManageBibInListMenu = ({
                   variant="secondary"
                   onClick={() => {
                     setShowCreateForm(false)
-                    setTimeout(() => createListButtonRef.current?.focus(), 100)
+                    setPersistentFocus(idConstants.createListButton)
                   }}
                   sx={{ background: "white" }}
                 >
@@ -356,10 +338,13 @@ export const ManageBibInListMenu = ({
           </Form>
         ) : (
           <Button
-            ref={createListButtonRef}
+            id={idConstants.createListButton}
             variant="text"
             paddingLeft="xs"
-            onClick={() => setShowCreateForm(true)}
+            onClick={() => {
+              setShowCreateForm(true)
+              setPersistentFocus(idConstants.createListNameInput)
+            }}
           >
             <Icon name="plus" size="medium" align="left" />
             Create new list
@@ -368,7 +353,7 @@ export const ManageBibInListMenu = ({
 
         <div
           tabIndex={-1}
-          ref={internalBannerRef}
+          id={idConstants.listMenuStatusBanner}
           style={{ marginTop: "8px", marginBottom: "16px" }}
         >
           {listCreationStatus && (

--- a/src/components/MyAccount/ListsTab/ListActions/CreateEditList.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/CreateEditList.tsx
@@ -20,6 +20,7 @@ import styles from "../../../../../styles/components/MyAccount.module.scss"
 import { useContext, useState, useEffect } from "react"
 import { PatronDataContext } from "../../../../context/PatronDataContext"
 import { BASE_URL } from "../../../../config/constants"
+import { STATIC_STATUS_MESSAGES } from "../../../../utils/statusUtils"
 
 /* Renders the Create or Edit list modal, and the triggering buttons (Create new list, Edit list). */
 export const CreateEditListModal = ({
@@ -28,7 +29,6 @@ export const CreateEditListModal = ({
   mode = "create",
   list,
   setStatus,
-  setStatusMessage,
   bannerRef,
 }: {
   isOpen: boolean
@@ -36,7 +36,6 @@ export const CreateEditListModal = ({
   mode?: "create" | "edit"
   list?: any
   setStatus: any
-  setStatusMessage: any
   bannerRef?: any
 }) => {
   const { updatedAccountData, setUpdatedAccountData } =
@@ -101,22 +100,20 @@ export const CreateEditListModal = ({
             })
           }
         }
-        setStatus("success")
-        setStatusMessage(
+        setStatus(
           isEdit
-            ? "Your changes have been saved."
-            : "Your list has been created."
+            ? STATIC_STATUS_MESSAGES["account-success"]
+            : STATIC_STATUS_MESSAGES["create-list-success"]
         )
       } else {
         if (isEdit) {
           setListName(list?.listName || "")
           setListDescription(list?.description || "")
         }
-        setStatus("failure")
-        setStatusMessage(
+        setStatus(
           isEdit
-            ? "Your changes were not saved."
-            : "Your list could not be created."
+            ? STATIC_STATUS_MESSAGES["account-failure"]
+            : STATIC_STATUS_MESSAGES["create-list-failure"]
         )
       }
     } catch (error) {
@@ -224,11 +221,7 @@ export const CreateEditListModal = ({
   )
 }
 
-export const CreateListButton = ({
-  setStatus,
-  setStatusMessage,
-  bannerRef,
-}: any) => {
+export const CreateListButton = ({ setStatus, bannerRef }: any) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   return (
@@ -242,19 +235,13 @@ export const CreateListButton = ({
         onClose={onClose}
         mode="create"
         setStatus={setStatus}
-        setStatusMessage={setStatusMessage}
         bannerRef={bannerRef}
       />
     </>
   )
 }
 
-export const EditListButton = ({
-  list,
-  setStatus,
-  setStatusMessage,
-  bannerRef,
-}: any) => {
+export const EditListButton = ({ list, setStatus, bannerRef }: any) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   return (
     <>
@@ -268,7 +255,6 @@ export const EditListButton = ({
         mode="edit"
         list={list}
         setStatus={setStatus}
-        setStatusMessage={setStatusMessage}
         bannerRef={bannerRef}
       />
     </>

--- a/src/components/MyAccount/ListsTab/ListActions/CreateEditList.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/CreateEditList.tsx
@@ -103,8 +103,8 @@ export const CreateEditListModal = ({
         }
         setStatus(
           isEdit
-            ? STATIC_STATUS_MESSAGES["account-success"]
-            : STATIC_STATUS_MESSAGES["create-list-success"]
+            ? STATIC_STATUS_MESSAGES.accountSuccess
+            : STATIC_STATUS_MESSAGES.createListSuccess
         )
       } else {
         if (isEdit) {
@@ -113,8 +113,8 @@ export const CreateEditListModal = ({
         }
         setStatus(
           isEdit
-            ? STATIC_STATUS_MESSAGES["account-failure"]
-            : STATIC_STATUS_MESSAGES["create-list-failure"]
+            ? STATIC_STATUS_MESSAGES.accountFailure
+            : STATIC_STATUS_MESSAGES.createListFailure
         )
       }
     } catch (error) {

--- a/src/components/MyAccount/ListsTab/ListActions/CreateEditList.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/CreateEditList.tsx
@@ -64,6 +64,7 @@ export const CreateEditListModal = ({
 
     setIsSubmitting(true)
     setIsSubmitted(true)
+    setStatus(null)
     try {
       const isEdit = mode === "edit"
       const url = isEdit

--- a/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
@@ -18,6 +18,7 @@ import type { List } from "../../../../types/listTypes"
 import { downloadList } from "../../../../utils/listUtils"
 import { useDisclosure } from "@chakra-ui/react"
 import { CreateEditListModal } from "./CreateEditList"
+import { STATIC_STATUS_MESSAGES } from "../../../../utils/statusUtils"
 
 /**
  * The ListActionsMenu component renders the actions button and menu (with list operations)
@@ -26,12 +27,10 @@ import { CreateEditListModal } from "./CreateEditList"
 const ListActionsMenu = ({
   list,
   setStatus,
-  setStatusMessage,
   bannerRef,
 }: {
   list: List
   setStatus
-  setStatusMessage
   bannerRef?: any
 }) => {
   const { updatedAccountData, setUpdatedAccountData } =
@@ -72,11 +71,9 @@ const ListActionsMenu = ({
             ...updatedAccountData,
             lists: updatedLists,
           })
-          setStatus("success")
-          setStatusMessage("Your list has been deleted.")
+          setStatus(STATIC_STATUS_MESSAGES["delete-list-success"])
         } else {
-          setStatus("failure")
-          setStatusMessage("Your list could not be deleted.")
+          setStatus(STATIC_STATUS_MESSAGES["delete-list-failure"])
         }
       } catch (error) {
         console.error("Error deleting list:", error)
@@ -85,7 +82,7 @@ const ListActionsMenu = ({
       }
     },
     onCancel: () => {
-      setStatus("")
+      setStatus(null)
       closeModal()
     },
   }
@@ -104,8 +101,7 @@ const ListActionsMenu = ({
       label: "Duplicate",
       media: { type: "icon", name: "contentCopy" },
       onClick: async () => {
-        setStatus("")
-        setStatusMessage("")
+        setStatus(null)
         try {
           const response = await fetch(`${BASE_URL}/api/account/lists/list`, {
             method: "POST",
@@ -127,16 +123,12 @@ const ListActionsMenu = ({
                 lists: [data.list, ...lists],
               })
             }
-            setStatus("success")
-            setStatusMessage("Your list has been duplicated.")
+            setStatus(STATIC_STATUS_MESSAGES["duplicate-list-success"])
           } else {
-            setStatus("failure")
-            setStatusMessage("Your list could not be duplicated.")
+            setStatus(STATIC_STATUS_MESSAGES["duplicate-list-failure"])
           }
         } catch (error) {
           console.error("Error duplicating list:", error)
-          setStatus("failure")
-          setStatusMessage("Your list could not be duplicated.")
         }
       },
     },
@@ -146,9 +138,8 @@ const ListActionsMenu = ({
       label: "Download",
       media: { type: "icon", name: "download" },
       onClick: async () => {
-        setStatus("")
-        setStatusMessage("")
-        downloadList(list, "modified_date_asc", setStatus, setStatusMessage)
+        setStatus(null)
+        downloadList(list, "modified_date_asc", setStatus)
       },
     },
   ]
@@ -160,8 +151,7 @@ const ListActionsMenu = ({
       label: "Delete",
       media: { type: "icon", name: "actionDelete" },
       onClick: () => {
-        setStatus("")
-        setStatusMessage("")
+        setStatus(null)
         setModalProps(deleteListModalProps as ConfirmationModalProps)
         openModal()
       },
@@ -172,8 +162,7 @@ const ListActionsMenu = ({
       label: "Edit",
       media: { type: "icon", name: "editorMode" },
       onClick: () => {
-        setStatus("")
-        setStatusMessage("")
+        setStatus(null)
         openEdit()
       },
     })
@@ -202,7 +191,6 @@ const ListActionsMenu = ({
         mode="edit"
         list={list}
         setStatus={setStatus}
-        setStatusMessage={setStatusMessage}
         bannerRef={bannerRef}
       />
     </>

--- a/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
@@ -74,11 +74,10 @@ const ListActionsMenu = ({
             lists: updatedLists,
           })
           setStatus(STATIC_STATUS_MESSAGES.deleteListSuccess)
-          setPersistentFocus(idConstants.listStatusBanner)
         } else {
           setStatus(STATIC_STATUS_MESSAGES.deleteListFailure)
-          setPersistentFocus(idConstants.listStatusBanner)
         }
+        setPersistentFocus(idConstants.listStatusBanner)
       } catch (error) {
         console.error("Error deleting list:", error)
       } finally {
@@ -131,6 +130,7 @@ const ListActionsMenu = ({
           } else {
             setStatus(STATIC_STATUS_MESSAGES.duplicateListFailure)
           }
+          setPersistentFocus(idConstants.listStatusBanner)
         } catch (error) {
           console.error("Error duplicating list:", error)
         }

--- a/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
@@ -73,10 +73,10 @@ const ListActionsMenu = ({
             ...updatedAccountData,
             lists: updatedLists,
           })
-          setStatus(STATIC_STATUS_MESSAGES["delete-list-success"])
+          setStatus(STATIC_STATUS_MESSAGES.deleteListSuccess)
           setPersistentFocus(idConstants.listStatusBanner)
         } else {
-          setStatus(STATIC_STATUS_MESSAGES["delete-list-failure"])
+          setStatus(STATIC_STATUS_MESSAGES.deleteListFailure)
           setPersistentFocus(idConstants.listStatusBanner)
         }
       } catch (error) {
@@ -127,9 +127,9 @@ const ListActionsMenu = ({
                 lists: [data.list, ...lists],
               })
             }
-            setStatus(STATIC_STATUS_MESSAGES["duplicate-list-success"])
+            setStatus(STATIC_STATUS_MESSAGES.duplicateListSuccess)
           } else {
-            setStatus(STATIC_STATUS_MESSAGES["duplicate-list-failure"])
+            setStatus(STATIC_STATUS_MESSAGES.duplicateListFailure)
           }
         } catch (error) {
           console.error("Error duplicating list:", error)

--- a/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
+++ b/src/components/MyAccount/ListsTab/ListActions/ListActionsMenu.tsx
@@ -19,6 +19,7 @@ import { downloadList } from "../../../../utils/listUtils"
 import { useDisclosure } from "@chakra-ui/react"
 import { CreateEditListModal } from "./CreateEditList"
 import { STATIC_STATUS_MESSAGES } from "../../../../utils/statusUtils"
+import { idConstants, useFocusContext } from "../../../../context/FocusContext"
 
 /**
  * The ListActionsMenu component renders the actions button and menu (with list operations)
@@ -36,6 +37,7 @@ const ListActionsMenu = ({
   const { updatedAccountData, setUpdatedAccountData } =
     useContext(PatronDataContext)
   const { patron, lists } = updatedAccountData
+  const { setPersistentFocus } = useFocusContext()
 
   // DS Modal controls used for Delete list modal
   const { onOpen: openModal, onClose: closeModal, Modal } = useModal()
@@ -72,8 +74,10 @@ const ListActionsMenu = ({
             lists: updatedLists,
           })
           setStatus(STATIC_STATUS_MESSAGES["delete-list-success"])
+          setPersistentFocus(idConstants.listStatusBanner)
         } else {
           setStatus(STATIC_STATUS_MESSAGES["delete-list-failure"])
+          setPersistentFocus(idConstants.listStatusBanner)
         }
       } catch (error) {
         console.error("Error deleting list:", error)
@@ -132,17 +136,20 @@ const ListActionsMenu = ({
         }
       },
     },
-    {
+  ]
+
+  if (list.recordCount > 0) {
+    listOptions.push({
       type: "action",
       id: "download",
       label: "Download",
       media: { type: "icon", name: "download" },
       onClick: async () => {
         setStatus(null)
-        downloadList(list, "modified_date_asc", setStatus)
+        downloadList(list, "modified_date_asc")
       },
-    },
-  ]
+    })
+  }
 
   if (!list.isDefaultList) {
     listOptions.push({

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -43,8 +43,6 @@ const ListDisplay = ({ list }: { list?: List }) => {
   const bannerRef = useRef<HTMLDivElement>(null)
   const [status, setStatus] = useState<StatusBannerState | null>(null)
 
-  console.log(status)
-
   // DS Modal controls used for Delete list modal
   const { onOpen: openModal, onClose: closeModal, Modal } = useModal()
   const [modalProps, setModalProps] = useState<BaseModalProps>()

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -113,9 +113,9 @@ const ListDisplay = ({ list }: { list?: List }) => {
             ...updatedAccountData,
             lists: updatedLists,
           })
-          setStatus(STATIC_STATUS_MESSAGES["delete-list-success"])
+          setStatus(STATIC_STATUS_MESSAGES.deleteListSuccess)
         } else {
-          setStatus(STATIC_STATUS_MESSAGES["delete-list-failure"])
+          setStatus(STATIC_STATUS_MESSAGES.deleteListFailure)
           closeModal()
         }
       } catch (error) {
@@ -224,9 +224,9 @@ const ListDisplay = ({ list }: { list?: List }) => {
                       "_blank"
                     )
                   }
-                  setStatus(STATIC_STATUS_MESSAGES["duplicate-list-success"])
+                  setStatus(STATIC_STATUS_MESSAGES.duplicateListSuccess)
                 } else {
-                  setStatus(STATIC_STATUS_MESSAGES["duplicate-list-failure"])
+                  setStatus(STATIC_STATUS_MESSAGES.duplicateListFailure)
                 }
                 setPersistentFocus(idConstants.listStatusBanner)
               } catch (error) {

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -19,11 +19,13 @@ import ListRecordsTable from "./ListRecordsTable"
 import { useRouter } from "next/router"
 import type { List, ListRecordsSort } from "../../../types/listTypes"
 import { useContext, useEffect, useRef, useState } from "react"
-import { StatusBanner, type StatusType } from "../Settings/StatusBanner"
+import { StatusBanner } from "../Settings/StatusBanner"
+import type { StatusBannerState } from "../Settings/StatusBanner"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import { BASE_URL } from "../../../config/constants"
 import { EditListButton } from "./ListActions/CreateEditList"
 import { downloadList } from "../../../utils/listUtils"
+import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
 
 /* ListDisplay renders the list metadata, list operations, and the ListRecordTable. */
 const ListDisplay = ({ list }: { list?: List }) => {
@@ -40,10 +42,10 @@ const ListDisplay = ({ list }: { list?: List }) => {
   const bannerRef = useRef<HTMLDivElement>(null)
 
   // Manage status banner display for list actions
-  const [status, setStatus] = useState<StatusType>("")
-  const [statusMessage, setStatusMessage] = useState<string>("")
+  const [status, setStatus] = useState<StatusBannerState | null>(null)
+
   useEffect(() => {
-    if (status !== "" && bannerRef.current) {
+    if (status && bannerRef.current) {
       setTimeout(() => {
         bannerRef.current?.focus()
       }, 100)
@@ -120,9 +122,9 @@ const ListDisplay = ({ list }: { list?: List }) => {
             ...updatedAccountData,
             lists: updatedLists,
           })
+          setStatus(STATIC_STATUS_MESSAGES["delete-list-success"])
         } else {
-          setStatus("failure")
-          setStatusMessage("Your list could not be deleted.")
+          setStatus(STATIC_STATUS_MESSAGES["delete-list-failure"])
           closeModal()
         }
       } catch (error) {
@@ -130,7 +132,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
       }
     },
     onCancel: () => {
-      setStatus("")
+      setStatus(null)
       closeModal()
     },
   }
@@ -195,14 +197,12 @@ const ListDisplay = ({ list }: { list?: List }) => {
               list={list}
               bannerRef={bannerRef}
               setStatus={setStatus}
-              setStatusMessage={setStatusMessage}
             />
           )}
           <Button
             variant="secondary"
             onClick={async () => {
-              setStatus("")
-              setStatusMessage("")
+              setStatus(null)
               try {
                 const response = await fetch(
                   `${BASE_URL}/api/account/lists/list`,
@@ -233,49 +233,42 @@ const ListDisplay = ({ list }: { list?: List }) => {
                       "_blank"
                     )
                   }
-                  setStatus("success")
-                  setStatusMessage("Your list has been duplicated.")
+                  setStatus(STATIC_STATUS_MESSAGES["duplicate-list-success"])
                 } else {
-                  setStatus("failure")
-                  setStatusMessage("Your list could not be duplicated.")
+                  setStatus(STATIC_STATUS_MESSAGES["duplicate-list-failure"])
                 }
               } catch (error) {
                 console.error("Error duplicating list:", error)
-                setStatus("failure")
-                setStatusMessage("Your list could not be duplicated.")
               }
             }}
           >
             <Icon name="contentCopy" align="left" size="medium" />
             Duplicate
           </Button>
-          <Button
-            variant="secondary"
-            onClick={() => {
-              downloadList(
-                list,
-                activeSort as ListRecordsSort,
-                setStatus,
-                setStatusMessage
-              )
-            }}
-          >
-            <Icon align="left" size="medium">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="18"
-                height="18"
-                viewBox="0 0 18 18"
-                fill="none"
-              >
-                <path
-                  d="M15 9L13.9425 7.9425L9.75 12.1275V3H8.25V12.1275L4.065 7.935L3 9L9 15L15 9Z"
-                  fill="#0069BF"
-                />
-              </svg>
-            </Icon>
-            Download
-          </Button>
+          {list.recordCount > 0 && (
+            <Button
+              variant="secondary"
+              onClick={() => {
+                downloadList(list, activeSort as ListRecordsSort, setStatus)
+              }}
+            >
+              <Icon align="left" size="medium">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 18 18"
+                  fill="none"
+                >
+                  <path
+                    d="M15 9L13.9425 7.9425L9.75 12.1275V3H8.25V12.1275L4.065 7.935L3 9L9 15L15 9Z"
+                    fill="#0069BF"
+                  />
+                </svg>
+              </Icon>
+              Download
+            </Button>
+          )}
           {!list.isDefaultList && (
             <Button
               variant="secondary"
@@ -289,8 +282,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
                 },
               }}
               onClick={() => {
-                setStatus("")
-                setStatusMessage("")
+                setStatus(null)
                 setModalProps(deleteListModalProps as ConfirmationModalProps)
                 openModal()
               }}
@@ -302,8 +294,8 @@ const ListDisplay = ({ list }: { list?: List }) => {
         </ButtonGroup>
         <Modal {...modalProps} />
         <div tabIndex={-1} ref={bannerRef} style={{ marginTop: "24px" }}>
-          {status !== "" && (
-            <StatusBanner status={status} statusMessage={statusMessage} />
+          {status && (
+            <StatusBanner type={status.type} message={status.message} />
           )}
         </div>
       </Flex>
@@ -312,7 +304,6 @@ const ListDisplay = ({ list }: { list?: List }) => {
         activeSort={activeSort}
         setActiveSort={setActiveSort}
         setStatus={setStatus}
-        setStatusMessage={setStatusMessage}
       />
     </Flex>
   )

--- a/src/components/MyAccount/ListsTab/ListDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListDisplay.tsx
@@ -14,11 +14,11 @@ import type {
 } from "@nypl/design-system-react-components"
 import styles from "../../../../styles/components/MyAccount.module.scss"
 import Link from "../../Link/Link"
-import { useFocusContext } from "../../../context/FocusContext"
+import { useFocusContext, idConstants } from "../../../context/FocusContext"
 import ListRecordsTable from "./ListRecordsTable"
 import { useRouter } from "next/router"
 import type { List, ListRecordsSort } from "../../../types/listTypes"
-import { useContext, useEffect, useRef, useState } from "react"
+import { useContext, useRef, useState } from "react"
 import { StatusBanner } from "../Settings/StatusBanner"
 import type { StatusBannerState } from "../Settings/StatusBanner"
 import { PatronDataContext } from "../../../context/PatronDataContext"
@@ -39,18 +39,11 @@ const ListDisplay = ({ list }: { list?: List }) => {
   // Sort state for list records.
   const [activeSort, setActiveSort] = useState("added_date_asc")
 
+  // Manage status banner display for list actions (CreateEditList modal needs explicit ref)
   const bannerRef = useRef<HTMLDivElement>(null)
-
-  // Manage status banner display for list actions
   const [status, setStatus] = useState<StatusBannerState | null>(null)
 
-  useEffect(() => {
-    if (status && bannerRef.current) {
-      setTimeout(() => {
-        bannerRef.current?.focus()
-      }, 100)
-    }
-  }, [status])
+  console.log(status)
 
   // DS Modal controls used for Delete list modal
   const { onOpen: openModal, onClose: closeModal, Modal } = useModal()
@@ -195,8 +188,8 @@ const ListDisplay = ({ list }: { list?: List }) => {
           {!list.isDefaultList && (
             <EditListButton
               list={list}
-              bannerRef={bannerRef}
               setStatus={setStatus}
+              bannerRef={bannerRef}
             />
           )}
           <Button
@@ -237,6 +230,7 @@ const ListDisplay = ({ list }: { list?: List }) => {
                 } else {
                   setStatus(STATIC_STATUS_MESSAGES["duplicate-list-failure"])
                 }
+                setPersistentFocus(idConstants.listStatusBanner)
               } catch (error) {
                 console.error("Error duplicating list:", error)
               }
@@ -248,8 +242,9 @@ const ListDisplay = ({ list }: { list?: List }) => {
           {list.recordCount > 0 && (
             <Button
               variant="secondary"
-              onClick={() => {
-                downloadList(list, activeSort as ListRecordsSort, setStatus)
+              onClick={async () => {
+                setStatus(null)
+                await downloadList(list, activeSort as ListRecordsSort)
               }}
             >
               <Icon align="left" size="medium">
@@ -293,7 +288,12 @@ const ListDisplay = ({ list }: { list?: List }) => {
           )}
         </ButtonGroup>
         <Modal {...modalProps} />
-        <div tabIndex={-1} ref={bannerRef} style={{ marginTop: "24px" }}>
+        <div
+          tabIndex={-1}
+          id={idConstants.listStatusBanner}
+          ref={bannerRef}
+          style={{ marginTop: "24px" }}
+        >
           {status && (
             <StatusBanner type={status.type} message={status.message} />
           )}

--- a/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
+++ b/src/components/MyAccount/ListsTab/ListRecordsTable.tsx
@@ -32,13 +32,11 @@ const ListRecordsTable = ({
   activeSort,
   setActiveSort,
   setStatus,
-  setStatusMessage,
 }: {
   list: List
   activeSort
   setActiveSort
   setStatus
-  setStatusMessage
 }) => {
   const listRecordsHeadingRef = useRef(null)
   const { setPersistentFocus } = useFocusContext()
@@ -163,7 +161,6 @@ const ListRecordsTable = ({
         recordId={record.uri}
         isAuthenticated={true}
         setStatus={setStatus}
-        setStatusMessage={setStatusMessage}
       />,
     ]
   })

--- a/src/components/MyAccount/ListsTab/ListsDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListsDisplay.tsx
@@ -15,7 +15,7 @@ import { CreateListButton } from "./ListActions/CreateEditList"
 import { BASE_URL } from "../../../config/constants"
 import { useRouter } from "next/router"
 import type { List } from "../../../types/listTypes"
-import type { StatusType } from "../Settings/StatusBanner"
+import type { StatusBannerState } from "../Settings/StatusBanner"
 import { StatusBanner } from "../Settings/StatusBanner"
 import ListActionsMenu from "./ListActions/ListActionsMenu"
 
@@ -36,10 +36,9 @@ const ListsDisplay = () => {
 
   // Manage status banner display for list actions
   const bannerRef = useRef<HTMLDivElement>(null)
-  const [status, setStatus] = useState<StatusType>("")
-  const [statusMessage, setStatusMessage] = useState<string>("")
+  const [status, setStatus] = useState<StatusBannerState | null>(null)
   useEffect(() => {
-    if (status !== "" && bannerRef.current) {
+    if (status && bannerRef.current) {
       setTimeout(() => {
         bannerRef.current?.focus()
       }, 100)
@@ -115,7 +114,6 @@ const ListsDisplay = () => {
         key={list.id}
         list={list}
         setStatus={setStatus}
-        setStatusMessage={setStatusMessage}
         bannerRef={bannerRef}
       />,
     ]
@@ -130,11 +128,7 @@ const ListsDisplay = () => {
         mb="m"
         gap="xs"
       >
-        <CreateListButton
-          setStatus={setStatus}
-          setStatusMessage={setStatusMessage}
-          bannerRef={bannerRef}
-        />
+        <CreateListButton setStatus={setStatus} bannerRef={bannerRef} />
         <ListSort
           ref={sortMenuRef}
           selectedValue={activeSort}
@@ -143,9 +137,7 @@ const ListsDisplay = () => {
         />
       </Flex>
       <div tabIndex={-1} ref={bannerRef}>
-        {status !== "" && (
-          <StatusBanner status={status} statusMessage={statusMessage} />
-        )}
+        {status && <StatusBanner type={status.type} message={status.message} />}
       </div>
       <Box display="grid" mt="xs">
         {isLoading ? (

--- a/src/components/MyAccount/ListsTab/ListsDisplay.tsx
+++ b/src/components/MyAccount/ListsTab/ListsDisplay.tsx
@@ -34,16 +34,9 @@ const ListsDisplay = () => {
 
   const [isLoading, setIsLoading] = useState(false)
 
-  // Manage status banner display for list actions
+  // Manage status banner display for list actions (CreateEditList modal needs explicit ref)
   const bannerRef = useRef<HTMLDivElement>(null)
   const [status, setStatus] = useState<StatusBannerState | null>(null)
-  useEffect(() => {
-    if (status && bannerRef.current) {
-      setTimeout(() => {
-        bannerRef.current?.focus()
-      }, 100)
-    }
-  }, [status])
 
   const loader = (
     <SkeletonLoader
@@ -136,7 +129,7 @@ const ListsDisplay = () => {
           handleSortChange={handleSortChange}
         />
       </Flex>
-      <div tabIndex={-1} ref={bannerRef}>
+      <div tabIndex={-1} ref={bannerRef} id={idConstants.listStatusBanner}>
         {status && <StatusBanner type={status.type} message={status.message} />}
       </div>
       <Box display="grid" mt="xs">

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -12,25 +12,20 @@ import type { IconListElementPropType } from "./IconListElement"
 import { buildListElementsWithIcons } from "./IconListElement"
 import UsernameForm from "./Settings/UsernameForm"
 import { useEffect, useRef, useState } from "react"
-import type { StatusType } from "./Settings/StatusBanner"
 import { StatusBanner } from "./Settings/StatusBanner"
+import type { StatusBannerState } from "./Settings/StatusBanner"
 
 const ProfileHeader = ({ patron }: { patron: Patron }) => {
   const { isLargerThanMobile } = useNYPLBreakpoints()
-  const [usernameStatus, setUsernameStatus] = useState<StatusType>("")
-  const [usernameStatusMessage, setUsernameStatusMessage] = useState<string>("")
+  const [usernameStatus, setUsernameStatus] =
+    useState<StatusBannerState | null>(null)
   const usernameBannerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (usernameStatus !== "" && usernameBannerRef.current) {
+    if (usernameStatus && usernameBannerRef.current) {
       usernameBannerRef.current.focus()
     }
   }, [usernameStatus])
-
-  const usernameState = {
-    setUsernameStatus,
-    setUsernameStatusMessage,
-  }
 
   const profileData = (
     [
@@ -39,7 +34,7 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
         icon: "actionIdentity",
         term: "Username",
         description: (
-          <UsernameForm patron={patron} usernameState={usernameState} />
+          <UsernameForm patron={patron} setUsernameStatus={setUsernameStatus} />
         ),
       },
       {
@@ -74,15 +69,15 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
 
   return (
     <>
-      {usernameStatus !== "" && (
+      {usernameStatus && (
         <div
           ref={usernameBannerRef}
           tabIndex={-1}
           style={{ marginTop: "32px", marginBottom: "32px" }}
         >
           <StatusBanner
-            status={usernameStatus}
-            statusMessage={usernameStatusMessage}
+            type={usernameStatus.type}
+            message={usernameStatus.message}
           />
         </div>
       )}

--- a/src/components/MyAccount/ProfileHeader.tsx
+++ b/src/components/MyAccount/ProfileHeader.tsx
@@ -11,21 +11,15 @@ import type { Patron } from "../../types/myAccountTypes"
 import type { IconListElementPropType } from "./IconListElement"
 import { buildListElementsWithIcons } from "./IconListElement"
 import UsernameForm from "./Settings/UsernameForm"
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 import { StatusBanner } from "./Settings/StatusBanner"
 import type { StatusBannerState } from "./Settings/StatusBanner"
+import { idConstants } from "../../context/FocusContext"
 
 const ProfileHeader = ({ patron }: { patron: Patron }) => {
   const { isLargerThanMobile } = useNYPLBreakpoints()
   const [usernameStatus, setUsernameStatus] =
     useState<StatusBannerState | null>(null)
-  const usernameBannerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (usernameStatus && usernameBannerRef.current) {
-      usernameBannerRef.current.focus()
-    }
-  }, [usernameStatus])
 
   const profileData = (
     [
@@ -71,7 +65,7 @@ const ProfileHeader = ({ patron }: { patron: Patron }) => {
     <>
       {usernameStatus && (
         <div
-          ref={usernameBannerRef}
+          id={idConstants.usernameStatusBanner}
           tabIndex={-1}
           style={{ marginTop: "32px", marginBottom: "32px" }}
         >

--- a/src/components/MyAccount/Settings/AccountSettingsTab.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsTab.tsx
@@ -5,15 +5,13 @@ import SettingsInputForm from "./SettingsInputForm"
 import SettingsSelectForm from "./SettingsSelectForm"
 import PasswordForm from "./PasswordForm"
 import { StatusBanner } from "./StatusBanner"
-
-type StatusType = "" | "failure" | "success"
+import type { StatusBannerState } from "./StatusBanner"
 
 const AccountSettingsTab = () => {
   const {
     updatedAccountData: { patron, pickupLocations },
   } = useContext(PatronDataContext)
-  const [status, setStatus] = useState<StatusType>("")
-  const [statusMessage, setStatusMessage] = useState<string>("")
+  const [status, setStatus] = useState<StatusBannerState | null>(null)
   const [editingField, setEditingField] = useState<string>("")
   const bannerRef = useRef<HTMLDivElement>(null)
 
@@ -25,20 +23,20 @@ const AccountSettingsTab = () => {
 
   const passwordSettingsState = {
     ...settingsState,
-    setStatusMessage,
+    setStatus,
   }
 
   useEffect(() => {
-    if (status !== "" && bannerRef.current) {
+    if (status && bannerRef.current) {
       bannerRef.current.focus()
     }
   }, [status])
 
   return (
     <>
-      {status !== "" && (
+      {status && (
         <div ref={bannerRef} tabIndex={-1} style={{ marginTop: "32px" }}>
-          <StatusBanner status={status} statusMessage={statusMessage} />
+          <StatusBanner type={status.type} message={status.message} />
         </div>
       )}
       <Flex flexDir="column" sx={{ marginTop: "m", gap: "s" }}>

--- a/src/components/MyAccount/Settings/AccountSettingsTab.tsx
+++ b/src/components/MyAccount/Settings/AccountSettingsTab.tsx
@@ -1,11 +1,12 @@
 import { Flex } from "@nypl/design-system-react-components"
-import { useContext, useEffect, useRef, useState } from "react"
+import { useContext, useRef, useState } from "react"
 import { PatronDataContext } from "../../../context/PatronDataContext"
 import SettingsInputForm from "./SettingsInputForm"
 import SettingsSelectForm from "./SettingsSelectForm"
 import PasswordForm from "./PasswordForm"
 import { StatusBanner } from "./StatusBanner"
 import type { StatusBannerState } from "./StatusBanner"
+import { idConstants } from "../../../context/FocusContext"
 
 const AccountSettingsTab = () => {
   const {
@@ -26,16 +27,14 @@ const AccountSettingsTab = () => {
     setStatus,
   }
 
-  useEffect(() => {
-    if (status && bannerRef.current) {
-      bannerRef.current.focus()
-    }
-  }, [status])
-
   return (
     <>
       {status && (
-        <div ref={bannerRef} tabIndex={-1} style={{ marginTop: "32px" }}>
+        <div
+          id={idConstants.accountStatusBanner}
+          tabIndex={-1}
+          style={{ marginTop: "32px" }}
+        >
           <StatusBanner type={status.type} message={status.message} />
         </div>
       )}

--- a/src/components/MyAccount/Settings/EmailForm.test.tsx
+++ b/src/components/MyAccount/Settings/EmailForm.test.tsx
@@ -3,6 +3,7 @@ import { filteredPickupLocations } from "../../../../__test__/fixtures/processed
 import { PatronDataProvider } from "../../../context/PatronDataContext"
 import { processedPatron } from "../../../../__test__/fixtures/processedMyAccountData"
 import SettingsInputForm from "./SettingsInputForm"
+import { FocusProvider } from "../../../context/FocusContext"
 
 describe("email form", () => {
   const mockSettingsState = {
@@ -22,18 +23,20 @@ describe("email form", () => {
   })
 
   const component = (
-    <PatronDataProvider
-      value={{
-        patron: processedPatron,
-        pickupLocations: filteredPickupLocations,
-      }}
-    >
-      <SettingsInputForm
-        patronData={processedPatron}
-        settingsState={mockSettingsState}
-        inputType="emails"
-      />
-    </PatronDataProvider>
+    <FocusProvider>
+      <PatronDataProvider
+        value={{
+          patron: processedPatron,
+          pickupLocations: filteredPickupLocations,
+        }}
+      >
+        <SettingsInputForm
+          patronData={processedPatron}
+          settingsState={mockSettingsState}
+          inputType="emails"
+        />
+      </PatronDataProvider>
+    </FocusProvider>
   )
 
   it("renders correctly with initial email", () => {

--- a/src/components/MyAccount/Settings/HomeLibraryForm.test.tsx
+++ b/src/components/MyAccount/Settings/HomeLibraryForm.test.tsx
@@ -4,6 +4,7 @@ import { PatronDataProvider } from "../../../context/PatronDataContext"
 import { processedPatron } from "../../../../__test__/fixtures/processedMyAccountData"
 import { pickupLocations } from "../../../../__test__/fixtures/rawSierraAccountData"
 import HomeLibraryNotificationForm from "./SettingsSelectForm"
+import { FocusProvider } from "../../../context/FocusContext"
 
 describe("home library form", () => {
   const mockSettingsState = {
@@ -13,19 +14,21 @@ describe("home library form", () => {
   }
 
   const component = (
-    <PatronDataProvider
-      value={{
-        patron: processedPatron,
-        pickupLocations: filteredPickupLocations,
-      }}
-    >
-      <HomeLibraryNotificationForm
-        patronData={processedPatron}
-        settingsState={mockSettingsState}
-        pickupLocations={pickupLocations}
-        type="library"
-      />
-    </PatronDataProvider>
+    <FocusProvider>
+      <PatronDataProvider
+        value={{
+          patron: processedPatron,
+          pickupLocations: filteredPickupLocations,
+        }}
+      >
+        <HomeLibraryNotificationForm
+          patronData={processedPatron}
+          settingsState={mockSettingsState}
+          pickupLocations={pickupLocations}
+          type="library"
+        />
+      </PatronDataProvider>
+    </FocusProvider>
   )
 
   beforeEach(() => {

--- a/src/components/MyAccount/Settings/NotificationForm.test.tsx
+++ b/src/components/MyAccount/Settings/NotificationForm.test.tsx
@@ -1,13 +1,11 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { filteredPickupLocations } from "../../../../__test__/fixtures/processedMyAccountData"
 import { PatronDataProvider } from "../../../context/PatronDataContext"
-import {
-  processedPatron,
-  emptyPatron,
-} from "../../../../__test__/fixtures/processedMyAccountData"
+import { processedPatron } from "../../../../__test__/fixtures/processedMyAccountData"
 import { pickupLocations } from "../../../../__test__/fixtures/rawSierraAccountData"
 import SettingsSelectForm from "./SettingsSelectForm"
 import type { Patron } from "../../../types/myAccountTypes"
+import { FocusProvider } from "../../../context/FocusContext"
 
 describe("notification preference form", () => {
   const mockSettingsState = {
@@ -83,20 +81,22 @@ describe("notification preference form", () => {
 
   const component = (patron) => {
     return (
-      <PatronDataProvider
-        testSpy={accountFetchSpy}
-        value={{
-          patron: patron,
-          pickupLocations: filteredPickupLocations,
-        }}
-      >
-        <SettingsSelectForm
-          patronData={patron}
-          settingsState={mockSettingsState}
-          pickupLocations={pickupLocations}
-          type="notification"
-        />
-      </PatronDataProvider>
+      <FocusProvider>
+        <PatronDataProvider
+          testSpy={accountFetchSpy}
+          value={{
+            patron: patron,
+            pickupLocations: filteredPickupLocations,
+          }}
+        >
+          <SettingsSelectForm
+            patronData={patron}
+            settingsState={mockSettingsState}
+            pickupLocations={pickupLocations}
+            type="notification"
+          />
+        </PatronDataProvider>
+      </FocusProvider>
     )
   }
 

--- a/src/components/MyAccount/Settings/PasswordForm.test.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.test.tsx
@@ -6,11 +6,10 @@ import {
   processedPatron,
 } from "../../../../__test__/fixtures/processedMyAccountData"
 import { PatronDataProvider } from "../../../context/PatronDataContext"
-import { passwordFormMessages } from "./PasswordForm"
+import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
 
 const mockSettingsState = {
   setStatus: jest.fn(),
-  setStatusMessage: jest.fn(),
   editingField: "",
   setEditingField: jest.fn(),
 }
@@ -33,7 +32,6 @@ const component = (
 
 beforeEach(() => {
   mockSettingsState.setStatus.mockClear()
-  mockSettingsState.setStatusMessage.mockClear()
   mockSettingsState.setEditingField.mockClear()
 })
 
@@ -116,10 +114,9 @@ describe("Pin/password form", () => {
     const submitButton = getByText("Save changes")
     fireEvent.click(submitButton)
     await waitFor(() =>
-      expect(mockSettingsState.setStatus).toHaveBeenCalledTimes(2)
-    )
-    expect(mockSettingsState.setStatusMessage).toHaveBeenCalledWith(
-      passwordFormMessages.INCORRECT
+      expect(mockSettingsState.setStatus).toHaveBeenCalledWith(
+        STATIC_STATUS_MESSAGES["password-incorrect-failure"]
+      )
     )
   })
 
@@ -149,11 +146,9 @@ describe("Pin/password form", () => {
     const submitButton = getByText("Save changes")
     fireEvent.click(submitButton)
     await waitFor(() =>
-      expect(mockSettingsState.setStatus).toHaveBeenCalledTimes(2)
-    )
-    expect(mockSettingsState.setStatus).toHaveBeenNthCalledWith(2, "failure")
-    expect(mockSettingsState.setStatusMessage).toHaveBeenCalledWith(
-      passwordFormMessages.INVALID
+      expect(mockSettingsState.setStatus).toHaveBeenCalledWith(
+        STATIC_STATUS_MESSAGES["password-invalid-failure"]
+      )
     )
   })
 

--- a/src/components/MyAccount/Settings/PasswordForm.test.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../../../__test__/fixtures/processedMyAccountData"
 import { PatronDataProvider } from "../../../context/PatronDataContext"
 import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
+import { FocusProvider } from "../../../context/FocusContext"
 
 const mockSettingsState = {
   setStatus: jest.fn(),
@@ -16,18 +17,20 @@ const mockSettingsState = {
 const accountFetchSpy = jest.fn()
 
 const component = (
-  <PatronDataProvider
-    testSpy={accountFetchSpy}
-    value={{
-      patron: processedPatron,
-      pickupLocations: filteredPickupLocations,
-    }}
-  >
-    <PasswordForm
-      patronData={processedPatron}
-      settingsState={mockSettingsState}
-    />
-  </PatronDataProvider>
+  <FocusProvider>
+    <PatronDataProvider
+      testSpy={accountFetchSpy}
+      value={{
+        patron: processedPatron,
+        pickupLocations: filteredPickupLocations,
+      }}
+    >
+      <PasswordForm
+        patronData={processedPatron}
+        settingsState={mockSettingsState}
+      />
+    </PatronDataProvider>
+  </FocusProvider>
 )
 
 beforeEach(() => {

--- a/src/components/MyAccount/Settings/PasswordForm.test.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.test.tsx
@@ -115,7 +115,7 @@ describe("Pin/password form", () => {
     fireEvent.click(submitButton)
     await waitFor(() =>
       expect(mockSettingsState.setStatus).toHaveBeenCalledWith(
-        STATIC_STATUS_MESSAGES["password-incorrect-failure"]
+        STATIC_STATUS_MESSAGES.passwordIncorrectFailure
       )
     )
   })
@@ -147,7 +147,7 @@ describe("Pin/password form", () => {
     fireEvent.click(submitButton)
     await waitFor(() =>
       expect(mockSettingsState.setStatus).toHaveBeenCalledWith(
-        STATIC_STATUS_MESSAGES["password-invalid-failure"]
+        STATIC_STATUS_MESSAGES.passwordInvalidFailure
       )
     )
   })

--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -137,13 +137,13 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
       const errorMessage = await response.json()
       if (response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setStatus(STATIC_STATUS_MESSAGES["account-success"])
+        setStatus(STATIC_STATUS_MESSAGES.accountSuccess)
       } else {
         if (errorMessage) {
           errorMessage.startsWith("Invalid parameter")
             ? // Returning a more user-friendly error message.
-              setStatus(STATIC_STATUS_MESSAGES["password-incorrect-failure"])
-            : setStatus(STATIC_STATUS_MESSAGES["password-invalid-failure"])
+              setStatus(STATIC_STATUS_MESSAGES.passwordIncorrectFailure)
+            : setStatus(STATIC_STATUS_MESSAGES.passwordInvalidFailure)
         }
       }
     } catch (error) {

--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -14,6 +14,7 @@ import type { Patron } from "../../../types/myAccountTypes"
 import { BASE_URL } from "../../../config/constants"
 import EditButton from "./EditButton"
 import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
+import { idConstants, useFocusContext } from "../../../context/FocusContext"
 
 interface PasswordFormProps {
   patronData: Patron
@@ -74,6 +75,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
   const { setStatus, editingField, setEditingField } = settingsState
   const editingRef = useRef<HTMLButtonElement | null>()
   const inputRef = useRef<TextInputRefType | null>()
+  const { setPersistentFocus } = useFocusContext()
 
   const cancelEditing = () => {
     setIsEditing(false)
@@ -117,7 +119,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
   const submitForm = async () => {
     setIsLoading(true)
     setIsEditing(false)
-    setStatus("")
+    setStatus(null)
     try {
       const response = await fetch(
         `${BASE_URL}/api/account/update-pin/${patronData.id}`,
@@ -138,6 +140,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
       if (response.status === 200) {
         await getMostUpdatedSierraAccountData()
         setStatus(STATIC_STATUS_MESSAGES.accountSuccess)
+        setPersistentFocus(idConstants.accountStatusBanner)
       } else {
         if (errorMessage) {
           errorMessage.startsWith("Invalid parameter")
@@ -145,6 +148,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
               setStatus(STATIC_STATUS_MESSAGES.passwordIncorrectFailure)
             : setStatus(STATIC_STATUS_MESSAGES.passwordInvalidFailure)
         }
+        setPersistentFocus(idConstants.accountStatusBanner)
       }
     } catch (error) {
       console.error("Error submitting", error)

--- a/src/components/MyAccount/Settings/PasswordForm.tsx
+++ b/src/components/MyAccount/Settings/PasswordForm.tsx
@@ -13,6 +13,7 @@ import SaveCancelButtons from "./SaveCancelButtons"
 import type { Patron } from "../../../types/myAccountTypes"
 import { BASE_URL } from "../../../config/constants"
 import EditButton from "./EditButton"
+import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
 
 interface PasswordFormProps {
   patronData: Patron
@@ -24,11 +25,6 @@ interface PasswordFormFieldProps {
   handler: (e) => void
   name: string
   isInvalid?: boolean
-}
-
-export const passwordFormMessages = {
-  INCORRECT: "Incorrect current pin/password.",
-  INVALID: "Invalid new pin/password.",
 }
 
 const PasswordFormField = forwardRef<TextInputRefType, PasswordFormFieldProps>(
@@ -75,8 +71,7 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
     confirmPassword: "",
     passwordsMatch: true,
   })
-  const { setStatus, setStatusMessage, editingField, setEditingField } =
-    settingsState
+  const { setStatus, editingField, setEditingField } = settingsState
   const editingRef = useRef<HTMLButtonElement | null>()
   const inputRef = useRef<TextInputRefType | null>()
 
@@ -142,14 +137,13 @@ const PasswordForm = ({ patronData, settingsState }: PasswordFormProps) => {
       const errorMessage = await response.json()
       if (response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setStatus("success")
+        setStatus(STATIC_STATUS_MESSAGES["account-success"])
       } else {
-        setStatus("failure")
         if (errorMessage) {
           errorMessage.startsWith("Invalid parameter")
             ? // Returning a more user-friendly error message.
-              setStatusMessage(passwordFormMessages.INCORRECT)
-            : setStatusMessage(passwordFormMessages.INVALID)
+              setStatus(STATIC_STATUS_MESSAGES["password-incorrect-failure"])
+            : setStatus(STATIC_STATUS_MESSAGES["password-invalid-failure"])
         }
       }
     } catch (error) {

--- a/src/components/MyAccount/Settings/PhoneForm.test.tsx
+++ b/src/components/MyAccount/Settings/PhoneForm.test.tsx
@@ -3,6 +3,7 @@ import { filteredPickupLocations } from "../../../../__test__/fixtures/processed
 import { PatronDataProvider } from "../../../context/PatronDataContext"
 import { processedPatron } from "../../../../__test__/fixtures/processedMyAccountData"
 import SettingsInputForm from "./SettingsInputForm"
+import { FocusProvider } from "../../../context/FocusContext"
 
 describe("phone form", () => {
   const mockSettingsState = {
@@ -22,18 +23,20 @@ describe("phone form", () => {
   })
 
   const component = (
-    <PatronDataProvider
-      value={{
-        patron: processedPatron,
-        pickupLocations: filteredPickupLocations,
-      }}
-    >
-      <SettingsInputForm
-        patronData={processedPatron}
-        settingsState={mockSettingsState}
-        inputType="phones"
-      />
-    </PatronDataProvider>
+    <FocusProvider>
+      <PatronDataProvider
+        value={{
+          patron: processedPatron,
+          pickupLocations: filteredPickupLocations,
+        }}
+      >
+        <SettingsInputForm
+          patronData={processedPatron}
+          settingsState={mockSettingsState}
+          inputType="phones"
+        />
+      </PatronDataProvider>
+    </FocusProvider>
   )
 
   it("renders correctly with initial phone", () => {

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -16,6 +16,7 @@ import SettingsLabel from "./SettingsLabel"
 import type { Patron } from "../../../types/myAccountTypes"
 import EditButton from "./EditButton"
 import AddButton from "./AddButton"
+import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
 
 interface SettingsInputFormProps {
   patronData: Patron
@@ -147,7 +148,7 @@ const SettingsInputForm = ({
   const submitInputs = async () => {
     setIsLoading(true)
     setIsEditing(false)
-    setStatus("")
+    setStatus(null)
     const validInputs = tempInputs.filter((input) =>
       validateInput(input, tempInputs)
     )
@@ -173,11 +174,11 @@ const SettingsInputForm = ({
 
       if (response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setStatus("success")
+        setStatus(STATIC_STATUS_MESSAGES["account-success"])
         setInputs([...validInputs])
         setTempInputs([...validInputs])
       } else {
-        setStatus("failure")
+        setStatus(STATIC_STATUS_MESSAGES["account-failure"])
         setTempInputs([...inputs])
       }
     } catch (error) {

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -17,6 +17,7 @@ import type { Patron } from "../../../types/myAccountTypes"
 import EditButton from "./EditButton"
 import AddButton from "./AddButton"
 import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
+import { idConstants, useFocusContext } from "../../../context/FocusContext"
 
 interface SettingsInputFormProps {
   patronData: Patron
@@ -41,6 +42,7 @@ const SettingsInputForm = ({
   const [error, setError] = useState(false)
 
   const { setStatus, editingField, setEditingField } = settingsState
+  const { setPersistentFocus } = useFocusContext()
 
   const [tempInputs, setTempInputs] = useState([...inputs])
 
@@ -181,6 +183,7 @@ const SettingsInputForm = ({
         setStatus(STATIC_STATUS_MESSAGES.accountFailure)
         setTempInputs([...inputs])
       }
+      setPersistentFocus(idConstants.accountStatusBanner)
     } catch (error) {
       console.error("Error submitting", inputType, error)
     } finally {

--- a/src/components/MyAccount/Settings/SettingsInputForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsInputForm.tsx
@@ -174,11 +174,11 @@ const SettingsInputForm = ({
 
       if (response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setStatus(STATIC_STATUS_MESSAGES["account-success"])
+        setStatus(STATIC_STATUS_MESSAGES.accountSuccess)
         setInputs([...validInputs])
         setTempInputs([...validInputs])
       } else {
-        setStatus(STATIC_STATUS_MESSAGES["account-failure"])
+        setStatus(STATIC_STATUS_MESSAGES.accountFailure)
         setTempInputs([...inputs])
       }
     } catch (error) {

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -128,11 +128,11 @@ const SettingsSelectForm = ({
 
       if (response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setStatus(STATIC_STATUS_MESSAGES["account-success"])
+        setStatus(STATIC_STATUS_MESSAGES.accountSuccess)
         setSelection(tempSelection)
         setTempSelection(tempSelection)
       } else {
-        setStatus(STATIC_STATUS_MESSAGES["account-failure"])
+        setStatus(STATIC_STATUS_MESSAGES.accountFailure)
         setTempSelection(tempSelection)
       }
     } catch (error) {

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -12,6 +12,7 @@ import SaveCancelButtons from "./SaveCancelButtons"
 import type { Patron, SierraCodeName } from "../../../types/myAccountTypes"
 import EditButton from "./EditButton"
 import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
+import { useFocusContext, idConstants } from "../../../context/FocusContext"
 
 interface SettingsSelectFormProps {
   type: "library" | "notification"
@@ -30,7 +31,7 @@ const SettingsSelectForm = ({
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [error, setError] = useState(false)
-
+  const { setPersistentFocus } = useFocusContext()
   const { setStatus, editingField, setEditingField } = settingsState
   const selectRef = useRef<HTMLSelectElement | null>()
   const editingRef = useRef<HTMLButtonElement | null>()
@@ -135,6 +136,7 @@ const SettingsSelectForm = ({
         setStatus(STATIC_STATUS_MESSAGES.accountFailure)
         setTempSelection(tempSelection)
       }
+      setPersistentFocus(idConstants.accountStatusBanner)
     } catch (error) {
       console.error("Error submitting", error)
     } finally {

--- a/src/components/MyAccount/Settings/SettingsSelectForm.tsx
+++ b/src/components/MyAccount/Settings/SettingsSelectForm.tsx
@@ -11,6 +11,7 @@ import SettingsLabel from "./SettingsLabel"
 import SaveCancelButtons from "./SaveCancelButtons"
 import type { Patron, SierraCodeName } from "../../../types/myAccountTypes"
 import EditButton from "./EditButton"
+import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
 
 interface SettingsSelectFormProps {
   type: "library" | "notification"
@@ -103,7 +104,7 @@ const SettingsSelectForm = ({
   const submitSelection = async () => {
     setIsLoading(true)
     setIsEditing(false)
-    setStatus("")
+    setStatus(null)
     const code = isNotification
       ? notificationPreferenceMap.find((pref) => pref.name === tempSelection)
           ?.code
@@ -127,11 +128,11 @@ const SettingsSelectForm = ({
 
       if (response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setStatus("success")
+        setStatus(STATIC_STATUS_MESSAGES["account-success"])
         setSelection(tempSelection)
         setTempSelection(tempSelection)
       } else {
-        setStatus("failure")
+        setStatus(STATIC_STATUS_MESSAGES["account-failure"])
         setTempSelection(tempSelection)
       }
     } catch (error) {

--- a/src/components/MyAccount/Settings/StatusBanner.test.tsx
+++ b/src/components/MyAccount/Settings/StatusBanner.test.tsx
@@ -2,23 +2,10 @@ import { render, screen } from "@testing-library/react"
 import { StatusBanner } from "./StatusBanner"
 
 describe("Status banner", () => {
-  it("displays specific failure message", () => {
-    render(<StatusBanner status="failure" statusMessage="Specific failure" />)
-    expect(
-      screen.getByText(/Specific failure Please try again/)
-    ).toBeInTheDocument()
-    expect(screen.getByRole("link")).toHaveAttribute(
-      "href",
-      "https://www.nypl.org/get-help/contact-us"
+  it("displays failure message", () => {
+    render(
+      <StatusBanner type="failure" message="Your changes were not saved" />
     )
-    expect(screen.getByRole("complementary")).toHaveAttribute(
-      "data-variant",
-      "negative"
-    )
-  })
-
-  it("displays general failure message", () => {
-    render(<StatusBanner status="failure" statusMessage="" />)
     expect(screen.getByText(/Your changes were not saved/)).toBeInTheDocument()
     expect(screen.getByRole("complementary")).toHaveAttribute(
       "data-variant",
@@ -27,7 +14,7 @@ describe("Status banner", () => {
   })
 
   it("displays success message", () => {
-    render(<StatusBanner status="success" statusMessage="" />)
+    render(<StatusBanner type="success" message="Your changes were saved" />)
     expect(screen.getByText(/Your changes were saved/)).toBeInTheDocument()
     expect(screen.getByRole("complementary")).toHaveAttribute(
       "data-variant",

--- a/src/components/MyAccount/Settings/StatusBanner.tsx
+++ b/src/components/MyAccount/Settings/StatusBanner.tsx
@@ -1,64 +1,22 @@
-import { Banner, Text, Link } from "@nypl/design-system-react-components"
+import { Banner } from "@nypl/design-system-react-components"
+import type { ReactElement } from "react"
 
-export type StatusType = "" | "failure" | "usernameFailure" | "success"
-
-type StatusBannerProps = {
-  status: StatusType
-  statusMessage: string
+export type StatusBannerState = {
+  type: string
+  message: ReactElement | string
 }
 
-const generalSuccessContent = <Text>Your changes were saved.</Text>
-
-const generalFailureContent = <Text>Your changes were not saved.</Text>
-
-const specificFailureContent = (statusMessage: string) => {
-  return (
-    <Text marginBottom={0}>
-      {statusMessage} Please try again or{" "}
-      <Link
-        color="ui.link.primary !important"
-        href="https://www.nypl.org/get-help/contact-us"
-      >
-        contact us
-      </Link>{" "}
-      for assistance.
-    </Text>
-  )
-}
-
-const specificSuccessContent = (statusMessage: string) => {
-  if (typeof statusMessage === "string") {
-    return <Text marginBottom={0}>{statusMessage}</Text>
-  } else {
-    return statusMessage
-  }
-}
-
-const statusContent = (status, statusMessage) => {
-  if (status === "success") {
-    if (statusMessage !== "") {
-      return specificSuccessContent(statusMessage)
-    } else {
-      return generalSuccessContent
-    }
-  }
-  if (status === "failure" && statusMessage !== "") {
-    return specificFailureContent(statusMessage)
-  } else {
-    return generalFailureContent
-  }
-}
-
-export const StatusBanner = ({ status, statusMessage }: StatusBannerProps) => {
+export const StatusBanner = ({ type, message }: StatusBannerState) => {
   return (
     <Banner
       isDismissible
-      content={
-        <div style={{ alignItems: "center" }}>
-          {statusContent(status, statusMessage)}
-        </div>
-      }
-      variant={status === "failure" ? "negative" : "positive"}
+      content={message}
+      variant={type === "failure" ? "negative" : "positive"}
+      sx={{
+        alignContent: "center",
+        color: "ui.body",
+        a: { color: "ui.link.primary" },
+      }}
     />
   )
 }

--- a/src/components/MyAccount/Settings/UsernameForm.test.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.test.tsx
@@ -6,15 +6,13 @@ import {
   processedPatron,
 } from "../../../../__test__/fixtures/processedMyAccountData"
 import UsernameForm from "./UsernameForm"
+import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
 
 describe("username form", () => {
-  const mockUsernameState = {
-    setUsernameStatus: jest.fn(),
-    setUsernameStatusMessage: jest.fn(),
-  }
-
+  const mockSetUsernameStatus = jest.fn()
   beforeEach(() => {
     jest.clearAllMocks()
+
     global.fetch = jest.fn().mockResolvedValue({
       json: async () => {
         console.log("Updated")
@@ -32,7 +30,7 @@ describe("username form", () => {
     >
       <UsernameForm
         patron={processedPatron}
-        usernameState={mockUsernameState}
+        setUsernameStatus={mockSetUsernameStatus}
       />
     </PatronDataProvider>
   )
@@ -44,7 +42,10 @@ describe("username form", () => {
         pickupLocations: filteredPickupLocations,
       }}
     >
-      <UsernameForm patron={emptyPatron} usernameState={mockUsernameState} />
+      <UsernameForm
+        patron={emptyPatron}
+        setUsernameStatus={mockSetUsernameStatus}
+      />
     </PatronDataProvider>
   )
 
@@ -184,5 +185,27 @@ describe("username form", () => {
 
     expect(screen.getByText(processedPatron.username)).toBeInTheDocument()
     expect(screen.queryByDisplayValue("newUsername")).not.toBeInTheDocument()
+  })
+
+  it("handles 'Username taken' response from Sierra", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 400,
+      json: async () => "Username taken",
+    } as Response)
+
+    render(component)
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }))
+
+    const input = screen.getByLabelText("Username")
+    fireEvent.change(input, { target: { value: "takenName123" } })
+
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
+
+    await waitFor(() => {
+      expect(mockSetUsernameStatus).toHaveBeenCalledWith(
+        STATIC_STATUS_MESSAGES["username-failure"]
+      )
+    })
   })
 })

--- a/src/components/MyAccount/Settings/UsernameForm.test.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../../../__test__/fixtures/processedMyAccountData"
 import UsernameForm from "./UsernameForm"
 import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
+import { FocusProvider } from "../../../context/FocusContext"
 
 describe("username form", () => {
   const mockSetUsernameStatus = jest.fn()
@@ -22,31 +23,35 @@ describe("username form", () => {
   })
 
   const component = (
-    <PatronDataProvider
-      value={{
-        patron: processedPatron,
-        pickupLocations: filteredPickupLocations,
-      }}
-    >
-      <UsernameForm
-        patron={processedPatron}
-        setUsernameStatus={mockSetUsernameStatus}
-      />
-    </PatronDataProvider>
+    <FocusProvider>
+      <PatronDataProvider
+        value={{
+          patron: processedPatron,
+          pickupLocations: filteredPickupLocations,
+        }}
+      >
+        <UsernameForm
+          patron={processedPatron}
+          setUsernameStatus={mockSetUsernameStatus}
+        />
+      </PatronDataProvider>
+    </FocusProvider>
   )
 
   const noUsernameComponent = (
-    <PatronDataProvider
-      value={{
-        patron: emptyPatron,
-        pickupLocations: filteredPickupLocations,
-      }}
-    >
-      <UsernameForm
-        patron={emptyPatron}
-        setUsernameStatus={mockSetUsernameStatus}
-      />
-    </PatronDataProvider>
+    <FocusProvider>
+      <PatronDataProvider
+        value={{
+          patron: emptyPatron,
+          pickupLocations: filteredPickupLocations,
+        }}
+      >
+        <UsernameForm
+          patron={emptyPatron}
+          setUsernameStatus={mockSetUsernameStatus}
+        />
+      </PatronDataProvider>
+    </FocusProvider>
   )
 
   it("renders correctly with initial username", () => {

--- a/src/components/MyAccount/Settings/UsernameForm.test.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.test.tsx
@@ -204,7 +204,7 @@ describe("username form", () => {
 
     await waitFor(() => {
       expect(mockSetUsernameStatus).toHaveBeenCalledWith(
-        STATIC_STATUS_MESSAGES["username-failure"]
+        STATIC_STATUS_MESSAGES.usernameFailure
       )
     })
   })

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -27,6 +27,7 @@ const UsernameForm = ({ patron, setUsernameStatus }: UsernameFormProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [error, setError] = useState(false)
+
   /**
    * In Sierra, the user NOT having a username is represented by the empty string: username = "".
    * Within this form, the user NOT having a username is represented by: username = null, so the

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -85,19 +85,19 @@ const UsernameForm = ({ patron, setUsernameStatus }: UsernameFormProps) => {
       const responseMessage = await response.json()
       if (responseMessage !== "Username taken" && response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setUsernameStatus(STATIC_STATUS_MESSAGES["account-success"])
+        setUsernameStatus(STATIC_STATUS_MESSAGES.accountSuccess)
         setusernameInSierra(submissionInput)
         setTempUsername(submissionInput)
       } else {
         setUsernameStatus(
           responseMessage === "Username taken"
-            ? STATIC_STATUS_MESSAGES["username-failure"]
-            : STATIC_STATUS_MESSAGES["account-failure"]
+            ? STATIC_STATUS_MESSAGES.usernameFailure
+            : STATIC_STATUS_MESSAGES.accountFailure
         )
         setTempUsername(usernameInSierra)
       }
     } catch (error) {
-      setUsernameStatus(STATIC_STATUS_MESSAGES["account-failure"])
+      setUsernameStatus(STATIC_STATUS_MESSAGES.accountFailure)
       console.error("Error submitting username:", error)
     } finally {
       setIsLoading(false)

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -15,19 +15,14 @@ import type { Patron } from "../../../types/myAccountTypes"
 import EditButton from "./EditButton"
 import AddButton from "./AddButton"
 import { BASE_URL } from "../../../config/constants"
-
-export const usernameStatusMessages = {
-  USERNAME_FAILURE: "This username already exists.",
-  FAILURE: "Your changes could not be saved.",
-  SUCCESS: "Your changes were saved.",
-}
+import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
 
 interface UsernameFormProps {
   patron: Patron
-  usernameState
+  setUsernameStatus
 }
 
-const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
+const UsernameForm = ({ patron, setUsernameStatus }: UsernameFormProps) => {
   const { getMostUpdatedSierraAccountData } = useContext(PatronDataContext)
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
@@ -43,7 +38,6 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
   const [tempUsername, setTempUsername] = useState(usernameInSierra)
   const currentUsernameNotDeleted = tempUsername !== null
 
-  const { setUsernameStatus, setUsernameStatusMessage } = usernameState
   const inputRef = useRef<TextInputRefType | null>()
   const editingRef = useRef<HTMLButtonElement | null>()
   const addButtonRef = useRef<HTMLButtonElement | null>()
@@ -75,7 +69,7 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
   const submitInput = async () => {
     setIsLoading(true)
     setIsEditing(false)
-    setUsernameStatus("")
+    setUsernameStatus(null)
     const submissionInput = tempUsername === null ? "" : tempUsername
     try {
       const response = await fetch(
@@ -91,21 +85,19 @@ const UsernameForm = ({ patron, usernameState }: UsernameFormProps) => {
       const responseMessage = await response.json()
       if (responseMessage !== "Username taken" && response.status === 200) {
         await getMostUpdatedSierraAccountData()
-        setUsernameStatus("success")
+        setUsernameStatus(STATIC_STATUS_MESSAGES["account-success"])
         setusernameInSierra(submissionInput)
         setTempUsername(submissionInput)
       } else {
-        setUsernameStatus("failure")
-        setUsernameStatusMessage(
+        setUsernameStatus(
           responseMessage === "Username taken"
-            ? usernameStatusMessages.USERNAME_FAILURE
-            : usernameStatusMessages.FAILURE
+            ? STATIC_STATUS_MESSAGES["username-failure"]
+            : STATIC_STATUS_MESSAGES["account-failure"]
         )
         setTempUsername(usernameInSierra)
       }
     } catch (error) {
-      setUsernameStatus("failure")
-      setUsernameStatusMessage(usernameStatusMessages.FAILURE)
+      setUsernameStatus(STATIC_STATUS_MESSAGES["account-failure"])
       console.error("Error submitting username:", error)
     } finally {
       setIsLoading(false)

--- a/src/components/MyAccount/Settings/UsernameForm.tsx
+++ b/src/components/MyAccount/Settings/UsernameForm.tsx
@@ -16,6 +16,7 @@ import EditButton from "./EditButton"
 import AddButton from "./AddButton"
 import { BASE_URL } from "../../../config/constants"
 import { STATIC_STATUS_MESSAGES } from "../../../utils/statusUtils"
+import { idConstants, useFocusContext } from "../../../context/FocusContext"
 
 interface UsernameFormProps {
   patron: Patron
@@ -27,6 +28,7 @@ const UsernameForm = ({ patron, setUsernameStatus }: UsernameFormProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [error, setError] = useState(false)
+  const { setPersistentFocus } = useFocusContext()
 
   /**
    * In Sierra, the user NOT having a username is represented by the empty string: username = "".
@@ -97,6 +99,7 @@ const UsernameForm = ({ patron, setUsernameStatus }: UsernameFormProps) => {
         )
         setTempUsername(usernameInSierra)
       }
+      setPersistentFocus(idConstants.usernameStatusBanner)
     } catch (error) {
       setUsernameStatus(STATIC_STATUS_MESSAGES.accountFailure)
       console.error("Error submitting username:", error)

--- a/src/components/SearchFilters/SearchFilters.test.tsx
+++ b/src/components/SearchFilters/SearchFilters.test.tsx
@@ -68,7 +68,7 @@ describe("SearchFilters", () => {
       setTimeout(() => {
         expect(subjectMultiselect).toHaveAttribute("aria-expanded", "true")
         expect(topFilterOption).toBeVisible()
-      }, 100)
+      }, 200)
     })
 
     it("searches filter options", async () => {
@@ -93,7 +93,7 @@ describe("SearchFilters", () => {
       setTimeout(() => {
         expect(audioFilter).not.toBeInTheDocument()
         expect(notatedMusicFilter).toBeInTheDocument()
-      }, 100)
+      }, 200)
     })
 
     it("should update the router query and add filter on checkbox click", async () => {

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -17,8 +17,8 @@ import { PATHS } from "../../config/constants"
 import FindingAid from "../BibPage/FindingAid"
 import SearchResultItems from "./SearchResultItems"
 import { ManageBibInList } from "../List/ManageBibInList"
-import type { StatusType } from "../MyAccount/Settings/StatusBanner"
 import { StatusBanner } from "../MyAccount/Settings/StatusBanner"
+import type { StatusBannerState } from "../MyAccount/Settings/StatusBanner"
 import { useEffect, useRef, useState } from "react"
 
 interface SearchResultProps {
@@ -58,10 +58,9 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
 
   // Manage status banner display for list actions
   const bannerRef = useRef<HTMLDivElement>(null)
-  const [status, setStatus] = useState<StatusType>("")
-  const [statusMessage, setStatusMessage] = useState<string>("")
+  const [status, setStatus] = useState<StatusBannerState | null>(null)
   useEffect(() => {
-    if (status !== "" && bannerRef.current) {
+    if (status && bannerRef.current) {
       setTimeout(() => {
         bannerRef.current?.focus()
       }, 100)
@@ -102,7 +101,6 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
               recordId={bib.id}
               isAuthenticated={isAuthenticated}
               setStatus={setStatus}
-              setStatusMessage={setStatusMessage}
             />
           </Box>
         </Flex>
@@ -118,8 +116,8 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
           {joinedMetadata}
         </Box>
         <div tabIndex={-1} ref={bannerRef} style={{ marginTop: "24px" }}>
-          {status !== "" && (
-            <StatusBanner status={status} statusMessage={statusMessage} />
+          {status && (
+            <StatusBanner type={status.type} message={status.message} />
           )}
         </div>
         {(bib.findingAid || bib.hasElectronicResources) && (

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -19,7 +19,8 @@ import SearchResultItems from "./SearchResultItems"
 import { ManageBibInList } from "../List/ManageBibInList"
 import { StatusBanner } from "../MyAccount/Settings/StatusBanner"
 import type { StatusBannerState } from "../MyAccount/Settings/StatusBanner"
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
+import { idConstants } from "../../context/FocusContext"
 
 interface SearchResultProps {
   bib: SearchResultsBib
@@ -57,15 +58,7 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
   }, [])
 
   // Manage status banner display for list actions
-  const bannerRef = useRef<HTMLDivElement>(null)
   const [status, setStatus] = useState<StatusBannerState | null>(null)
-  useEffect(() => {
-    if (status && bannerRef.current) {
-      setTimeout(() => {
-        bannerRef.current?.focus()
-      }, 100)
-    }
-  }, [status])
 
   return (
     <Card
@@ -115,7 +108,11 @@ const SearchResult = ({ bib, isAuthenticated }: SearchResultProps) => {
         >
           {joinedMetadata}
         </Box>
-        <div tabIndex={-1} ref={bannerRef} style={{ marginTop: "24px" }}>
+        <div
+          tabIndex={-1}
+          id={idConstants.listStatusBanner}
+          style={{ marginTop: "24px" }}
+        >
           {status && (
             <StatusBanner type={status.type} message={status.message} />
           )}

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -39,6 +39,10 @@ export const idConstants = {
   listRecordsHeading: "list-records-heading",
   listStatusBanner: "list-status-banner",
   accountStatusBanner: "account-status-banner",
+  listMenuStatusBanner: "list-menu-status-banner",
+  usernameStatusBanner: "username-status-banner",
+  createListNameInput: "list-name-input",
+  createListButton: "create-list",
 }
 
 export const FocusProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -37,6 +37,7 @@ export const idConstants = {
   dateTo: "date-to",
   advancedSearchError: "advanced-search-error",
   listRecordsHeading: "list-records-heading",
+  listStatusBanner: "list-status-banner",
 }
 
 export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
@@ -51,10 +52,13 @@ export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
   const setFocusById = useCallback(
     (id: string) => {
       if (isClient) {
-        const el = document.getElementById(id)
-        if (el) {
-          el.focus()
-        }
+        // Focus happens after React flushes DOM updates
+        setTimeout(() => {
+          const el = document.getElementById(id)
+          if (el) {
+            el.focus()
+          }
+        }, 100)
       }
     },
     [isClient]
@@ -73,7 +77,9 @@ export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
   )
 
   useEffect(() => {
-    setIsClient(true)
+    setTimeout(() => {
+      setIsClient(true)
+    }, 100)
   }, [])
 
   return (

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -77,9 +77,7 @@ export const FocusProvider = ({ children }: { children: React.ReactNode }) => {
   )
 
   useEffect(() => {
-    setTimeout(() => {
-      setIsClient(true)
-    }, 100)
+    setIsClient(true)
   }, [])
 
   return (

--- a/src/context/FocusContext.tsx
+++ b/src/context/FocusContext.tsx
@@ -38,6 +38,7 @@ export const idConstants = {
   advancedSearchError: "advanced-search-error",
   listRecordsHeading: "list-records-heading",
   listStatusBanner: "list-status-banner",
+  accountStatusBanner: "account-status-banner",
 }
 
 export const FocusProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -174,15 +174,9 @@ export const buildListRecords = (
   return updatedRecords
 }
 
-export const downloadList = async (
-  list: List,
-  sort: ListRecordsSort,
-  setStatus: any
-) => {
-  setStatus(null)
+export const downloadList = async (list: List, sort: ListRecordsSort) => {
   try {
     if (list.recordCount === 0 || !list.records) {
-      setStatus(STATIC_STATUS_MESSAGES["download-list-failure"])
       return
     }
 
@@ -255,10 +249,7 @@ export const downloadList = async (
     link.click()
     document.body.removeChild(link)
     URL.revokeObjectURL(url)
-
-    setStatus(STATIC_STATUS_MESSAGES["download-list-success"])
   } catch (error) {
     console.error("Error downloading list:", error)
-    setStatus(STATIC_STATUS_MESSAGES["download-list-failure"])
   }
 }

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -246,7 +246,6 @@ export const duplicateList = async ({
   updatedAccountData,
   setUpdatedAccountData,
   setStatus,
-  setStatusMessage,
   openListInNewTab = false,
 }: {
   list: List
@@ -255,11 +254,8 @@ export const duplicateList = async ({
   updatedAccountData: any
   setUpdatedAccountData: any
   setStatus: any
-  setStatusMessage: any
   openListInNewTab?: boolean
 }) => {
-  setStatus("")
-  setStatusMessage("")
   try {
     const response = await fetch(`${BASE_URL}/api/account/lists/list`, {
       method: "POST",
@@ -284,15 +280,11 @@ export const duplicateList = async ({
           window.open(`${BASE_URL}/account/lists/${data.list.id}`, "_blank")
         }
       }
-      setStatus("success")
-      setStatusMessage("Your list has been duplicated.")
+      setStatus(STATIC_STATUS_MESSAGES.duplicateListSuccess)
     } else {
-      setStatus("failure")
-      setStatusMessage("Your list could not be duplicated.")
+      setStatus(STATIC_STATUS_MESSAGES.duplicateListFailure)
     }
   } catch (error) {
     console.error("Error duplicating list:", error)
-    setStatus("failure")
-    setStatusMessage("Your list could not be duplicated.")
   }
 }

--- a/src/utils/listUtils.ts
+++ b/src/utils/listUtils.ts
@@ -7,6 +7,7 @@ import type {
 } from "../types/listTypes"
 import type { DiscoverySearchResultsElement } from "../types/searchTypes"
 import { formatMMDDYYYY } from "./dateUtils"
+import { STATIC_STATUS_MESSAGES } from "./statusUtils"
 
 export const LIST_RECORDS_PER_PAGE = 20
 
@@ -176,15 +177,12 @@ export const buildListRecords = (
 export const downloadList = async (
   list: List,
   sort: ListRecordsSort,
-  setStatus: any,
-  setStatusMessage: any
+  setStatus: any
 ) => {
-  setStatus("")
-  setStatusMessage("")
+  setStatus(null)
   try {
     if (list.recordCount === 0 || !list.records) {
-      setStatus("failure")
-      setStatusMessage("Your list has no records to download.")
+      setStatus(STATIC_STATUS_MESSAGES["download-list-failure"])
       return
     }
 
@@ -258,11 +256,9 @@ export const downloadList = async (
     document.body.removeChild(link)
     URL.revokeObjectURL(url)
 
-    setStatus("success")
-    setStatusMessage("Your list has been downloaded.")
+    setStatus(STATIC_STATUS_MESSAGES["download-list-success"])
   } catch (error) {
     console.error("Error downloading list:", error)
-    setStatus("failure")
-    setStatusMessage("Your list could not be downloaded.")
+    setStatus(STATIC_STATUS_MESSAGES["download-list-failure"])
   }
 }

--- a/src/utils/statusUtils.tsx
+++ b/src/utils/statusUtils.tsx
@@ -3,51 +3,51 @@ import Link from "../components/Link/Link"
 import type { StatusBannerState } from "../components/MyAccount/Settings/StatusBanner"
 
 export type StaticStatusKey =
-  | "duplicate-list-success"
-  | "duplicate-list-failure"
-  | "delete-list-success"
-  | "delete-list-failure"
-  | "save-record-failure"
-  | "list-changes-success"
-  | "list-changes-failure"
-  | "remove-record-failure"
-  | "account-success"
-  | "account-failure"
-  | "create-list-success"
-  | "create-list-failure"
-  | "password-incorrect-failure"
-  | "password-invalid-failure"
-  | "username-failure"
+  | "duplicateListSuccess"
+  | "duplicateListFailure"
+  | "deleteListSuccess"
+  | "deleteListFailure"
+  | "saveRecordFailure"
+  | "listChangesSuccess"
+  | "listChangesFailure"
+  | "removeRecordFailure"
+  | "accountSuccess"
+  | "accountFailure"
+  | "createListSuccess"
+  | "createListFailure"
+  | "passwordIncorrectFailure"
+  | "passwordInvalidFailure"
+  | "usernameFailure"
 
 export const STATIC_STATUS_MESSAGES: Record<
   StaticStatusKey,
   StatusBannerState
 > = {
-  "duplicate-list-success": {
+  duplicateListSuccess: {
     type: "success",
     message: <Text marginBottom={0}>Your list has been duplicated.</Text>,
   },
-  "duplicate-list-failure": {
+  duplicateListFailure: {
     type: "failure",
     message: <Text marginBottom={0}>Your list could not be duplicated.</Text>,
   },
-  "delete-list-success": {
+  deleteListSuccess: {
     type: "success",
     message: <Text marginBottom={0}>Your list has been deleted.</Text>,
   },
-  "delete-list-failure": {
+  deleteListFailure: {
     type: "failure",
     message: <Text marginBottom={0}>Your list could not be deleted.</Text>,
   },
-  "create-list-success": {
+  createListSuccess: {
     type: "success",
     message: <Text marginBottom={0}>List created.</Text>,
   },
-  "create-list-failure": {
+  createListFailure: {
     type: "failure",
     message: <Text marginBottom={0}>List creation failed. Try again.</Text>,
   },
-  "list-changes-success": {
+  listChangesSuccess: {
     type: "success",
     message: (
       <Text marginBottom={0}>
@@ -56,7 +56,7 @@ export const STATIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   },
-  "list-changes-failure": {
+  listChangesFailure: {
     type: "failure",
     message: (
       <Text>
@@ -69,19 +69,19 @@ export const STATIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   },
-  "save-record-failure": {
+  saveRecordFailure: {
     type: "failure",
     message: <Text marginBottom={0}>This record could not be saved.</Text>,
   },
-  "remove-record-failure": {
+  removeRecordFailure: {
     type: "failure",
     message: <Text marginBottom={0}>This record could not be removed.</Text>,
   },
-  "account-success": {
+  accountSuccess: {
     type: "success",
     message: <Text marginBottom={0}>Your changes were saved.</Text>,
   },
-  "account-failure": {
+  accountFailure: {
     type: "failure",
     message: (
       <Text marginBottom={0}>
@@ -93,7 +93,7 @@ export const STATIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   },
-  "password-incorrect-failure": {
+  passwordIncorrectFailure: {
     type: "failure",
     message: (
       <Text marginBottom={0}>
@@ -105,7 +105,7 @@ export const STATIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   },
-  "password-invalid-failure": {
+  passwordInvalidFailure: {
     type: "failure",
     message: (
       <Text marginBottom={0}>
@@ -117,7 +117,7 @@ export const STATIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   },
-  "username-failure": {
+  usernameFailure: {
     type: "failure",
     message: (
       <Text marginBottom={0}>
@@ -133,15 +133,15 @@ export const STATIC_STATUS_MESSAGES: Record<
 
 // Statii that require a param to set a linked value.
 export type DynamicStatusKey =
-  | "save-record-success"
-  | "remove-record-success"
-  | "account-specific-failure"
+  | "saveRecordSuccess"
+  | "removeRecordSuccess"
+  | "accountSpecificFailure"
 
 export const DYNAMIC_STATUS_MESSAGES: Record<
   DynamicStatusKey,
   (param: string) => StatusBannerState
 > = {
-  "save-record-success": (listId: string) => ({
+  saveRecordSuccess: (listId: string) => ({
     type: "success",
     message: (
       <Text marginBottom={0}>
@@ -165,7 +165,7 @@ export const DYNAMIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   }),
-  "remove-record-success": (listId: string) => ({
+  removeRecordSuccess: (listId: string) => ({
     type: "success",
     message: (
       <Text marginBottom={0}>
@@ -189,7 +189,7 @@ export const DYNAMIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   }),
-  "account-specific-failure": (message: string) => ({
+  accountSpecificFailure: (message: string) => ({
     type: "failure",
     message: (
       <Text marginBottom={0}>

--- a/src/utils/statusUtils.tsx
+++ b/src/utils/statusUtils.tsx
@@ -1,0 +1,180 @@
+import { Text } from "@nypl/design-system-react-components"
+import Link from "../components/Link/Link"
+import type { StatusBannerState } from "../components/MyAccount/Settings/StatusBanner"
+
+export type StaticStatusKey =
+  | "duplicate-list-success"
+  | "duplicate-list-failure"
+  | "delete-list-success"
+  | "delete-list-failure"
+  | "save-record-failure"
+  | "list-changes-success"
+  | "list-changes-failure"
+  | "remove-record-failure"
+  | "account-success"
+  | "account-failure"
+  | "create-list-success"
+  | "create-list-failure"
+  | "password-incorrect-failure"
+  | "password-invalid-failure"
+
+export const STATIC_STATUS_MESSAGES: Record<
+  StaticStatusKey,
+  StatusBannerState
+> = {
+  "duplicate-list-success": {
+    type: "success",
+    message: <Text marginBottom={0}>Your list has been duplicated.</Text>,
+  },
+  "duplicate-list-failure": {
+    type: "failure",
+    message: <Text marginBottom={0}>Your list could not be duplicated.</Text>,
+  },
+  "delete-list-success": {
+    type: "success",
+    message: <Text marginBottom={0}>Your list has been deleted.</Text>,
+  },
+  "delete-list-failure": {
+    type: "failure",
+    message: <Text marginBottom={0}>Your list could not be deleted.</Text>,
+  },
+  "create-list-success": {
+    type: "success",
+    message: <Text marginBottom={0}>List created.</Text>,
+  },
+  "create-list-failure": {
+    type: "failure",
+    message: <Text marginBottom={0}>List creation failed. Try again.</Text>,
+  },
+  "list-changes-success": {
+    type: "success",
+    message: (
+      <Text marginBottom={0}>
+        Your list changes have been saved. Lists can be managed from your{" "}
+        <Link href="/account/lists">patron account.</Link>
+      </Text>
+    ),
+  },
+  "list-changes-failure": {
+    type: "failure",
+    message: (
+      <Text>
+        Your list changes could not be saved. Try again or{" "}
+        <Link isExternal href="https://www.nypl.org/get-help/contact-us">
+          contact us
+        </Link>{" "}
+        for assistance. Lists can be managed from your{" "}
+        <Link href="/account/lists">patron account.</Link>
+      </Text>
+    ),
+  },
+  "save-record-failure": {
+    type: "failure",
+    message: <Text marginBottom={0}>This record could not be saved.</Text>,
+  },
+  "remove-record-failure": {
+    type: "failure",
+    message: <Text marginBottom={0}>This record could not be removed.</Text>,
+  },
+  "account-success": {
+    type: "success",
+    message: <Text marginBottom={0}>Your changes were saved.</Text>,
+  },
+  "account-failure": {
+    type: "failure",
+    message: <Text marginBottom={0}>Your changes were not saved.</Text>,
+  },
+  "password-incorrect-failure": {
+    type: "failure",
+    message: (
+      <Text marginBottom={0}>
+        Incorrect current pin/password. Please try again or{" "}
+        <Link isExternal href="https://www.nypl.org/get-help/contact-us">
+          contact us
+        </Link>{" "}
+        for assistance.
+      </Text>
+    ),
+  },
+  "password-invalid-failure": {
+    type: "failure",
+    message: (
+      <Text marginBottom={0}>
+        Invalid new pin/password. Please try again or{" "}
+        <Link isExternal href="https://www.nypl.org/get-help/contact-us">
+          contact us
+        </Link>{" "}
+        for assistance.
+      </Text>
+    ),
+  },
+}
+
+export type DynamicStatusKey =
+  | "save-record-success"
+  | "remove-record-success"
+  | "account-specific-failure"
+
+export const DYNAMIC_STATUS_MESSAGES: Record<
+  DynamicStatusKey,
+  (param: string) => StatusBannerState
+> = {
+  "save-record-success": (listId: string) => ({
+    type: "success",
+    message: (
+      <Text marginBottom={0}>
+        This record has been saved to{" "}
+        <Link
+          target="_blank"
+          color="ui.link.primary !important"
+          href={`/account/lists/${listId}`}
+        >
+          My workspace (default list)
+        </Link>
+        . Lists can be managed from your{" "}
+        <Link
+          target="_blank"
+          color="ui.link.primary !important"
+          href="/account/lists"
+        >
+          patron account
+        </Link>
+        .
+      </Text>
+    ),
+  }),
+  "remove-record-success": (listId: string) => ({
+    type: "success",
+    message: (
+      <Text marginBottom={0}>
+        This record has been removed from{" "}
+        <Link
+          target="_blank"
+          color="ui.link.primary !important"
+          href={`/account/lists/${listId}`}
+        >
+          My workspace (default list)
+        </Link>
+        . Lists can be managed from your{" "}
+        <Link
+          target="_blank"
+          color="ui.link.primary !important"
+          href="/account/lists"
+        >
+          patron account
+        </Link>
+        .
+      </Text>
+    ),
+  }),
+  "account-specific-failure": (message: string) => ({
+    type: "failure",
+    message: (
+      <Text marginBottom={0}>
+        {message} Please try again or{" "}
+        <Link href="https://www.nypl.org/get-help/contact-us">contact us</Link>{" "}
+        for assistance.
+      </Text>
+    ),
+  }),
+}

--- a/src/utils/statusUtils.tsx
+++ b/src/utils/statusUtils.tsx
@@ -17,6 +17,7 @@ export type StaticStatusKey =
   | "create-list-failure"
   | "password-incorrect-failure"
   | "password-invalid-failure"
+  | "username-failure"
 
 export const STATIC_STATUS_MESSAGES: Record<
   StaticStatusKey,
@@ -82,7 +83,15 @@ export const STATIC_STATUS_MESSAGES: Record<
   },
   "account-failure": {
     type: "failure",
-    message: <Text marginBottom={0}>Your changes were not saved.</Text>,
+    message: (
+      <Text marginBottom={0}>
+        Your changes could not be saved. Please try again or{" "}
+        <Link isExternal href="https://www.nypl.org/get-help/contact-us">
+          contact us
+        </Link>{" "}
+        for assistance.
+      </Text>
+    ),
   },
   "password-incorrect-failure": {
     type: "failure",
@@ -108,8 +117,21 @@ export const STATIC_STATUS_MESSAGES: Record<
       </Text>
     ),
   },
+  "username-failure": {
+    type: "failure",
+    message: (
+      <Text marginBottom={0}>
+        This username already exists. Please try again or{" "}
+        <Link isExternal href="https://www.nypl.org/get-help/contact-us">
+          contact us
+        </Link>{" "}
+        for assistance.
+      </Text>
+    ),
+  },
 }
 
+// Statii that require a param to set a linked value.
 export type DynamicStatusKey =
   | "save-record-success"
   | "remove-record-success"


### PR DESCRIPTION
## Ticket:

- n/a, comes from lots of statii on Lists

## This PR does the following:

<!--- Brief, bulleted list of changes. -->

**status** (first two commits)
- In various places (mainly My Account) we display a status banner when a user takes a successful or failed action
- Passing that displayed message and type (success/failure) was using two states. By mapping a bunch of statuses to their corresponding type and message, now it can just be one state, distinguished by a string in `STATIC_STATUS_MESSAGES` or `DYNAMIC_STATUS_MESSAGES`

**focus**
- Additionally, removes `useEffect` + `ref` approach to focus from list status banners
- Adds 100ms delay to the part of `FocusContext` that actually focuses the active element ID, which allows the DOM to flush and display whatever it wants (like a banner!)

## How has this been tested? How should a reviewer test this?

<!--- Describe how you tested your changes and how the reviewer can test the changes made in this PR. -->

All status banner interactions should be exactly the same

## Accessibility updates?

n/a

## Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.
