### PR TITLE
Update header tests for Visit link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Updated search bar Query option to use quotes instead of span tag
+- Updated header link Playwright tests
 
 ## [2.1.1] 2026-06-22
 

--- a/playwright/pages/base_page.ts
+++ b/playwright/pages/base_page.ts
@@ -15,7 +15,7 @@ export class BasePage {
   readonly header_research: Locator
   readonly header_education: Locator
   readonly header_events: Locator
-  readonly header_connect: Locator
+  readonly header_visit: Locator
   readonly header_give: Locator
   readonly header_get_help: Locator
   readonly header_search: Locator
@@ -78,9 +78,9 @@ export class BasePage {
       .getByRole("link", {
         name: "Events",
       })
-    this.header_connect = page
+    this.header_visit = page
       .getByLabel("Header bottom links")
-      .getByRole("link", { name: "Connect" })
+      .getByRole("link", { name: "Visit" })
     this.header_give = page
       .getByLabel("Header bottom links")
       .getByRole("link", { name: "Give" })

--- a/playwright/tests/base_page.spec.ts
+++ b/playwright/tests/base_page.spec.ts
@@ -22,7 +22,7 @@ test.describe("Global Header", () => {
     await expect(basePage.header_research).toBeVisible()
     await expect(basePage.header_education).toBeVisible()
     await expect(basePage.header_events).toBeVisible()
-    await expect(basePage.header_connect).toBeVisible()
+    await expect(basePage.header_visit).toBeVisible()
     await expect(basePage.header_give).toBeVisible()
     await expect(basePage.header_get_help).toBeVisible()
     await expect(basePage.header_search).toBeVisible()


### PR DESCRIPTION
## Ticket:

- n/a

## This PR does the following:

- Playwright tests failing bc of link update within the universal header ([update was made here](https://github.com/NYPL/nypl-header-app/pull/85))
- Updates to look for "Visit" link
- I think this mismatch not being caught is a good argument in favor of RC not testing the header at all in Playwright– we don't control its updates and aren't even necessarily aware of them. Will add to the agenda for our upcoming meeting

## How has this been tested? How should a reviewer test this?

<!--- Describe how you tested your changes and how the reviewer can test the changes made in this PR. -->

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [ ] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [ ] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [ ] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [ ] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.
