### PR TITLE
SCC-5333: Remove finding aid appointment link for partner bibs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Removed
+
+- Removed appointment link in finding aid for partner items [SCC-5333](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5333)
+
 ## [2.1.3] 2026-07-28
 
 ### Updated

--- a/pages/bib/[id]/index.tsx
+++ b/pages/bib/[id]/index.tsx
@@ -1,5 +1,5 @@
 import type { SyntheticEvent } from "react"
-import { useState, useRef, useEffect } from "react"
+import { useState, useRef } from "react"
 import { useRouter } from "next/router"
 import {
   Heading,
@@ -21,6 +21,7 @@ import {
   getBibQueryString,
   buildItemTableDisplayingString,
   buildBibMetadataTitle,
+  isNyplBibID,
 } from "../../../src/utils/bibUtils"
 import BibDetailsModel from "../../../src/models/BibDetails"
 import BibDetails from "../../../src/components/BibPage/BibDetail"
@@ -268,6 +269,7 @@ export default function BibPage({
           {findingAid && (
             <FindingAid
               findingAidURL={findingAid}
+              isNyplBib={isNyplBibID(bib.id)}
               hasElectronicResources={bib.hasElectronicResources}
             />
           )}

--- a/src/components/BibPage/FindingAid.test.tsx
+++ b/src/components/BibPage/FindingAid.test.tsx
@@ -1,18 +1,24 @@
 import { render, screen } from "@testing-library/react"
 import FindingAid from "./FindingAid"
 
-describe("FindingAid component", () => {
-  beforeEach(() => {
-    render(
-      <FindingAid findingAidURL={"mockUrl"} hasElectronicResources={false} />
-    )
-  })
+const renderFindingAid = ({ isNyplBib }) => {
+  render(
+    <FindingAid
+      findingAidURL={"mockUrl"}
+      isNyplBib={isNyplBib}
+      hasElectronicResources={false}
+    />
+  )
+}
 
+describe("FindingAid component", () => {
   it("renders the correct heading", () => {
+    renderFindingAid({ isNyplBib: true })
     expect(screen.queryByText("Collection information")).toBeInTheDocument()
   })
 
   it("renders the given Archives link", () => {
+    renderFindingAid({ isNyplBib: true })
     const findingAidContainer = screen.queryByTestId("collection-information")
     expect(findingAidContainer).toBeInTheDocument()
 
@@ -22,7 +28,8 @@ describe("FindingAid component", () => {
     expect(archivesLink).toHaveAttribute("href", "mockUrl")
   })
 
-  it("renders the appointments link", () => {
+  it("renders the appointments link if isNyplBib is true", () => {
+    renderFindingAid({ isNyplBib: true })
     const appointmentsLink = screen.getByRole("link", {
       name: "may require an appointment",
     })
@@ -30,5 +37,13 @@ describe("FindingAid component", () => {
       "href",
       "https://libguides.nypl.org/NYPLSpecialCollectionsAccount"
     )
+  })
+
+  it("does not render the appointments link if isNyplBib is false", () => {
+    renderFindingAid({ isNyplBib: false })
+    const appointmentsLink = screen.queryByRole("link", {
+      name: "may require an appointment",
+    })
+    expect(appointmentsLink).not.toBeInTheDocument()
   })
 })

--- a/src/components/BibPage/FindingAid.tsx
+++ b/src/components/BibPage/FindingAid.tsx
@@ -10,11 +10,13 @@ import Link from "../Link/Link"
 
 interface FindingAidProps {
   findingAidURL: string
+  isNyplBib?: boolean
   hasElectronicResources: boolean
 }
 
 const FindingAid = ({
   findingAidURL,
+  isNyplBib,
   hasElectronicResources,
 }: FindingAidProps) => {
   return (
@@ -48,16 +50,20 @@ const FindingAid = ({
               organization and contents of this archival collection.
             </Text>
           </Flex>
-          <Text size="caption" mb="0" ml="24px">
-            Archival collections{" "}
-            <Link
-              isExternal
-              href={"https://libguides.nypl.org/NYPLSpecialCollectionsAccount"}
-            >
-              may require an appointment
-            </Link>{" "}
-            to view and use onsite.
-          </Text>
+          {isNyplBib && (
+            <Text size="caption" mb="0" ml="24px">
+              Archival collections{" "}
+              <Link
+                isExternal
+                href={
+                  "https://libguides.nypl.org/NYPLSpecialCollectionsAccount"
+                }
+              >
+                may require an appointment
+              </Link>{" "}
+              to view and use onsite.
+            </Text>
+          )}
         </Flex>
       </CardContent>
     </Card>

--- a/src/components/SearchResults/SearchResult.tsx
+++ b/src/components/SearchResults/SearchResult.tsx
@@ -22,6 +22,7 @@ import type { StatusBannerState } from "../MyAccount/Settings/StatusBanner"
 import { useState } from "react"
 import { idConstants } from "../../context/FocusContext"
 import { FeaturePopup } from "../Banners/FeaturePopup"
+import { isNyplBibID } from "../../utils/bibUtils"
 
 interface SearchResultProps {
   bib: SearchResultsBib
@@ -145,6 +146,7 @@ const SearchResult = ({
             {bib.findingAid ? (
               <FindingAid
                 findingAidURL={bib.findingAid}
+                isNyplBib={isNyplBibID(bib.id)}
                 hasElectronicResources={bib.hasElectronicResources}
               />
             ) : null}


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5333](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5333)

## This PR does the following:

- Removes sentence about appointments in the finding aid info section for partner bibs

## How has this been tested? How should a reviewer test this?

- Verify that the appointment sentence is still displays for NYPL bibs but not for partner bibs (`cb4078376`, `cb4079237`)

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [ ] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [ ] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [ ] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [ ] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.


[SCC-5333]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ