### PR TITLE
SCC-5559: Search results table headers top align

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Prerelease
 
+### Updated
+
+- Updated search results table row headers to be top-aligned [SCC-5559](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5559)
+
 ## [2.1.3] 2026-07-28
 
 ### Updated

--- a/src/components/SearchResults/SearchResultItems.tsx
+++ b/src/components/SearchResults/SearchResultItems.tsx
@@ -29,6 +29,7 @@ const SearchResultItems = ({ itemTableData }: SearchResultItemsProps) => {
                 style={{
                   width: "181px",
                   minWidth: "60px",
+                  verticalAlign: "top",
                 }}
               >
                 <Text


### PR DESCRIPTION
## Ticket:

- JIRA ticket [SCC-5559](https://newyorkpubliclibrary.atlassian.net/browse/SCC-5559)

## This PR does the following:

<!--- Brief, bulleted list of changes. -->

- The heavy task of making search results table row headers top aligned

## How has this been tested? How should a reviewer test this?

<!--- Describe how you tested your changes and how the reviewer can test the changes made in this PR. -->

- Go to any search results page, view mobile mode, check that "Call number" and "Item location" are vertically aligned with first line of data

## Accessibility updates?

<!--- If your PR changes a user's ability to access/interact with the app or introduces a new feature, briefly describe the change and check the below criteria. -->

### Accessibility checklist

- [ ] The feature works with keyboard inputs (tabbing, arrows, space, enter, esc).
- [ ] Tested with a screen reader if the feature involves hidden text or `aria-live`.
- [ ] Confirmed focus management is correct for UI updates and DOM `ref`s.
- [ ] Verified the feature works when zoomed in to 200% and 400%.

### Developer checklist

<!--- Check all the boxes that apply. -->

- [x] I have updated the changelog and any relevant documentation.
- [x] All new and existing unit tests passed.


[SCC-5559]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-5559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ