### PR TITLE
Release 2.1.1 (part 2)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Condensed status state for account/lists banners
 - Updated to DS `v4.2.0` [SCC-5433](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5433)
+- Updated copy on home page to reflect legacy deprecation updates [SCC-5444](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5444)
 
 ## [2.0.0] 2026-06-04
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.1] 2026-06-22
 
+### Updated
+
+- Updated copy on home page to reflect legacy deprecation updates [SCC-5444](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5444)
+
 ### Removed
 
 - Removed the "View in Legacy (onsite only)" link on the bib page [SCC-5327](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5327)
@@ -30,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Condensed status state for account/lists banners
 - Updated to DS `v4.2.0` [SCC-5433](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5433)
-- Updated copy on home page to reflect legacy deprecation updates [SCC-5444](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5444)
 
 ## [2.0.0] 2026-06-04
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,24 +63,8 @@ export default function Home({ isAuthenticated }: HomeProps) {
                 </Link>
               </Text>
               <Text mb="s">
-                NYPL began a phased deprecation of the{" "}
-                <Link isExternal href={appConfig.urls.legacyCatalog}>
-                  Legacy Catalog
-                </Link>{" "}
-                in May 2026. The Legacy Catalog is currently available onsite
-                only, and in June 2026, we will completely remove access to the
-                Legacy Catalog both onsite and offsite. The Legacy Catalog does
-                not include our{" "}
-                <Link
-                  isExternal
-                  href={
-                    "https://www.nypl.org/research/services/scan-and-deliver"
-                  }
-                >
-                  Scan & Deliver
-                </Link>{" "}
-                service or the Columbia University, Harvard University, or
-                Princeton University material from the Shared Collection.
+                As of June 23, 2026, the Legacy Catalog is no longer available
+                from any location.
               </Text>
             </Box>
             <SimpleGrid columns={1} gap="grid.m">


### PR DESCRIPTION
### Updated

- Updated copy on home page to reflect legacy deprecation updates [SCC-5444](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5444)


[SCC-5444]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ