### PR TITLE
SCC-5327: Remove bib page legacy link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added lists context and manage bib button to search results/bib page [SCC-5248](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5248)
 - Added manage bib in list menu [SCC-5248](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5248)
 - Added warn log for no results from query with a single filter and no keyword [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)
-- Remove the "View in Legacy (onsite only)" link on the bib pages [SCC-5327](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5327)
+- Remove the "View in Legacy (onsite only)" link on the bib page [SCC-5327](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5327)
 
 ### Updated
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added lists context and manage bib button to search results/bib page [SCC-5248](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5248)
 - Added manage bib in list menu [SCC-5248](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5248)
 - Added warn log for no results from query with a single filter and no keyword [SCC-5269](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5269)
+- Remove the "View in Legacy (onsite only)" link on the bib pages [SCC-5327](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5327)
 
 ### Updated
 

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -16,12 +16,10 @@ import {
   FOCUS_TIMEOUT,
   ERROR_MESSAGES,
 } from "../../../src/config/constants"
-import { appConfig } from "../../../src/config/appConfig"
 import { fetchBib } from "../../../src/server/api/bib"
 import {
   getBibQueryString,
   buildItemTableDisplayingString,
-  isNyplBibID,
   buildBibMetadataTitle,
 } from "../../../src/utils/bibUtils"
 import BibDetailsModel from "../../../src/models/BibDetails"
@@ -120,7 +118,6 @@ export default function BibPage({
 
   const { topDetails, bottomDetails, holdingsDetails, findingAid } =
     new BibDetailsModel(discoveryBibResult, annotatedMarc)
-  const displayLegacyCatalogLink = isNyplBibID(bib.id)
 
   const filtersAreApplied = areFiltersApplied(appliedFilters)
 
@@ -356,18 +353,6 @@ export default function BibPage({
             details={bottomDetails}
           />
           <Flex flexDirection="column">
-            {displayLegacyCatalogLink ? (
-              <Link
-                isExternal
-                id="legacy-catalog-link"
-                href={`${appConfig.urls.legacyCatalog}/record=${bib.id}`}
-                variant="standalone"
-                width="max-content"
-                mt="s"
-              >
-                View in Legacy Catalog (available onsite only)
-              </Link>
-            ) : null}
             <Link
               id="marc-link"
               href={`/bib/${bib.id}/marc`}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5327](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5327)

## This PR does the following:

<!--- Brief, bulleted list of changes. -->

- Removes the link to legacy catalog at the bottom of all (NYPL) bib pages

## How has this been tested? How should a reviewer test this?

<!--- Describe how you tested your changes and how the reviewer can test the changes made in this PR. -->

- Link should not appear anymore 👍 and there were never any unit tests for this so there are none to remove 👍

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [ ] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [ ] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [ ] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [ ] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.


[SCC-5327]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ