### PR TITLE
SCC-5058: Split heading into screenreader and focusable visual element

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added warn log for no results from query with a single filter and no keyword [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)
 
+### Updated
+
+- Split results heading into screenreader and focusable visual element [SCC-5058](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5058)
+
 ## [2.0.0] 2026-06-04
 
 ### Added

--- a/__test__/pages/browse/authors/authorResults.test.tsx
+++ b/__test__/pages/browse/authors/authorResults.test.tsx
@@ -28,9 +28,9 @@ describe("Browse author/contributor results page", () => {
       />
     )
 
-    const displayingText = screen.queryByText(
-      'Displaying 1-50 of 423 results for author/contributor "test"'
-    )
+    const displayingText = screen.getByRole("heading", {
+      name: 'Displaying 1-50 of 423 results for author/contributor "test"',
+    })
     expect(displayingText).toBeInTheDocument()
 
     const cards = screen.getAllByRole("heading", { level: 3 })
@@ -95,9 +95,9 @@ describe("Browse author/contributor results page", () => {
       />
     )
 
-    const displayingText = screen.queryByText(
-      'Displaying 1-50 of 423 results for author/contributor "test, performer"'
-    )
+    const displayingText = screen.getByRole("heading", {
+      name: 'Displaying 1-50 of 423 results for author/contributor "test, performer"',
+    })
     expect(displayingText).toBeInTheDocument()
   })
 })

--- a/__test__/pages/browse/subjects/subjectResults.test.tsx
+++ b/__test__/pages/browse/subjects/subjectResults.test.tsx
@@ -27,9 +27,9 @@ describe("Browse subject heading results page", () => {
       />
     )
 
-    const displayingText = screen.queryByText(
-      'Displaying 1-50 of 423 results for Subject Heading "test"'
-    )
+    const displayingText = screen.getByRole("heading", {
+      name: 'Displaying 1-50 of 423 results for Subject Heading "test"',
+    })
     expect(displayingText).toBeInTheDocument()
 
     const cards = screen.getAllByRole("heading", { level: 3 })

--- a/__test__/pages/search/searchResults.test.tsx
+++ b/__test__/pages/search/searchResults.test.tsx
@@ -1,6 +1,11 @@
 import React from "react"
 import userEvent from "@testing-library/user-event"
-import { render, screen, fireEvent } from "../../../src/utils/testUtils"
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "../../../src/utils/testUtils"
 import mockRouter from "next-router-mock"
 import { results } from "../../fixtures/searchResultsManyBibs"
 import SearchPage from "../../../pages/search/index"
@@ -9,7 +14,6 @@ jest.mock("next/router", () => jest.requireActual("next-router-mock"))
 const query = "spaghetti"
 
 describe("Search Results page", () => {
-  // TODO: describe("focus", () => {})
   describe("More than 50 bibs", () => {
     it("displays many bibs", async () => {
       await mockRouter.push(`/search?q=${query}`)
@@ -17,9 +21,9 @@ describe("Search Results page", () => {
         <SearchPage isAuthenticated={true} results={{ results, status: 200 }} />
       )
 
-      const displayingText = screen.getByText(
-        `Displaying 1-50 of ${results.totalResults} results for keyword "${query}"`
-      )
+      const displayingText = screen.getByRole("heading", {
+        name: `Displaying 1-50 of ${results.totalResults} results for keyword "${query}"`,
+      })
       expect(displayingText).toBeInTheDocument()
 
       const cards = screen.getAllByRole("heading", { level: 3 })
@@ -69,6 +73,37 @@ describe("Search Results page", () => {
         exact: false,
       })[0]
       expect(sortByPost).toHaveTextContent("Sort by: Title (Z - A)")
+    })
+  })
+  describe("focus", () => {
+    it("should focus on heading after search", async () => {
+      await mockRouter.push(`/search?q=${query}`)
+      render(
+        <SearchPage isAuthenticated={true} results={{ results, status: 200 }} />
+      )
+      const input = screen.getByRole("textbox")
+
+      await userEvent.type(input, "spaghetti")
+      fireEvent(
+        screen.getByText("Search").closest("button"),
+        new MouseEvent("click")
+      )
+
+      const heading = screen.getByTestId("search-results-heading")
+      await waitFor(() => expect(heading).toHaveFocus())
+    })
+    it("should focus on heading after pagination change", async () => {
+      await mockRouter.push(`/search?q=${query}`)
+      render(
+        <SearchPage isAuthenticated={true} results={{ results, status: 200 }} />
+      )
+      screen.getByLabelText("Pagination")
+
+      const pageButton = screen.getByLabelText("Page 2")
+      fireEvent.click(pageButton)
+
+      const heading = screen.getByTestId("search-results-heading")
+      await waitFor(() => expect(heading).toHaveFocus())
     })
   })
   describe("errors", () => {

--- a/pages/browse/[[...browseType]].tsx
+++ b/pages/browse/[[...browseType]].tsx
@@ -9,7 +9,11 @@ import {
 import RCHead from "../../src/components/Head/RCHead"
 import Layout from "../../src/components/Layout/Layout"
 import SubjectTable from "../../src/components/BrowseTable/SubjectTable/SubjectTable"
-import { SITE_NAME, BROWSE_RESULTS_PER_PAGE } from "../../src/config/constants"
+import {
+  SITE_NAME,
+  BROWSE_RESULTS_PER_PAGE,
+  FOCUS_TIMEOUT,
+} from "../../src/config/constants"
 import { fetchBrowse } from "../../src/server/api/browse"
 import initializePatronTokenAuth from "../../src/server/auth"
 import type { HTTPStatusCode } from "../../src/types/appTypes"
@@ -35,6 +39,7 @@ import type { SortOrder } from "../../src/types/searchTypes"
 import { useBrowseContext } from "../../src/context/BrowseContext"
 import ContributorTable from "../../src/components/BrowseTable/ContributorTable/ContributorTable"
 import BrowseResultsSort from "../../src/components/SearchResults/Sort/BrowseResultsSort"
+import a11yStyles from "../../styles/utils/a11y.module.scss"
 
 interface BrowseProps {
   results: DiscoverySubjectsResponse | DiscoveryContributorsResponse
@@ -83,8 +88,8 @@ export default function Browse({
       page: page,
     })
 
-    setPersistentFocus(idConstants.browseResultsHeading)
     await push(`${basePath}${queryString}`, undefined, { scroll: false })
+    setPersistentFocus(idConstants.browseResultsHeading)
   }
 
   const handleSortChange = async (selectedSortOption: string) => {
@@ -164,6 +169,11 @@ export default function Browse({
   const renderResults = () => {
     // Separate from the browse type in BrowseProvider context: the browse type of the currently displaying results.
     const resultsType = isSubjectResponse(results) ? "subjects" : "contributors"
+    const browseIndexHeading = getBrowseIndexHeading(
+      resultsType,
+      browseParams,
+      results.totalResults
+    )
     return (
       <Box mb="xxl">
         <Flex
@@ -172,22 +182,28 @@ export default function Browse({
           mb="l"
           gap={{ base: 0, md: "xs" }}
         >
-          <Heading
+          <Box aria-live="polite" className={a11yStyles.screenreaderOnly}>
+            {browseIndexHeading}
+          </Box>
+          <Box
+            flex={1}
+            mb={{ base: "m", md: 0 }}
+            tabIndex={-1}
             id="browse-results-heading"
             data-testid="browse-results-heading"
-            level="h2"
-            size="heading5"
-            tabIndex={-1}
-            minH="40px"
-            aria-live="polite"
-            mb={{ base: "m", md: 0 }}
           >
-            {getBrowseIndexHeading(
-              resultsType,
-              browseParams,
-              results.totalResults
+            {isLoading ? (
+              <SkeletonLoader
+                contentSize={1}
+                showImage={false}
+                headingSize={0}
+              />
+            ) : (
+              <Heading level="h2" size="heading5" minH="40px">
+                {browseIndexHeading}
+              </Heading>
             )}
-          </Heading>
+          </Box>
           <BrowseResultsSort
             ref={sortMenuRef}
             params={browseParams}

--- a/pages/browse/authors/[slug].tsx
+++ b/pages/browse/authors/[slug].tsx
@@ -44,7 +44,6 @@ export default function ContributorResults({
   const searchParams = mapQueryToSearchParams(query)
 
   const handlePageChange = async (newPage: number) => {
-    setPersistentFocus(idConstants.searchResultsHeading)
     await push({
       pathname,
       query: {
@@ -52,6 +51,7 @@ export default function ContributorResults({
         page: newPage.toString(),
       },
     })
+    setPersistentFocus(idConstants.searchResultsHeading)
   }
 
   const handleSortChange = async (selectedSortOption: string) => {

--- a/pages/browse/subjects/[slug].tsx
+++ b/pages/browse/subjects/[slug].tsx
@@ -42,7 +42,6 @@ export default function SubjectHeadingResults({
   const searchParams = mapQueryToSearchParams(query)
 
   const handlePageChange = async (newPage: number) => {
-    setPersistentFocus(idConstants.searchResultsHeading)
     await push({
       pathname,
       query: {
@@ -50,6 +49,7 @@ export default function SubjectHeadingResults({
         page: newPage.toString(),
       },
     })
+    setPersistentFocus(idConstants.searchResultsHeading)
   }
 
   const handleSortChange = async (selectedSortOption: string) => {

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -159,8 +159,8 @@ export default function AdvancedSearch({
       setErrorMessage(defaultEmptySearchErrorMessage)
       setAlert(true)
     } else {
-      setPersistentFocus(idConstants.searchResultsHeading)
       await router.push(`${PATHS.SEARCH}${queryString}&searched_from=advanced`)
+      setPersistentFocus(idConstants.searchResultsHeading)
     }
   }
 

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -50,10 +50,10 @@ export default function SearchPage({
 
   const handlePageChange = async (page: number) => {
     const newQuery = getSearchQuery({ ...searchParams, page })
-    setPersistentFocus(idConstants.searchResultsHeading)
     await push(
       `${newQuery}${searchedFromAdvanced ? "&searched_from=advanced" : ""}`
     )
+    setPersistentFocus(idConstants.searchResultsHeading)
   }
 
   const handleSortChange = async (selectedSortOption: string) => {

--- a/src/components/BrowseForm/BrowseForm.tsx
+++ b/src/components/BrowseForm/BrowseForm.tsx
@@ -98,8 +98,8 @@ const BrowseForm = ({
       searchScope: optionData.scope,
     })
 
-    setPersistentFocus(idConstants.browseResultsHeading)
     await router.push(`${basePath}${queryString}`)
+    setPersistentFocus(idConstants.browseResultsHeading)
   }
 
   const displayFilters = !!aggregations?.filter((agg) => agg.values.length)

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -34,6 +34,7 @@ import type {
 import type { RCPage } from "../../types/pageTypes"
 import { getBrowseTypeFromPath } from "../../utils/appUtils"
 import { useRouter } from "next/router"
+import a11yStyles from "../../../styles/utils/a11y.module.scss"
 
 interface SearchProps {
   errorStatus?: HTTPStatusCode | null
@@ -103,6 +104,20 @@ const Search = ({
   const displayFilters = !!aggs?.filter((agg: Aggregation) => agg.values.length)
     .length
 
+  const searchResultsHeading = getSearchResultsHeading(
+    searchParams,
+    totalResults,
+
+    slug
+      ? {
+          slug,
+          browseType: resultsType,
+          role,
+        }
+      : undefined,
+    parsedQuery
+  )
+
   const searchResultBibs = mapElementsToSearchResultsBibs(searchResultsElements)
   return (
     <>
@@ -152,13 +167,16 @@ const Search = ({
               direction={{ base: "column", md: "row" }}
               mb={{ base: "m", md: 0 }}
             >
+              <Box aria-live="polite" className={a11yStyles.screenreaderOnly}>
+                {searchResultsHeading}
+              </Box>
               <Box
                 flex={1}
                 mb={{ base: "s", md: "l" }}
                 mr="m"
                 tabIndex={-1}
                 id="search-results-heading"
-                aria-live="polite"
+                data-testid="search-results-heading"
               >
                 {isLoading ? (
                   <SkeletonLoader
@@ -169,25 +187,12 @@ const Search = ({
                 ) : (
                   <Heading
                     ref={searchResultsHeadingRef}
-                    data-testid="search-results-heading"
                     level="h2"
                     size="heading5"
                     paddingBottom="0"
                     minH="40px"
                   >
-                    {getSearchResultsHeading(
-                      searchParams,
-                      totalResults,
-
-                      slug
-                        ? {
-                            slug,
-                            browseType: resultsType,
-                            role,
-                          }
-                        : undefined,
-                      parsedQuery
-                    )}
+                    {searchResultsHeading}
                   </Heading>
                 )}
               </Box>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -152,7 +152,14 @@ const Search = ({
               direction={{ base: "column", md: "row" }}
               mb={{ base: "m", md: 0 }}
             >
-              <Box flex={1} mb={{ base: "s", md: "l" }} mr="m">
+              <Box
+                flex={1}
+                mb={{ base: "s", md: "l" }}
+                mr="m"
+                tabIndex={-1}
+                id="search-results-heading"
+                aria-live="polite"
+              >
                 {isLoading ? (
                   <SkeletonLoader
                     contentSize={1}
@@ -161,8 +168,6 @@ const Search = ({
                   />
                 ) : (
                   <Heading
-                    id="search-results-heading"
-                    tabIndex={-1}
                     ref={searchResultsHeadingRef}
                     data-testid="search-results-heading"
                     level="h2"

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -152,33 +152,40 @@ const Search = ({
               direction={{ base: "column", md: "row" }}
               mb={{ base: "m", md: 0 }}
             >
-              <Heading
-                id="search-results-heading"
-                data-testid="search-results-heading"
-                level="h2"
-                size="heading5"
-                tabIndex={-1}
-                paddingBottom="0"
-                mb={{ base: "s", md: "l" }}
-                mr="m"
-                minH="40px"
-                ref={searchResultsHeadingRef}
-                aria-live="polite"
-              >
-                {getSearchResultsHeading(
-                  searchParams,
-                  totalResults,
+              <Box flex={1} mb={{ base: "s", md: "l" }} mr="m">
+                {isLoading ? (
+                  <SkeletonLoader
+                    contentSize={1}
+                    showImage={false}
+                    headingSize={0}
+                  />
+                ) : (
+                  <Heading
+                    id="search-results-heading"
+                    tabIndex={-1}
+                    ref={searchResultsHeadingRef}
+                    data-testid="search-results-heading"
+                    level="h2"
+                    size="heading5"
+                    paddingBottom="0"
+                    minH="40px"
+                  >
+                    {getSearchResultsHeading(
+                      searchParams,
+                      totalResults,
 
-                  slug
-                    ? {
-                        slug,
-                        browseType: resultsType,
-                        role,
-                      }
-                    : undefined,
-                  parsedQuery
+                      slug
+                        ? {
+                            slug,
+                            browseType: resultsType,
+                            role,
+                          }
+                        : undefined,
+                      parsedQuery
+                    )}
+                  </Heading>
                 )}
-              </Heading>
+              </Box>
               <ResultsSort
                 ref={sortMenuRef}
                 sortOptions={sortOptions}

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -77,10 +77,10 @@ const SearchForm = ({
       field: searchScope,
     }
     const queryString = getSearchQuery(params)
-    setPersistentFocus(idConstants.searchResultsHeading)
     await router.push(`${PATHS.SEARCH}${queryString}`, undefined, {
       scroll: false,
     })
+    setPersistentFocus(idConstants.searchResultsHeading)
   }
 
   return (


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5058](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5058)

## This PR does the following:

- Wraps results heading for search/browse in a container with skeleton loading
- Adds hidden aria-live region for reading out updated heading

## How has this been tested? How should a reviewer test this?

On the search results page, perform a new search. The results heading should disappear. After results are loaded, the heading should be focused, and the screen reader should read out the updated heading once.
The same thing should be tested for the browse pages.

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->
Upon performing a new search, the previous results heading should not be on the page. After new search results are loaded, the results heading should be read out once by the screen reader.

### Accessibility checklist

- [x] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [x] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [x] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [x] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.


[SCC-5058]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ