### PR TITLE
SCC-5441: Drag-select RTL remove leading newline/tab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
-- Updated search results table and item table to remove extra copied whitespace [SCC-5441](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5441)
+- Updated search results table and item table to remove extra copied newlines/tabs [SCC-5441](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5441)
 
 ## [2.1.3] 2026-07-28
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Updated
+
+- Updated search results item table width/padding to remove extra copied whitespace [SCC-5441](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5441)
+
 ## [2.1.3] 2026-07-28
 
 ### Updated

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Updated
 
-- Updated search results item table width/padding to remove extra copied whitespace [SCC-5441](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5441)
+- Updated search results table and item table to remove extra copied whitespace [SCC-5441](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5441)
 
 ## [2.1.3] 2026-07-28
 

--- a/src/components/ItemTable/ItemTable.tsx
+++ b/src/components/ItemTable/ItemTable.tsx
@@ -1,6 +1,7 @@
 import { Box, Table } from "@nypl/design-system-react-components"
 import type ItemTableData from "../../models/ItemTableData"
 import styles from "../../../styles/components/ItemTable.module.scss"
+import { handleTableCopy } from "../../utils/appUtils"
 
 interface ItemTableProps {
   itemTableData: ItemTableData
@@ -16,6 +17,7 @@ const ItemTable = ({ itemTableData }: ItemTableProps) => {
     // Display as grid to prevent bug where the outer container stretches to the Table's width on mobile
     <Box display="grid">
       <Table
+        onCopy={(e) => handleTableCopy(e, "\t")}
         className={`${styles.itemTable} itemTable`}
         columnHeaders={tableHeadings}
         columnHeadersBackgroundColor={"ui.gray.x-light-cool"}

--- a/src/components/SearchResults/SearchResultItems.tsx
+++ b/src/components/SearchResults/SearchResultItems.tsx
@@ -27,7 +27,7 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
             <tr key={heading}>
               <td
                 style={{
-                  width: "181px",
+                  width: "161px",
                   minWidth: "60px",
                 }}
               >
@@ -41,7 +41,9 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
                 </Text>
               </td>
               <td>
-                <Text fontSize="small">{tableData[0][index]}</Text>
+                <Text fontSize="small" paddingLeft="20px">
+                  {tableData[0][index]}
+                </Text>
               </td>
             </tr>
           ))}

--- a/src/components/SearchResults/SearchResultItems.tsx
+++ b/src/components/SearchResults/SearchResultItems.tsx
@@ -27,7 +27,7 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
             <tr key={heading}>
               <td
                 style={{
-                  width: "161px",
+                  width: "151px",
                   minWidth: "60px",
                 }}
               >
@@ -41,7 +41,10 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
                 </Text>
               </td>
               <td>
-                <Text fontSize="small" paddingLeft="20px">
+                <Text
+                  fontSize="small"
+                  paddingLeft={{ base: "0px", md: "30px" }}
+                >
                   {tableData[0][index]}
                 </Text>
               </td>

--- a/src/components/SearchResults/SearchResultItems.tsx
+++ b/src/components/SearchResults/SearchResultItems.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "@nypl/design-system-react-components"
 import type ItemTableData from "../../models/ItemTableData"
 import StatusLinks from "../ItemTable/StatusLinks"
+import { handleTableCopy } from "../../utils/appUtils"
 
 interface SearchResultItemsProps {
   itemTableData: ItemTableData
@@ -14,6 +15,7 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
   return (
     <Box>
       <table
+        onCopy={(e) => handleTableCopy(e, "\n")}
         style={{
           width: "100%",
           paddingTop: "24px",
@@ -27,7 +29,7 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
             <tr key={heading}>
               <td
                 style={{
-                  width: "151px",
+                  width: "181px",
                   minWidth: "60px",
                 }}
               >
@@ -41,12 +43,7 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
                 </Text>
               </td>
               <td>
-                <Text
-                  fontSize="small"
-                  paddingLeft={{ base: "0px", md: "30px" }}
-                >
-                  {tableData[0][index]}
-                </Text>
+                <Text fontSize="small">{tableData[0][index]}</Text>
               </td>
             </tr>
           ))}

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -60,8 +60,9 @@ export const convertCamelToShishKabobCase = (str: string) =>
 
 /**
  * An onCopy handler to prevent extra newlines from being copied between table cells.
- * If text is copied from one cell but the selection includes another cell, strips the resulting
- * extra whitespace. Used in SearchResultsItems and ItemTable.
+ * If a copy selection extends into multiple cells but contains text from only one cell,
+ * sets the clipboard data to that text without extra whitespace.
+ * Used in SearchResultsItems and ItemTable.
  */
 export const handleTableCopy = (
   e: React.ClipboardEvent<HTMLElement>,

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -59,6 +59,26 @@ export const convertCamelToShishKabobCase = (str: string) =>
     })
 
 /**
+ * An onCopy handler to prevent extra newlines from being copied between table cells.
+ * If text is copied from one cell but the selection includes another cell, strips the resulting
+ * extra whitespace. Used in SearchResultsItems and ItemTable.
+ */
+export const handleTableCopy = (
+  e: React.ClipboardEvent<HTMLElement>,
+  separator: string
+) => {
+  const selection = window.getSelection()
+  if (!selection) return
+  const text = selection.toString()
+  const segments = text.split(separator)
+  const meaningfulSegments = segments.filter((s) => s.trim() !== "")
+  if (meaningfulSegments.length === 1 && segments.length > 1) {
+    e.clipboardData.setData("text/plain", meaningfulSegments[0])
+    e.preventDefault()
+  }
+}
+
+/**
  * Attempts to instantiate an object using the provided constructor and arguments.
  * If instantiation fails without a flag to ignore failure, throws an error with the given message.
  * Otherwise, returns null.

--- a/src/utils/appUtils.ts
+++ b/src/utils/appUtils.ts
@@ -59,9 +59,9 @@ export const convertCamelToShishKabobCase = (str: string) =>
     })
 
 /**
- * An onCopy handler to prevent extra newlines from being copied between table cells.
+ * An onCopy handler to prevent extra newlines/tabs from being copied between table cells.
  * If a copy selection extends into multiple cells but contains text from only one cell,
- * sets the clipboard data to that text without extra whitespace.
+ * sets the clipboard data to that text without the browser-injected separators.
  * Used in SearchResultsItems and ItemTable.
  */
 export const handleTableCopy = (

--- a/src/utils/utilsTests/appUtils.test.ts
+++ b/src/utils/utilsTests/appUtils.test.ts
@@ -58,14 +58,18 @@ describe("appUtils", () => {
   })
   describe("handleTableCopy", () => {
     afterEach(() => jest.restoreAllMocks())
-
-    it("does nothing when selection has multiple segments with text", () => {
+    it("does nothing when selection has multiple segments with text, separated by newline", () => {
       mockSelection("Call number\n*LZR 72182 [Disc]")
       const e = makeEvent()
       handleTableCopy(e as any, "\n")
       expect(e.clipboardData.setData).not.toHaveBeenCalled()
     })
-
+    it("does nothing when selection has multiple segments with text, separated by tab", () => {
+      mockSelection("Call number\t*LZR 72182 [Disc]")
+      const e = makeEvent()
+      handleTableCopy(e as any, "\t")
+      expect(e.clipboardData.setData).not.toHaveBeenCalled()
+    })
     it("strips leading newline when only one segment has content", () => {
       mockSelection("\n*LZR 72182 [Disc]")
       const e = makeEvent()
@@ -75,7 +79,15 @@ describe("appUtils", () => {
         "*LZR 72182 [Disc]"
       )
     })
-
+    it("strips leading tab when only one segment has content", () => {
+      mockSelection("\t*LZR 72182 [Disc]")
+      const e = makeEvent()
+      handleTableCopy(e as any, "\t")
+      expect(e.clipboardData.setData).toHaveBeenCalledWith(
+        "text/plain",
+        "*LZR 72182 [Disc]"
+      )
+    })
     it("does nothing when selection has only one segment", () => {
       mockSelection("*LZR 72182 [Disc]")
       const e = makeEvent()

--- a/src/utils/utilsTests/appUtils.test.ts
+++ b/src/utils/utilsTests/appUtils.test.ts
@@ -3,7 +3,18 @@ import {
   getPaginationOffsetStrings,
   convertToSentenceCase,
   tryInstantiate,
+  handleTableCopy,
 } from "../appUtils"
+
+const makeEvent = () => ({
+  clipboardData: { setData: jest.fn() },
+  preventDefault: jest.fn(),
+})
+
+const mockSelection = (text: string) =>
+  jest.spyOn(window, "getSelection").mockReturnValue({
+    toString: () => text,
+  } as Selection)
 
 describe("appUtils", () => {
   describe("encodeHTML", () => {
@@ -43,6 +54,33 @@ describe("appUtils", () => {
     })
     it("returns the string that is passed in if it's a single word, to avoid sentence-casing acronyms", () => {
       expect(convertToSentenceCase("ISSN")).toEqual("ISSN")
+    })
+  })
+  describe("handleTableCopy", () => {
+    afterEach(() => jest.restoreAllMocks())
+
+    it("does nothing when selection has multiple segments with text", () => {
+      mockSelection("Call number\n*LZR 72182 [Disc]")
+      const e = makeEvent()
+      handleTableCopy(e as any, "\n")
+      expect(e.clipboardData.setData).not.toHaveBeenCalled()
+    })
+
+    it("strips leading newline when only one segment has content", () => {
+      mockSelection("\n*LZR 72182 [Disc]")
+      const e = makeEvent()
+      handleTableCopy(e as any, "\n")
+      expect(e.clipboardData.setData).toHaveBeenCalledWith(
+        "text/plain",
+        "*LZR 72182 [Disc]"
+      )
+    })
+
+    it("does nothing when selection has only one segment", () => {
+      mockSelection("*LZR 72182 [Disc]")
+      const e = makeEvent()
+      handleTableCopy(e as any, "\n")
+      expect(e.clipboardData.setData).not.toHaveBeenCalled()
     })
   })
   class TestClass {


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5441](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5441)

## This PR does the following:
- Adds a copy handler to search results table and item table. If a copy selection spans multiple table cells but contains text from only one, extra newlines/tabs injected by the browser are removed
~~On desktop, adds left padding to the search results item table data cells and decreases the width of the row heading cells to compensate. Hopefully the padding of 30px is enough?~~

## How has this been tested? How should a reviewer test this?

- Perform a search, drag-select a shelfmark from right to left, copy-paste into a text editor, verify no leading whitespace or newline

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [ ] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [ ] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [ ] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [ ] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.

[SCC-5441]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ