### PR TITLE
SCC 5420/playwright nyql - Adds query search tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Playwright tests for query searches [SCC-5420] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-5420)
+
 - Added warn log for no results from query with a single filter and no keyword [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)
 
 ## [2.0.0] 2026-06-04

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Playwright tests for query searches [SCC-5420] (https://newyorkpubliclibrary.atlassian.net/browse/SCC-5420)
+- Added Playwright tests for query searches [SCC-5420](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5420)
 
 - Added warn log for no results from query with a single filter and no keyword [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)
 

--- a/playwright/pages/browse_page.ts
+++ b/playwright/pages/browse_page.ts
@@ -26,10 +26,7 @@ export class BrowsePage {
 
     this.search_dropdown = page.getByLabel("Select a category")
     this.search_input = page.getByRole("textbox")
-    this.search_submit_button = page.getByRole("button", {
-      name: "Search",
-      exact: true,
-    })
+    this.search_submit_button = page.locator(".ds-searchBar-button")
 
     this.searchResultsTitle = page.locator("//span/div", {
       hasText: this.searchterm,

--- a/playwright/pages/rc_home_page.ts
+++ b/playwright/pages/rc_home_page.ts
@@ -38,10 +38,7 @@ export class RC_Home_Page extends BasePage {
     this.search_input = page.getByRole("textbox", {
       name: "Enter one or more keywords.",
     })
-    this.search_submit_button = page.getByRole("button", {
-      name: "Search",
-      exact: true,
-    })
+    this.search_submit_button = page.locator(".ds-searchBar-button")
     this.advanced_search_link = page.getByRole("link", {
       name: "Advanced Search",
     })

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -32,21 +32,11 @@ export class SearchPage {
   }
 
   get searchResultsHeading() {
-    // Escape special regex characters in searchterm
-    const escapedSearchterm = this.searchterm.replace(
-      /[.*+?^${}()|[\]\\]/g,
-      "\\$&"
-    )
-
-    // Query searches use different heading format: "for query: <syntax>"
-    // Standard searches use: "for <SearchType> "<searchterm>""
-    const headingPattern =
-      this.searchType.toLowerCase() === "query"
-        ? `Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for query: ${escapedSearchterm}`
-        : `Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for ${this.searchType}s? "${escapedSearchterm}"`
-
     return this.page.getByRole("heading", {
-      name: new RegExp(headingPattern, "i"),
+      name: new RegExp(
+        `Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for ${this.searchType}s? "${this.searchterm}"`,
+        "i"
+      ),
     })
   }
 

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -19,10 +19,7 @@ export class SearchPage {
 
     this.search_dropdown = page.getByLabel("Select a category")
     this.search_input = page.getByRole("textbox")
-    this.search_submit_button = page.getByRole("button", {
-      name: "Search",
-      exact: true,
-    })
+    this.search_submit_button = page.locator(".ds-searchBar-button")
 
     this.searchResultsContainer = page.locator("#search-results-list")
     this.searchResults = page.locator("#search-results-list h3 a")
@@ -46,6 +43,9 @@ export class SearchPage {
     await this.search_dropdown.selectOption({ label: searchType })
 
     await this.search_input.fill(searchterm)
-    await this.search_submit_button.click()
+
+    // Firefox can intermittently show a portal overlay during hydration.
+    // Submitting with Enter avoids pointer interception on the button.
+    await this.search_input.press("Enter")
   }
 }

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -32,11 +32,21 @@ export class SearchPage {
   }
 
   get searchResultsHeading() {
+    // Escape special regex characters in searchterm
+    const escapedSearchterm = this.searchterm.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&"
+    )
+
+    // Query searches use different heading format: "for query: <syntax>"
+    // Standard searches use: "for <SearchType> "<searchterm>""
+    const headingPattern =
+      this.searchType.toLowerCase() === "query"
+        ? `Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for query: ${escapedSearchterm}`
+        : `Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for ${this.searchType}s? "${escapedSearchterm}"`
+
     return this.page.getByRole("heading", {
-      name: new RegExp(
-        `Displaying (\\d+-\\d+|\\d+) of (over )?\\d{1,3}(,\\d{3})* results for ${this.searchType}s? "${this.searchterm}"`,
-        "i"
-      ),
+      name: new RegExp(headingPattern, "i"),
     })
   }
 

--- a/playwright/test-1.spec.ts
+++ b/playwright/test-1.spec.ts
@@ -1,5 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('test', async ({ page }) => {
-  // Recording...
-});

--- a/playwright/test-1.spec.ts
+++ b/playwright/test-1.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  // Recording...
+});

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test"
+import { SearchPage } from "../../pages/search_page"
+
+let searchPage: SearchPage
+const queryBaseUrl =
+  process.env.PLAYWRIGHT_QUERY_BASE_URL ??
+  "https://train-research-catalog.nypl.org/research/research-catalog"
+
+test.beforeEach(async ({ page }) => {
+  searchPage = new SearchPage(page, "")
+  await page.goto(queryBaseUrl)
+})
+
+test.describe("Query Search", () => {
+  test("Do a query search and assert that it returns results", async () => {
+    await searchPage.searchFor('author = "Meillassoux, Quentin"', "Query")
+
+    await expect(searchPage.searchResultsHeading).toBeVisible({
+      timeout: 15000,
+    })
+    // print the titles of the first 5 search results to the console
+    const titles = await searchPage.searchResults.allTextContents()
+    console.log("Search results titles:")
+    for (const title of titles.slice(0, 5)) {
+      console.log(title)
+    }
+
+    // now go to the advanced search page and do an Author/Contributor search and assert the results are the same as the query search
+    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    // enter "Meillassoux, Quentin" into the Author/Contributor textbox
+    await searchPage.page
+      .getByRole("textbox", { name: "Author/Contributor" })
+      .fill("Meillassoux, Quentin")
+    // click the search button
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResultsHeading).toBeVisible({
+      timeout: 15000,
+    })
+
+    await expect(async () => {
+      const count = await searchPage.searchResults.count()
+      expect(count).toBeGreaterThan(0)
+    }).toPass({ timeout: 10000 })
+  })
+})

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -20,7 +20,7 @@ test.describe("Query Search", () => {
       .filter(Boolean)
 
     // now go to the advanced search page and do an Author/Contributor search and assert the results are the same as the query search
-    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page.goto("" + "/search/advanced")
     // enter "Meillassoux, Quentin" into the Author/Contributor textbox
     await searchPage.page
       .getByRole("textbox", { name: "Author/Contributor" })
@@ -51,7 +51,7 @@ test.describe("Query Search", () => {
       .filter(Boolean)
 
     // now go to the advanced search page and do a Keyword search and assert the results are the same as the query search
-    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page.goto("" + "/search/advanced")
     // enter "pterosaur" into the Keyword textbox
     await searchPage.page
       .getByRole("textbox", { name: "Keyword" })
@@ -83,7 +83,7 @@ test.describe("Query Search", () => {
       .filter(Boolean)
 
     // now go to the advanced search page and do a Keyword search and assert the results are the same as the query search
-    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page.goto("" + "/search/advanced")
     // enter "pterosaur" into the Keyword textbox
     await searchPage.page
       .getByRole("textbox", { name: "Keyword" })
@@ -118,7 +118,7 @@ test.describe("title = the cat in the hat", () => {
       .filter(Boolean)
 
     // now go to the advanced search page and do a Title search and assert the results are the same as the query search
-    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page.goto("" + "/search/advanced")
     // enter "the cat in the hat" into the Title textbox
     await searchPage.page
       .getByRole("textbox", { name: "Title" })

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -11,8 +11,8 @@ test.beforeEach(async ({ page }) => {
   searchPage = new SearchPage(page, "")
   await page.goto("")
 
-  // Wait for hydration to complete and page to be stable
-  await page.waitForLoadState("networkidle")
+  // Wait for the search UI to be ready
+  await expect(searchPage.search_dropdown).toBeVisible()
 })
 
 test.describe("Query Search", () => {

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -2,13 +2,10 @@ import { test, expect } from "@playwright/test"
 import { SearchPage } from "../../pages/search_page"
 
 let searchPage: SearchPage
-const queryBaseUrl =
-  process.env.PLAYWRIGHT_QUERY_BASE_URL ??
-  "https://train-research-catalog.nypl.org/research/research-catalog"
 
 test.beforeEach(async ({ page }) => {
   searchPage = new SearchPage(page, "")
-  await page.goto(queryBaseUrl)
+  await page.goto("")
 })
 
 test.describe("Query Search", () => {

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -4,12 +4,7 @@ import { SearchPage } from "../../pages/search_page"
 let searchPage: SearchPage
 
 test.beforeEach(async ({ page }) => {
-  // Suppress hydration warnings in console
-  page.on("console", (msg) => {
-    if (msg.type() === "warning" && msg.text().includes("hydration")) {
-      return
-    }
-  })
+  // No console listener is needed here; Playwright does not fail tests on console hydration warnings by default.
 
   // Dismiss any Next.js error dialogs that may appear
   page.on("dialog", async (dialog) => {

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -152,7 +152,7 @@ test.describe("callnumber = JFE 86-3252", () => {
         .filter(Boolean)
 
       expect(callNumberTitles).toHaveLength(queryTitles.length)
-      expect(callNumberTitles).toEqual(queryTitles)
+      expect([...callNumberTitles].sort()).toEqual([...queryTitles].sort())
       expect(queryTitles.length).toBeGreaterThan(0)
     }).toPass({ timeout: 15000 })
   })

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -6,10 +6,7 @@ let searchPage: SearchPage
 test.beforeEach(async ({ page }) => {
   // No console listener is needed here; Playwright does not fail tests on console hydration warnings by default.
 
-  // Dismiss any Next.js error dialogs that may appear
-  page.on("dialog", async (dialog) => {
-    await dialog.dismiss()
-  })
+  // Do not auto-dismiss dialogs; unexpected dialogs should fail the test run so errors are visible.
 
   searchPage = new SearchPage(page, "")
   await page.goto("")

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -39,7 +39,10 @@ test.describe("Query Search", () => {
     await searchPage.page
       .getByRole("textbox", { name: "Author/Contributor" })
       .fill("Meillassoux, Quentin")
-    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
+    await searchPage.page
+      .locator("form")
+      .locator("#submit-advanced-search")
+      .click()
 
     await expect(async () => {
       await expect(searchPage.searchResults.first()).toBeVisible({
@@ -70,7 +73,10 @@ test.describe("Query Search", () => {
       .getByRole("textbox", { name: "Keyword" })
       .fill("pterosaur")
     // click the search button
-    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
+    await searchPage.page
+      .locator("form")
+      .locator("#submit-advanced-search")
+      .click()
 
     await expect(async () => {
       await expect(searchPage.searchResults.first()).toBeVisible({
@@ -102,7 +108,10 @@ test.describe("Query Search", () => {
       .getByRole("textbox", { name: "Keyword" })
       .fill("pterosaur")
     // click the search button
-    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
+    await searchPage.page
+      .locator("form")
+      .locator("#submit-advanced-search")
+      .click()
 
     await expect(async () => {
       await expect(searchPage.searchResults.first()).toBeVisible({
@@ -120,8 +129,6 @@ test.describe("Query Search", () => {
     }).toPass({ timeout: 15000 })
   })
 })
-
-
 
 test.describe("callnumber = JFE 86-3252", () => {
   test("callnumber = JFE 86-3252", async () => {
@@ -159,8 +166,6 @@ test.describe("callnumber = JFE 86-3252", () => {
   })
 })
 
-
-
 test.describe('callnumber = "^JFE 24"', () => {
   test('callnumber = "^JFE 24"', async () => {
     await searchPage.searchFor('callnumber = "^JFE 24"', "Query")
@@ -178,7 +183,10 @@ test.describe('callnumber = "^JFE 24"', () => {
       .getByRole("textbox", { name: "Call number" })
       .fill("^JFE 24")
     // click the search button
-    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
+    await searchPage.page
+      .locator("form")
+      .locator("#submit-advanced-search")
+      .click()
 
     await expect(async () => {
       await expect(searchPage.searchResults.first()).toBeVisible({
@@ -225,7 +233,10 @@ test.describe('subject = "Mitanni (Ancient kingdom)"', () => {
       .getByRole("textbox", { name: "Subject" })
       .fill("Mitanni (Ancient kingdom)")
     // click the search button
-    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
+    await searchPage.page
+      .locator("form")
+      .locator("#submit-advanced-search")
+      .click()
 
     await expect(async () => {
       await expect(searchPage.searchResults.first()).toBeVisible({

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -4,8 +4,23 @@ import { SearchPage } from "../../pages/search_page"
 let searchPage: SearchPage
 
 test.beforeEach(async ({ page }) => {
+  // Suppress hydration warnings in console
+  page.on("console", (msg) => {
+    if (msg.type() === "warning" && msg.text().includes("hydration")) {
+      return
+    }
+  })
+
+  // Dismiss any Next.js error dialogs that may appear
+  page.on("dialog", async (dialog) => {
+    await dialog.dismiss()
+  })
+
   searchPage = new SearchPage(page, "")
   await page.goto("")
+
+  // Wait for hydration to complete and page to be stable
+  await page.waitForLoadState("networkidle")
 })
 
 test.describe("Query Search", () => {
@@ -20,24 +35,24 @@ test.describe("Query Search", () => {
       .filter(Boolean)
 
     // now go to the advanced search page and do an Author/Contributor search and assert the results are the same as the query search
-    await searchPage.page.goto("" + "/search/advanced")
-    // enter "Meillassoux, Quentin" into the Author/Contributor textbox
+    await searchPage.page.goto("search/advanced")
     await searchPage.page
       .getByRole("textbox", { name: "Author/Contributor" })
       .fill("Meillassoux, Quentin")
-    // click the search button
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
+    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
 
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 15000,
-    })
-    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
+    await expect(async () => {
+      await expect(searchPage.searchResults.first()).toBeVisible({
+        timeout: 15000,
+      })
+      const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+        .map((t) => t.trim())
+        .filter(Boolean)
 
-    expect(advancedTitles).toHaveLength(queryTitles.length)
-    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
-    expect(queryTitles.length).toBeGreaterThan(0)
+      expect(advancedTitles).toHaveLength(queryTitles.length)
+      expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+      expect(queryTitles.length).toBeGreaterThan(0)
+    }).toPass({ timeout: 15000 })
   })
 
   test('keyword = "pterosaur"', async () => {
@@ -50,27 +65,27 @@ test.describe("Query Search", () => {
       .map((t) => t.trim())
       .filter(Boolean)
 
-    // now go to the advanced search page and do a Keyword search and assert the results are the same as the query search
-    await searchPage.page.goto("" + "/search/advanced")
-    // enter "pterosaur" into the Keyword textbox
+    await searchPage.page.goto("search/advanced")
     await searchPage.page
       .getByRole("textbox", { name: "Keyword" })
       .fill("pterosaur")
     // click the search button
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
+    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
 
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 15000,
-    })
-    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
+    await expect(async () => {
+      await expect(searchPage.searchResults.first()).toBeVisible({
+        timeout: 15000,
+      })
+      const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+        .map((t) => t.trim())
+        .filter(Boolean)
 
-    expect(advancedTitles).toHaveLength(queryTitles.length)
-    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
-    // if exact same order is expected, use this instead:
-    //expect(advancedTitles).toEqual(queryTitles)
-    expect(queryTitles.length).toBeGreaterThan(0)
+      expect(advancedTitles).toHaveLength(queryTitles.length)
+      expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+      // if exact same order is expected, use this instead:
+      //expect(advancedTitles).toEqual(queryTitles)
+      expect(queryTitles.length).toBeGreaterThan(0)
+    }).toPass({ timeout: 15000 })
   })
   test("keyword = pterosaur", async () => {
     await searchPage.searchFor("keyword = pterosaur", "Query")
@@ -82,62 +97,31 @@ test.describe("Query Search", () => {
       .map((t) => t.trim())
       .filter(Boolean)
 
-    // now go to the advanced search page and do a Keyword search and assert the results are the same as the query search
-    await searchPage.page.goto("" + "/search/advanced")
-    // enter "pterosaur" into the Keyword textbox
+    await searchPage.page.goto("search/advanced")
     await searchPage.page
       .getByRole("textbox", { name: "Keyword" })
       .fill("pterosaur")
     // click the search button
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
+    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
 
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 15000,
-    })
-    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
+    await expect(async () => {
+      await expect(searchPage.searchResults.first()).toBeVisible({
+        timeout: 15000,
+      })
+      const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+        .map((t) => t.trim())
+        .filter(Boolean)
 
-    expect(advancedTitles).toHaveLength(queryTitles.length)
-    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
-    // if exact same order is expected, use this instead:
-    //expect(advancedTitles).toEqual(queryTitles)
-    expect(queryTitles.length).toBeGreaterThan(0)
+      expect(advancedTitles).toHaveLength(queryTitles.length)
+      expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+      // if exact same order is expected, use this instead:
+      //expect(advancedTitles).toEqual(queryTitles)
+      expect(queryTitles.length).toBeGreaterThan(0)
+    }).toPass({ timeout: 15000 })
   })
 })
 
-test.describe("title = the cat in the hat", () => {
-  test("title = the cat in the hat", async () => {
-    await searchPage.searchFor('title = "the cat in the hat"', "Query")
 
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 15000,
-    })
-    const queryTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
-
-    // now go to the advanced search page and do a Title search and assert the results are the same as the query search
-    await searchPage.page.goto("" + "/search/advanced")
-    // enter "the cat in the hat" into the Title textbox
-    await searchPage.page
-      .getByRole("textbox", { name: "Title" })
-      .fill("the cat in the hat")
-    // click the search button
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
-
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 30000,
-    })
-    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
-
-    expect(advancedTitles).toHaveLength(queryTitles.length)
-    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
-    expect(queryTitles.length).toBeGreaterThan(0)
-  })
-})
 
 test.describe("callnumber = JFE 86-3252", () => {
   test("callnumber = JFE 86-3252", async () => {
@@ -154,53 +138,28 @@ test.describe("callnumber = JFE 86-3252", () => {
     await searchPage.page
       .getByLabel("Select a category")
       .selectOption({ label: "Call number" })
-    await searchPage.page
-      .getByRole("textbox", { name: "Enter a call number or the" })
-      .fill("JFE 86-3252")
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
-
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 15000,
+    const callNumberInput = searchPage.page.getByRole("textbox", {
+      name: "Enter a call number or the",
     })
-    const callNumberTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
+    await callNumberInput.fill("JFE 86-3252")
+    await callNumberInput.press("Enter")
 
-    expect(callNumberTitles).toHaveLength(queryTitles.length)
-    expect(callNumberTitles).toEqual(queryTitles)
-    expect(queryTitles.length).toBeGreaterThan(0)
+    await expect(async () => {
+      await expect(searchPage.searchResults.first()).toBeVisible({
+        timeout: 15000,
+      })
+      const callNumberTitles = (await searchPage.searchResults.allInnerTexts())
+        .map((t) => t.trim())
+        .filter(Boolean)
+
+      expect(callNumberTitles).toHaveLength(queryTitles.length)
+      expect(callNumberTitles).toEqual(queryTitles)
+      expect(queryTitles.length).toBeGreaterThan(0)
+    }).toPass({ timeout: 15000 })
   })
 })
 
-test.describe('callnumber = "MGZMD" AND keyword = "graham"', () => {
-  test('callnumber = "MGZMD" AND keyword = "graham"', async () => {
-    await searchPage.searchFor(
-      'callnumber = "MGZMD" AND keyword = "graham"',
-      "Query"
-    )
 
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 15000,
-    })
-    const queryTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
-    expect(queryTitles.length).toBeGreaterThan(0)
-
-    // Locate all target cells that immediately follow a 'CALL NUMBER' cell
-    const targetCells = searchPage.page.locator(
-      'td:has-text("CALL NUMBER") + td'
-    )
-
-    // Get an array of locators for every instance found on the page
-    const allInstances = await targetCells.all()
-
-    // Assert each call number cell contains MGZMD
-    for (const cell of allInstances) {
-      await expect(cell).toContainText("MGZMD")
-    }
-  })
-})
 
 test.describe('callnumber = "^JFE 24"', () => {
   test('callnumber = "^JFE 24"', async () => {
@@ -214,23 +173,24 @@ test.describe('callnumber = "^JFE 24"', () => {
       .filter(Boolean)
 
     // now go to the advanced search page and do a Title search and assert the results are the same as the query search
-    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page.goto("search/advanced")
     await searchPage.page
       .getByRole("textbox", { name: "Call number" })
       .fill("^JFE 24")
     // click the search button
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
+    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
 
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 30000,
-    })
-    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
+    await expect(async () => {
+      await expect(searchPage.searchResults.first()).toBeVisible({
+        timeout: 30000,
+      })
+      const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+        .map((t) => t.trim())
+        .filter(Boolean)
 
-    expect(advancedTitles).toHaveLength(queryTitles.length)
-    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
-    expect(queryTitles.length).toBeGreaterThan(0)
+      expect(advancedTitles).toHaveLength(queryTitles.length)
+      expect(queryTitles.length).toBeGreaterThan(0)
+    }).toPass({ timeout: 30000 })
   })
 })
 test.describe('identifier = "b10670401"', () => {
@@ -242,8 +202,10 @@ test.describe('identifier = "b10670401"', () => {
     })
     // expect 1 result to be returned and the link on the title to contain "b10670401"
     const queryTitles = searchPage.searchResults
-    await expect(queryTitles).toHaveCount(1)
-    await expect(queryTitles.first()).toHaveAttribute("href", /b10670401/)
+    await expect(async () => {
+      await expect(queryTitles).toHaveCount(1)
+      await expect(queryTitles.first()).toHaveAttribute("href", /b10670401/)
+    }).toPass({ timeout: 15000 })
   })
 })
 test.describe('subject = "Mitanni (Ancient kingdom)"', () => {
@@ -258,68 +220,23 @@ test.describe('subject = "Mitanni (Ancient kingdom)"', () => {
       .filter(Boolean)
 
     // now go to the advanced search page and do a Title search and assert the results are the same as the query search
-    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page.goto("search/advanced")
     await searchPage.page
       .getByRole("textbox", { name: "Subject" })
       .fill("Mitanni (Ancient kingdom)")
     // click the search button
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
+    await searchPage.page.locator("form").locator("#submit-advanced-search").click()
 
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 30000,
-    })
-    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
+    await expect(async () => {
+      await expect(searchPage.searchResults.first()).toBeVisible({
+        timeout: 30000,
+      })
+      const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+        .map((t) => t.trim())
+        .filter(Boolean)
 
-    expect(advancedTitles).toHaveLength(queryTitles.length)
-    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
-    expect(queryTitles.length).toBeGreaterThan(0)
-  })
-})
-test.describe('language = "Irish"', () => {
-  test('language = "Irish"', async () => {
-    await searchPage.searchFor('language = "Irish"', "Query")
-
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 15000,
-    })
-    const queryTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
-
-    // now go to the advanced search page and do a Title search and assert the results are the same as the query search
-    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
-    // click getByRole('button', { name: 'Language, 0 items currently' })
-    await searchPage.page
-      .getByRole("button", { name: "Language, 0 items currently selected" })
-      .click()
-    // fill Irish in the language search box getByRole('textbox', { name: 'Search Language' })
-    await searchPage.page
-      .getByRole("textbox", { name: "Search Language" })
-      .fill("Irish")
-    // click all checkboxes that appear in the results that have the label that starts with Irish
-    await searchPage.page.waitForTimeout(1000)
-    const irishCheckboxes = searchPage.page.locator(
-      'input[type="checkbox"][name="language"][value^="Irish"]'
-    )
-    const count = await irishCheckboxes.count()
-    for (let i = 0; i < count; i++) {
-      await irishCheckboxes.nth(i).check()
-    }
-
-    // click the search button
-    await searchPage.page.getByRole("button", { name: "Search" }).click()
-
-    await expect(searchPage.searchResults.first()).toBeVisible({
-      timeout: 30000,
-    })
-    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
-      .map((t) => t.trim())
-      .filter(Boolean)
-
-    expect(advancedTitles).toHaveLength(queryTitles.length)
-    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
-    expect(queryTitles.length).toBeGreaterThan(0)
+      expect(advancedTitles).toHaveLength(queryTitles.length)
+      expect(queryTitles.length).toBeGreaterThan(0)
+    }).toPass({ timeout: 30000 })
   })
 })

--- a/playwright/tests/search/search_nyql.spec.ts
+++ b/playwright/tests/search/search_nyql.spec.ts
@@ -12,18 +12,15 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe("Query Search", () => {
-  test("Do a query search and assert that it returns results", async () => {
+  test('author = "Meillassoux, Quentin"', async () => {
     await searchPage.searchFor('author = "Meillassoux, Quentin"', "Query")
 
-    await expect(searchPage.searchResultsHeading).toBeVisible({
+    await expect(searchPage.searchResults.first()).toBeVisible({
       timeout: 15000,
     })
-    // print the titles of the first 5 search results to the console
-    const titles = await searchPage.searchResults.allTextContents()
-    console.log("Search results titles:")
-    for (const title of titles.slice(0, 5)) {
-      console.log(title)
-    }
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
 
     // now go to the advanced search page and do an Author/Contributor search and assert the results are the same as the query search
     await searchPage.page.goto(queryBaseUrl + "/search/advanced")
@@ -34,13 +31,298 @@ test.describe("Query Search", () => {
     // click the search button
     await searchPage.page.getByRole("button", { name: "Search" }).click()
 
-    await expect(searchPage.searchResultsHeading).toBeVisible({
+    await expect(searchPage.searchResults.first()).toBeVisible({
       timeout: 15000,
     })
+    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
 
-    await expect(async () => {
-      const count = await searchPage.searchResults.count()
-      expect(count).toBeGreaterThan(0)
-    }).toPass({ timeout: 10000 })
+    expect(advancedTitles).toHaveLength(queryTitles.length)
+    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+    expect(queryTitles.length).toBeGreaterThan(0)
+  })
+
+  test('keyword = "pterosaur"', async () => {
+    await searchPage.searchFor('keyword = "pterosaur"', "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // now go to the advanced search page and do a Keyword search and assert the results are the same as the query search
+    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    // enter "pterosaur" into the Keyword textbox
+    await searchPage.page
+      .getByRole("textbox", { name: "Keyword" })
+      .fill("pterosaur")
+    // click the search button
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    expect(advancedTitles).toHaveLength(queryTitles.length)
+    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+    // if exact same order is expected, use this instead:
+    //expect(advancedTitles).toEqual(queryTitles)
+    expect(queryTitles.length).toBeGreaterThan(0)
+  })
+  test("keyword = pterosaur", async () => {
+    await searchPage.searchFor("keyword = pterosaur", "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // now go to the advanced search page and do a Keyword search and assert the results are the same as the query search
+    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    // enter "pterosaur" into the Keyword textbox
+    await searchPage.page
+      .getByRole("textbox", { name: "Keyword" })
+      .fill("pterosaur")
+    // click the search button
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    expect(advancedTitles).toHaveLength(queryTitles.length)
+    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+    // if exact same order is expected, use this instead:
+    //expect(advancedTitles).toEqual(queryTitles)
+    expect(queryTitles.length).toBeGreaterThan(0)
+  })
+})
+
+test.describe("title = the cat in the hat", () => {
+  test("title = the cat in the hat", async () => {
+    await searchPage.searchFor('title = "the cat in the hat"', "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // now go to the advanced search page and do a Title search and assert the results are the same as the query search
+    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    // enter "the cat in the hat" into the Title textbox
+    await searchPage.page
+      .getByRole("textbox", { name: "Title" })
+      .fill("the cat in the hat")
+    // click the search button
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 30000,
+    })
+    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    expect(advancedTitles).toHaveLength(queryTitles.length)
+    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+    expect(queryTitles.length).toBeGreaterThan(0)
+  })
+})
+
+test.describe("callnumber = JFE 86-3252", () => {
+  test("callnumber = JFE 86-3252", async () => {
+    await searchPage.searchFor('callnumber = "JFE 86-3252"', "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // now do a Call Number search and assert the results are the same as the query search
+    await searchPage.page
+      .getByLabel("Select a category")
+      .selectOption({ label: "Call number" })
+    await searchPage.page
+      .getByRole("textbox", { name: "Enter a call number or the" })
+      .fill("JFE 86-3252")
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const callNumberTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    expect(callNumberTitles).toHaveLength(queryTitles.length)
+    expect(callNumberTitles).toEqual(queryTitles)
+    expect(queryTitles.length).toBeGreaterThan(0)
+  })
+})
+
+test.describe('callnumber = "MGZMD" AND keyword = "graham"', () => {
+  test('callnumber = "MGZMD" AND keyword = "graham"', async () => {
+    await searchPage.searchFor(
+      'callnumber = "MGZMD" AND keyword = "graham"',
+      "Query"
+    )
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+    expect(queryTitles.length).toBeGreaterThan(0)
+
+    // Locate all target cells that immediately follow a 'CALL NUMBER' cell
+    const targetCells = searchPage.page.locator(
+      'td:has-text("CALL NUMBER") + td'
+    )
+
+    // Get an array of locators for every instance found on the page
+    const allInstances = await targetCells.all()
+
+    // Assert each call number cell contains MGZMD
+    for (const cell of allInstances) {
+      await expect(cell).toContainText("MGZMD")
+    }
+  })
+})
+
+test.describe('callnumber = "^JFE 24"', () => {
+  test('callnumber = "^JFE 24"', async () => {
+    await searchPage.searchFor('callnumber = "^JFE 24"', "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // now go to the advanced search page and do a Title search and assert the results are the same as the query search
+    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page
+      .getByRole("textbox", { name: "Call number" })
+      .fill("^JFE 24")
+    // click the search button
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 30000,
+    })
+    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    expect(advancedTitles).toHaveLength(queryTitles.length)
+    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+    expect(queryTitles.length).toBeGreaterThan(0)
+  })
+})
+test.describe('identifier = "b10670401"', () => {
+  test('identifier = "b10670401"', async () => {
+    await searchPage.searchFor('identifier = "b10670401"', "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    // expect 1 result to be returned and the link on the title to contain "b10670401"
+    const queryTitles = searchPage.searchResults
+    await expect(queryTitles).toHaveCount(1)
+    await expect(queryTitles.first()).toHaveAttribute("href", /b10670401/)
+  })
+})
+test.describe('subject = "Mitanni (Ancient kingdom)"', () => {
+  test('subject = "Mitanni (Ancient kingdom)"', async () => {
+    await searchPage.searchFor('subject = "Mitanni (Ancient kingdom)"', "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // now go to the advanced search page and do a Title search and assert the results are the same as the query search
+    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    await searchPage.page
+      .getByRole("textbox", { name: "Subject" })
+      .fill("Mitanni (Ancient kingdom)")
+    // click the search button
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 30000,
+    })
+    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    expect(advancedTitles).toHaveLength(queryTitles.length)
+    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+    expect(queryTitles.length).toBeGreaterThan(0)
+  })
+})
+test.describe('language = "Irish"', () => {
+  test('language = "Irish"', async () => {
+    await searchPage.searchFor('language = "Irish"', "Query")
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 15000,
+    })
+    const queryTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    // now go to the advanced search page and do a Title search and assert the results are the same as the query search
+    await searchPage.page.goto(queryBaseUrl + "/search/advanced")
+    // click getByRole('button', { name: 'Language, 0 items currently' })
+    await searchPage.page
+      .getByRole("button", { name: "Language, 0 items currently selected" })
+      .click()
+    // fill Irish in the language search box getByRole('textbox', { name: 'Search Language' })
+    await searchPage.page
+      .getByRole("textbox", { name: "Search Language" })
+      .fill("Irish")
+    // click all checkboxes that appear in the results that have the label that starts with Irish
+    await searchPage.page.waitForTimeout(1000)
+    const irishCheckboxes = searchPage.page.locator(
+      'input[type="checkbox"][name="language"][value^="Irish"]'
+    )
+    const count = await irishCheckboxes.count()
+    for (let i = 0; i < count; i++) {
+      await irishCheckboxes.nth(i).check()
+    }
+
+    // click the search button
+    await searchPage.page.getByRole("button", { name: "Search" }).click()
+
+    await expect(searchPage.searchResults.first()).toBeVisible({
+      timeout: 30000,
+    })
+    const advancedTitles = (await searchPage.searchResults.allInnerTexts())
+      .map((t) => t.trim())
+      .filter(Boolean)
+
+    expect(advancedTitles).toHaveLength(queryTitles.length)
+    expect([...advancedTitles].sort()).toEqual([...queryTitles].sort())
+    expect(queryTitles.length).toBeGreaterThan(0)
   })
 })

--- a/playwright/tests/search/search_unique_identifier.spec.ts
+++ b/playwright/tests/search/search_unique_identifier.spec.ts
@@ -16,9 +16,10 @@ test.describe("Unique Identifier Search", () => {
   }) => {
     await searchPage.searchFor(searchterm, "Unique identifier")
     await expect(searchPage.searchResultsHeading).toBeVisible()
-    // navigate to the first search result via its href to avoid portal overlay
-    const href = await searchPage.searchResults.first().getAttribute("href")
-    await page.goto(href || "")
+// navigate to the first search result via its href to avoid portal overlay
+const href = await searchPage.searchResults.first().getAttribute("href")
+expect(href, "Expected first search result to have an href").toBeTruthy()
+await page.goto(href!)
     // assert that the unique identifier is present on the item detail page
     await expect(page.getByText(new RegExp(searchterm))).toBeVisible()
   })

--- a/playwright/tests/search/search_unique_identifier.spec.ts
+++ b/playwright/tests/search/search_unique_identifier.spec.ts
@@ -7,6 +7,7 @@ const searchterm = "82048999"
 test.beforeEach(async ({ page }) => {
   searchPage = new SearchPage(page, searchterm)
   await page.goto("")
+  await page.waitForFunction(() => document.readyState === "complete")
 })
 
 test.describe("Unique Identifier Search", () => {
@@ -15,8 +16,9 @@ test.describe("Unique Identifier Search", () => {
   }) => {
     await searchPage.searchFor(searchterm, "Unique identifier")
     await expect(searchPage.searchResultsHeading).toBeVisible()
-    // click on the title of the first search result
-    await searchPage.searchResults.first().click()
+    // navigate to the first search result via its href to avoid portal overlay
+    const href = await searchPage.searchResults.first().getAttribute("href")
+    await page.goto(href || "")
     // assert that the unique identifier is present on the item detail page
     await expect(page.getByText(new RegExp(searchterm))).toBeVisible()
   })

--- a/playwright/tests/search/search_unique_identifier.spec.ts
+++ b/playwright/tests/search/search_unique_identifier.spec.ts
@@ -16,10 +16,10 @@ test.describe("Unique Identifier Search", () => {
   }) => {
     await searchPage.searchFor(searchterm, "Unique identifier")
     await expect(searchPage.searchResultsHeading).toBeVisible()
-// navigate to the first search result via its href to avoid portal overlay
-const href = await searchPage.searchResults.first().getAttribute("href")
-expect(href, "Expected first search result to have an href").toBeTruthy()
-await page.goto(href!)
+    // navigate to the first search result via its href to avoid portal overlay
+    const href = await searchPage.searchResults.first().getAttribute("href")
+    expect(href, "Expected first search result to have an href").toBeTruthy()
+    await page.goto(href!)
     // assert that the unique identifier is present on the item detail page
     await expect(page.getByText(new RegExp(searchterm))).toBeVisible()
   })


### PR DESCRIPTION
## Ticket:

- JIRA ticket [5420](https://newyorkpubliclibrary.atlassian.net/browse/5420)

## This PR does the following:

Adds Playwright tests for query searches.

## How has this been tested? How should a reviewer test this?

All tests pass locally.

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [ ] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [ ] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [ ] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [ ] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.
