### PR TITLE
SCC-5167: Advanced search form loading state

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
-- Updated advanced search page to use refs and isolated components [SCC-5167](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5167)
+- Improved advanced search page performance and added loading state [SCC-5167](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5167)
 
 ## [2.1.2] 2026-07-07
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import { FeedbackProvider } from "../src/context/FeedbackContext"
 import { FocusProvider } from "../src/context/FocusContext"
 import { BrowseProvider } from "../src/context/BrowseContext"
 import { useRouter } from "next/router"
+import "../public/styles/globals.css"
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function App({ Component, pageProps }) {

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -174,25 +174,28 @@ export default function AdvancedSearch({
   // inputs to an indiviual component triggers rerenders in only that component,
   // rather than all components on the page.
 
-  const multiselects = fields.map((field) => {
-    return field.value !== "collection" ? (
-      <IsolatedMultiSelect
-        key={`${field.value}-${resetKey}`}
-        fieldValue={field.value}
-        label={field.label}
-        options={field.options}
-        onSelectionChange={handleFilterChange}
-        globalInputChangeHandler={globalInputChangeHandler}
-      />
-    ) : (
-      <DivisionSelect
-        key={`collection-${resetKey}`}
-        collectionOptions={collectionOptions}
-        onSelectionChange={handleFilterChange}
-        globalInputChangeHandler={globalInputChangeHandler}
-      />
-    )
-  })
+  const multiselects = fields.map((field) => (
+    <div
+      key={`${field.value}-${resetKey}`}
+      className={getDisabledStateStyle(isLoading)}
+    >
+      {field.value !== "collection" ? (
+        <IsolatedMultiSelect
+          fieldValue={field.value}
+          label={field.label}
+          options={field.options}
+          onSelectionChange={handleFilterChange}
+          globalInputChangeHandler={globalInputChangeHandler}
+        />
+      ) : (
+        <DivisionSelect
+          collectionOptions={collectionOptions}
+          onSelectionChange={handleFilterChange}
+          globalInputChangeHandler={globalInputChangeHandler}
+        />
+      )}
+    </div>
+  ))
 
   return (
     <>
@@ -230,7 +233,6 @@ export default function AdvancedSearch({
           method="post"
           action={`${BASE_URL}/search`}
           onSubmit={handleSubmit}
-          className={getDisabledStateStyle(isLoading)}
         >
           <Flex flexDirection={{ base: "column", md: "row" }}>
             <Flex
@@ -245,6 +247,7 @@ export default function AdvancedSearch({
                   key={`${name}-${resetKey}`}
                   name={name}
                   label={label}
+                  isDisabled={isLoading}
                   globalInputChangeHandler={globalInputChangeHandler}
                 />
               ))}
@@ -253,6 +256,7 @@ export default function AdvancedSearch({
                   key={resetKey}
                   isAdvancedSearch
                   {...dateFilterProps}
+                  isDisabled={isLoading}
                 />
               </FormField>
             </Flex>
@@ -294,6 +298,7 @@ export default function AdvancedSearch({
               cancelHandler={handleClear}
               cancelLabel="Clear fields"
               submitLabel="Search"
+              disableSubmit={isLoading}
             />
           </Flex>
         </Form>

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -31,6 +31,7 @@ import { idConstants, useFocusContext } from "../../src/context/FocusContext"
 import IsolatedMultiSelect from "../../src/components/AdvancedSearch/IsolatedMultiSelect"
 import DivisionSelect from "../../src/components/AdvancedSearch/DivisionSelect"
 import IsolatedTextInput from "../../src/components/AdvancedSearch/IsolatedTextInput"
+import useLoading from "../../src/hooks/useLoading"
 
 export const defaultEmptySearchErrorMessage =
   "Error: please enter at least one field to submit an advanced search."
@@ -58,6 +59,7 @@ export default function AdvancedSearch({
   // so incrementation triggers a reset of those components
   const [resetKey, setResetKey] = useState(0)
   const { setPersistentFocus } = useFocusContext()
+  const isLoading = useLoading()
 
   const globalInputChangeHandler = () => {
     alert && setAlert(false)
@@ -227,6 +229,7 @@ export default function AdvancedSearch({
           method="post"
           action={`${BASE_URL}/search`}
           onSubmit={handleSubmit}
+          className={`canDisable ${isLoading ? "isDisabled" : ""}`}
         >
           <Flex flexDirection={{ base: "column", md: "row" }}>
             <Flex

--- a/pages/search/advanced.tsx
+++ b/pages/search/advanced.tsx
@@ -32,6 +32,7 @@ import IsolatedMultiSelect from "../../src/components/AdvancedSearch/IsolatedMul
 import DivisionSelect from "../../src/components/AdvancedSearch/DivisionSelect"
 import IsolatedTextInput from "../../src/components/AdvancedSearch/IsolatedTextInput"
 import useLoading from "../../src/hooks/useLoading"
+import { getDisabledStateStyle } from "../../src/utils/appUtils"
 
 export const defaultEmptySearchErrorMessage =
   "Error: please enter at least one field to submit an advanced search."
@@ -229,7 +230,7 @@ export default function AdvancedSearch({
           method="post"
           action={`${BASE_URL}/search`}
           onSubmit={handleSubmit}
-          className={`canDisable ${isLoading ? "isDisabled" : ""}`}
+          className={getDisabledStateStyle(isLoading)}
         >
           <Flex flexDirection={{ base: "column", md: "row" }}>
             <Flex

--- a/public/styles/globals.css
+++ b/public/styles/globals.css
@@ -21,3 +21,12 @@
     table-layout: fixed !important;
   }
 }
+
+.canDisable {
+  transition: opacity 0.2s ease;
+}
+
+.isDisabled {
+  opacity: 0.4;
+  pointer-events: none;
+}

--- a/src/components/AdvancedSearch/CancelSubmitButtonGroup.tsx
+++ b/src/components/AdvancedSearch/CancelSubmitButtonGroup.tsx
@@ -1,4 +1,9 @@
-import { Button, Icon, ButtonGroup } from "@nypl/design-system-react-components"
+import {
+  Button,
+  Icon,
+  ButtonGroup,
+  ProgressIndicator,
+} from "@nypl/design-system-react-components"
 import type { SyntheticEvent } from "react"
 
 interface CancelSubmitButtonGroupProps {
@@ -27,9 +32,20 @@ const CancelSubmitButtonGroup = ({
         id={`submit-${formName}`}
         type="submit"
         variant="primary"
-        isDisabled={disableSubmit}
       >
-        <Icon name={submitIcon} align="left" size="large" />
+        {disableSubmit ? (
+          <ProgressIndicator
+            id={"freeze-loading"}
+            labelText="Renew"
+            showLabel={false}
+            size="small"
+            indicatorType="circular"
+            mr="xs"
+            isIndeterminate
+          />
+        ) : (
+          <Icon name={submitIcon} align="left" size="large" />
+        )}
         {submitLabel}
       </Button>
       <Button
@@ -39,6 +55,7 @@ const CancelSubmitButtonGroup = ({
         type="reset"
         variant="secondary"
         backgroundColor="ui.white"
+        isDisabled={disableSubmit}
       >
         <Icon name="actionDelete" align="left" size="large" />
         {cancelLabel}

--- a/src/components/AdvancedSearch/CancelSubmitButtonGroup.tsx
+++ b/src/components/AdvancedSearch/CancelSubmitButtonGroup.tsx
@@ -35,8 +35,8 @@ const CancelSubmitButtonGroup = ({
       >
         {disableSubmit ? (
           <ProgressIndicator
-            id={"freeze-loading"}
-            labelText="Renew"
+            id="loading-submit"
+            labelText="Submit"
             showLabel={false}
             size="small"
             indicatorType="circular"

--- a/src/components/AdvancedSearch/IsolatedTextInput.tsx
+++ b/src/components/AdvancedSearch/IsolatedTextInput.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 interface IsolatedTextInputProps {
   name: string
   label: string
+  isDisabled?: boolean
   globalInputChangeHandler: () => void
 }
 
@@ -17,6 +18,7 @@ interface IsolatedTextInputProps {
 const IsolatedTextInput = ({
   name,
   label,
+  isDisabled = false,
   globalInputChangeHandler,
 }: IsolatedTextInputProps) => {
   const [value, setValue] = useState("")
@@ -28,6 +30,7 @@ const IsolatedTextInput = ({
         labelText={label}
         name={name}
         value={value}
+        isDisabled={isDisabled}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           globalInputChangeHandler()
           setValue(e.target.value)

--- a/src/components/DateFilter/DateFilter.tsx
+++ b/src/components/DateFilter/DateFilter.tsx
@@ -19,6 +19,7 @@ interface DateFilterPropsType extends DateFilterHookPropsType {
   onApply: (nextValues?: { dateFrom: string; dateTo: string }) => DateErrorState
   onChange: (e: SyntheticEvent) => void
   isAdvancedSearch?: boolean
+  isDisabled?: boolean
 }
 
 // Render date filter fields and, if not in advanced search, Apply button.
@@ -30,6 +31,7 @@ const DateFilter = ({
   onBlur,
   onApply,
   isAdvancedSearch = false,
+  isDisabled = false,
 }: DateFilterPropsType) => {
   // Including local state because advanced search form does not manage its own date range state
   const [localDateFrom, setLocalDateFrom] = useState(dateFrom)
@@ -101,6 +103,7 @@ const DateFilter = ({
                 sx={{
                   label: { fontSize: isAdvancedSearch ? "12px" : undefined },
                 }}
+                isDisabled={isDisabled}
                 aria-describedby="date-from-helperText date-errorText"
               />
               {/* Replicating HelperErrorText without aria-live or aria-invalid */}
@@ -131,6 +134,7 @@ const DateFilter = ({
                 sx={{
                   label: { fontSize: isAdvancedSearch ? "12px" : undefined },
                 }}
+                isDisabled={isDisabled}
                 aria-describedby="date-to-helperText date-errorText"
               />
               {/* Replicating HelperErrorText without aria-live or aria-invalid */}

--- a/src/components/HoldPages/HoldRequestForm.tsx
+++ b/src/components/HoldPages/HoldRequestForm.tsx
@@ -10,6 +10,7 @@ import {
 import type { DeliveryLocation } from "../../../src/types/locationTypes"
 import type { HoldErrorStatus } from "../../../src/types/holdPageTypes"
 import { holdButtonDisabledStatuses } from "../../../src/utils/holdPageUtils"
+import { getDisabledStateStyle } from "../../utils/appUtils"
 
 import { BASE_URL } from "../../config/constants"
 
@@ -45,7 +46,7 @@ const HoldRequestForm = ({
       onSubmit={handleSubmit}
       mb="l"
       aria-disabled={isDisabled}
-      className={`canDisable ${isDisabled ? "isDisabled" : ""}`}
+      className={getDisabledStateStyle(isDisabled)}
     >
       <input type="hidden" id="patronId" name="patronId" value={patronId} />
       <input type="hidden" id="source" name="source" value={source} />

--- a/src/components/HoldPages/HoldRequestForm.tsx
+++ b/src/components/HoldPages/HoldRequestForm.tsx
@@ -45,10 +45,7 @@ const HoldRequestForm = ({
       onSubmit={handleSubmit}
       mb="l"
       aria-disabled={isDisabled}
-      sx={{
-        opacity: isDisabled && 0.5,
-        pointerEvents: isDisabled && "none",
-      }}
+      className={`canDisable ${isDisabled ? "isDisabled" : ""}`}
     >
       <input type="hidden" id="patronId" name="patronId" value={patronId} />
       <input type="hidden" id="source" name="source" value={source} />

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -108,12 +108,9 @@ const SearchFilters = ({
       return (
         <div
           key={field.value}
-          style={{
-            opacity: focusedFilter && focusedFilter !== field.value ? 0.4 : 1,
-            pointerEvents:
-              focusedFilter && focusedFilter !== field.value ? "none" : "unset",
-            transition: "opacity 0.2s ease",
-          }}
+          className={`canDisable ${
+            focusedFilter && focusedFilter !== field.value ? "isDisabled" : ""
+          }`}
         >
           {!(field.value === "collection") ? (
             <MultiSelect
@@ -213,12 +210,9 @@ const SearchFilters = ({
   const dateFilter = (
     <div
       key="date"
-      style={{
-        opacity: focusedFilter && focusedFilter !== "date" ? 0.4 : 1,
-        pointerEvents:
-          focusedFilter && focusedFilter !== "date" ? "none" : "unset",
-        transition: "opacity 0.2s ease",
-      }}
+      className={`canDisable ${
+        focusedFilter && focusedFilter !== "date" ? "isDisabled" : ""
+      }`}
     >
       <Accordion
         data-testid="date-accordion"

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -20,6 +20,7 @@ import { mapCollectionsIntoLocations } from "../../utils/advancedSearchUtils"
 import DateFilter from "../DateFilter/DateFilter"
 import { useDateFilter } from "../../hooks/useDateFilter"
 import { getNewSelectedFilters } from "../../utils/searchUtils"
+import { getDisabledStateStyle } from "../../utils/appUtils"
 
 let fields = [
   { value: "buildingLocation", label: "Item location" },
@@ -90,10 +91,8 @@ const SearchFilters = ({
 
   const [focusedFilter, setFocusedFilter] = useState<string | null>(null)
 
-  const getLoadingStateClassName = (fieldValue) => {
-    return `canDisable ${
-      focusedFilter && focusedFilter !== fieldValue ? "isDisabled" : ""
-    }`
+  const getFieldLoadingStateStyle = (fieldValue) => {
+    return getDisabledStateStyle(focusedFilter && focusedFilter !== fieldValue)
   }
 
   // Do not display Subject filter if there is no query term and a subject filter is applied
@@ -114,7 +113,7 @@ const SearchFilters = ({
       return (
         <div
           key={field.value}
-          className={getLoadingStateClassName(field.value)}
+          className={getFieldLoadingStateStyle(field.value)}
         >
           {!(field.value === "collection") ? (
             <MultiSelect
@@ -212,7 +211,7 @@ const SearchFilters = ({
   })
 
   const dateFilter = (
-    <div key="date" className={getLoadingStateClassName("date")}>
+    <div key="date" className={getFieldLoadingStateStyle("date")}>
       <Accordion
         data-testid="date-accordion"
         id="date"

--- a/src/components/SearchFilters/SearchFilters.tsx
+++ b/src/components/SearchFilters/SearchFilters.tsx
@@ -90,6 +90,12 @@ const SearchFilters = ({
 
   const [focusedFilter, setFocusedFilter] = useState<string | null>(null)
 
+  const getLoadingStateClassName = (fieldValue) => {
+    return `canDisable ${
+      focusedFilter && focusedFilter !== fieldValue ? "isDisabled" : ""
+    }`
+  }
+
   // Do not display Subject filter if there is no query term and a subject filter is applied
   if (
     (router.query?.q === "" || !router.query.q) &&
@@ -108,9 +114,7 @@ const SearchFilters = ({
       return (
         <div
           key={field.value}
-          className={`canDisable ${
-            focusedFilter && focusedFilter !== field.value ? "isDisabled" : ""
-          }`}
+          className={getLoadingStateClassName(field.value)}
         >
           {!(field.value === "collection") ? (
             <MultiSelect
@@ -208,12 +212,7 @@ const SearchFilters = ({
   })
 
   const dateFilter = (
-    <div
-      key="date"
-      className={`canDisable ${
-        focusedFilter && focusedFilter !== "date" ? "isDisabled" : ""
-      }`}
-    >
+    <div key="date" className={getLoadingStateClassName("date")}>
       <Accordion
         data-testid="date-accordion"
         id="date"

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -87,3 +87,7 @@ export function tryInstantiate<T>({
 export function getBrowseTypeFromPath(path): BrowseType {
   return path.includes("/authors") ? "contributors" : "subjects"
 }
+
+export function getDisabledStateStyle(disabledCondition: boolean): string {
+  return `canDisable ${disabledCondition ? "isDisabled" : ""}`
+}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5167](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5167)

## This PR does the following:

- Adds a global style for components that can be disabled, which is used for the loading state in advanced search form
- Also updates hold request and search results filters to use this style

## How has this been tested? How should a reviewer test this?

- Verify loading state after submitting advanced search form
- Verify that loading state in hold request and search results filters is (pretty much) unchanged

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [ ] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [ ] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [ ] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [ ] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.


[SCC-5167]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ