### PR TITLE
SCC-5058: Loading state in search results heading

### DIFF
--- a/pages/browse/[[...browseType]].tsx
+++ b/pages/browse/[[...browseType]].tsx
@@ -9,7 +9,11 @@ import {
 import RCHead from "../../src/components/Head/RCHead"
 import Layout from "../../src/components/Layout/Layout"
 import SubjectTable from "../../src/components/BrowseTable/SubjectTable/SubjectTable"
-import { SITE_NAME, BROWSE_RESULTS_PER_PAGE } from "../../src/config/constants"
+import {
+  SITE_NAME,
+  BROWSE_RESULTS_PER_PAGE,
+  LOADING_RESULTS,
+} from "../../src/config/constants"
 import { fetchBrowse } from "../../src/server/api/browse"
 import initializePatronTokenAuth from "../../src/server/auth"
 import type { HTTPStatusCode } from "../../src/types/appTypes"
@@ -182,11 +186,13 @@ export default function Browse({
             aria-live="polite"
             mb={{ base: "m", md: 0 }}
           >
-            {getBrowseIndexHeading(
-              resultsType,
-              browseParams,
-              results.totalResults
-            )}
+            {isLoading
+              ? LOADING_RESULTS
+              : getBrowseIndexHeading(
+                  resultsType,
+                  browseParams,
+                  results.totalResults
+                )}
           </Heading>
           <BrowseResultsSort
             ref={sortMenuRef}

--- a/playwright/pages/browse_page.ts
+++ b/playwright/pages/browse_page.ts
@@ -1,4 +1,5 @@
 import type { Page, Locator } from "@playwright/test"
+import { LOADING_RESULTS } from "../../src/config/constants"
 
 export class BrowsePage {
   readonly page: Page
@@ -44,6 +45,12 @@ export class BrowsePage {
     this.titleCount = page.locator(
       "//span[preceding-sibling::span[text()='Results']]"
     )
+  }
+
+  get loadingSearchResultsHeading() {
+    return this.page.getByRole("heading", {
+      name: LOADING_RESULTS,
+    })
   }
 
   get searchResultsHeading() {

--- a/playwright/pages/search_page.ts
+++ b/playwright/pages/search_page.ts
@@ -1,4 +1,5 @@
 import type { Page, Locator } from "@playwright/test"
+import { LOADING_RESULTS } from "../../src/config/constants"
 
 export class SearchPage {
   readonly page: Page
@@ -28,6 +29,12 @@ export class SearchPage {
     this.searchResults = page.locator("#search-results-list h3 a")
     this.searchResultsTitle = page.locator("#search-results-list a", {
       hasText: this.searchterm,
+    })
+  }
+
+  get loadingSearchResultsHeading() {
+    return this.page.getByRole("heading", {
+      name: LOADING_RESULTS,
     })
   }
 

--- a/playwright/tests/browse/browse_author.spec.ts
+++ b/playwright/tests/browse/browse_author.spec.ts
@@ -137,3 +137,14 @@ test.describe("Authors/Contributors sort order", () => {
     }).toPass({ timeout: 5000 })
   })
 })
+test.describe("Authors/Contributors results loading heading", () => {
+  test("Do an author/contributor search and assert that the heading reflects loading state", async () => {
+    await browsePage.searchFor("Jake", "Authors/Contributors containing") // doesn't render heading on first search
+
+    await browsePage.searchFor(searchterm, "Authors/Contributors containing")
+
+    await expect(browsePage.loadingSearchResultsHeading).toBeVisible({
+      timeout: 100,
+    })
+  })
+})

--- a/playwright/tests/browse/browse_subject.spec.ts
+++ b/playwright/tests/browse/browse_subject.spec.ts
@@ -134,3 +134,14 @@ test.describe("Subject sort order", () => {
     }).toPass({ timeout: 5000 })
   })
 })
+test.describe("Subject results loading heading", () => {
+  test("Do an author/contributor search and assert that the heading reflects loading state", async () => {
+    await browsePage.searchFor("Jake", "Subject Headings containing") // doesn't render heading on first search
+
+    await browsePage.searchFor(searchterm, "Subject Headings containing")
+
+    await expect(browsePage.loadingSearchResultsHeading).toBeVisible({
+      timeout: 100,
+    })
+  })
+})

--- a/playwright/tests/search/search_keyword.spec.ts
+++ b/playwright/tests/search/search_keyword.spec.ts
@@ -22,4 +22,18 @@ test.describe("Keyword Search", () => {
       expect(count).toBeGreaterThan(10)
     }).toPass({ timeout: 10000 })
   })
+  test("Do a keyword search and assert that the heading reflects loading state", async ({
+    page,
+  }) => {
+    await searchPage.searchFor("IBM 1402", "Keyword") // doesn't render heading on first search
+
+    await page
+      .getByRole("textbox", { name: "Enter one or more keywords." })
+      .fill(searchterm)
+    await searchPage.search_submit_button.click()
+
+    await expect(searchPage.loadingSearchResultsHeading).toBeVisible({
+      timeout: 100,
+    })
+  })
 })

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -9,7 +9,7 @@ import {
   SimpleGrid,
   Pagination,
 } from "@nypl/design-system-react-components"
-import { RESULTS_PER_PAGE } from "../../config/constants"
+import { LOADING_RESULTS, RESULTS_PER_PAGE } from "../../config/constants"
 import type SearchResultsBib from "../../models/SearchResultsBib"
 import {
   getSearchResultsHeading,
@@ -165,19 +165,21 @@ const Search = ({
                 ref={searchResultsHeadingRef}
                 aria-live="polite"
               >
-                {getSearchResultsHeading(
-                  searchParams,
-                  totalResults,
+                {isLoading
+                  ? LOADING_RESULTS
+                  : getSearchResultsHeading(
+                      searchParams,
+                      totalResults,
 
-                  slug
-                    ? {
-                        slug,
-                        browseType: resultsType,
-                        role,
-                      }
-                    : undefined,
-                  parsedQuery
-                )}
+                      slug
+                        ? {
+                            slug,
+                            browseType: resultsType,
+                            role,
+                          }
+                        : undefined,
+                      parsedQuery
+                    )}
               </Heading>
               <ResultsSort
                 ref={sortMenuRef}

--- a/src/config/constants.tsx
+++ b/src/config/constants.tsx
@@ -33,6 +33,8 @@ export const PATHS = {
 export const DISCOVERY_API_SEARCH_ROUTE = "/discovery/resources"
 export const DISCOVERY_API_BROWSE_ROUTE = "/discovery/browse"
 
+export const LOADING_RESULTS = "Loading results..."
+
 // Query params
 export const SOURCE_PARAM = "?source=catalog"
 


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5058](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5058)

## This PR does the following:

- When submitting a new search, the results heading now changes to "Loading results..." instead of continuing to display the results from the previous search

## How has this been tested? How should a reviewer test this?

- Search for a term in search/browse. Then search for another term, and verify that the heading says "Loading results..." instead of the previous results heading

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [x] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [x] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [x] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [x] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.


[SCC-5058]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ